### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/src/memory_ingest.py
+++ b/src/memory_ingest.py
@@ -493,11 +493,15 @@ def _resolve_codebook(codebook: str, source_type: str) -> list[str]:
     # Profile-based resolution: try modular codebook for non-reserved names
     # that are not in _CODEBOOK_PATHS (e.g. "laravel", "python", "generic").
     if codebook not in _RESERVED and codebook not in _CODEBOOK_PATHS:
+        safe_codebook = str(codebook).strip()
+        # Allow only simple profile identifiers; block traversal/absolute-path input.
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", safe_codebook):
+            return list(_ORIGINAL_MAYRING_CATEGORIES)
         try:
             from src.categorizer import load_codebook_modular
-            _profile_path = Path(__file__).parent.parent / "codebooks" / "profiles" / f"{codebook}.yaml"
+            _profile_path = Path(__file__).parent.parent / "codebooks" / "profiles" / f"{safe_codebook}.yaml"
             if _profile_path.exists():
-                _exclude_pats, _cats = load_codebook_modular(codebook)
+                _exclude_pats, _cats = load_codebook_modular(safe_codebook)
                 names = [cat["name"] for cat in _cats if "name" in cat]
                 if names:
                     return names


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/5](https://github.com/Nileneb/MayringCoder/security/code-scanning/5)

The best fix is to add strict server-side validation for `codebook` profile identifiers before any path construction. Specifically, only allow simple profile names (e.g., alphanumeric plus `_`/`-`), reject names containing path separators, dots used for traversal, or absolute-path characteristics, and then use the sanitized value for both path construction and modular loading.

In `src/memory_ingest.py`, update `_resolve_codebook` in the profile-resolution branch:
- Introduce a validated local variable (e.g., `safe_codebook = str(codebook).strip()`).
- Enforce a conservative regex like `^[A-Za-z0-9_-]+$`.
- If invalid, immediately return fallback categories (`_ORIGINAL_MAYRING_CATEGORIES`), preserving existing behavior style (safe fallback, no crash).
- Use `safe_codebook` instead of raw `codebook` when building `_profile_path` and calling `load_codebook_modular`.

This single change addresses all alert variants because all tainted inputs converge into the same `codebook` sink.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Add strict validation for non-reserved codebook profile names to block path traversal and other unsafe inputs before constructing profile file paths.