### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/src/categorizer.py
+++ b/src/categorizer.py
@@ -98,6 +98,13 @@ def _matches_patterns(filename: str, patterns: list[str]) -> bool:
     return False
 
 
+def _is_safe_profile_name(profile: str) -> bool:
+    """Allow only simple profile identifiers (no path chars / traversal)."""
+    if not profile:
+        return False
+    return re.fullmatch(r"[A-Za-z0-9_-]+", profile) is not None
+
+
 def load_codebook_modular(profile: str = "generic") -> tuple[list[str], list[dict]]:
     """Load exclude patterns and categories from a codebook profile.
 
@@ -109,7 +116,16 @@ def load_codebook_modular(profile: str = "generic") -> tuple[list[str], list[dic
     Fallback: if codebooks/ doesn't exist or the profile is not found,
     delegates to load_codebook() + load_exclude_patterns().
     """
-    profile_path = CODEBOOKS_DIR / "profiles" / f"{profile}.yaml"
+    if not _is_safe_profile_name(profile):
+        return load_exclude_patterns(), load_codebook()
+
+    profiles_dir = (CODEBOOKS_DIR / "profiles").resolve()
+    profile_path = (profiles_dir / f"{profile}.yaml").resolve()
+    try:
+        profile_path.relative_to(profiles_dir)
+    except ValueError:
+        return load_exclude_patterns(), load_codebook()
+
     if not CODEBOOKS_DIR.exists() or not profile_path.exists():
         return load_exclude_patterns(), load_codebook()
 


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/6](https://github.com/Nileneb/MayringCoder/security/code-scanning/6)

General fix: enforce server-side validation of any user-influenced value used to build file paths. Prefer an allowlist or strict character policy plus canonical path containment checks.

Best fix here (minimal functional change): in `src/categorizer.py` inside `load_codebook_modular`, validate `profile` before using it in `f"{profile}.yaml"`. Reject unsafe profile names (empty, path separators, traversal, unexpected characters) and fall back to existing safe behavior (`load_exclude_patterns(), load_codebook()`). Then resolve and verify `profile_path` stays under `CODEBOOKS_DIR / "profiles"` before reading. This addresses all three variants because all flows converge on this same sink.

Changes needed:
- Edit `src/categorizer.py`.
- Add a small helper `_is_safe_profile_name(profile: str) -> bool`.
- Update `load_codebook_modular` to:
  - validate `profile` early,
  - compute `profiles_dir = (CODEBOOKS_DIR / "profiles").resolve()`,
  - build `profile_path = (profiles_dir / f"{profile}.yaml").resolve()`,
  - ensure containment via `profile_path.relative_to(profiles_dir)` in `try/except`.
- No new dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Validate profile identifiers used to load modular codebook YAML files to prevent unsafe path usage.

Bug Fixes:
- Reject invalid or potentially unsafe profile names before constructing profile file paths and fall back to the default codebook loading logic when validation fails.

Enhancements:
- Add a helper to enforce a restricted character set for profile identifiers and verify resolved profile paths remain within the expected profiles directory.