### PR TITLE
Potential fix for code scanning alert no. 18: Uncontrolled data used in path expression

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -239,10 +239,13 @@ async def list_reports(
     workspace_id: str = Depends(get_workspace),
 ) -> dict:
     """List analysis reports for this workspace."""
-    reports_dir = _ROOT / "reports" / workspace_id
+    base_reports_dir = (_ROOT / "reports").resolve()
+    reports_dir = (base_reports_dir / workspace_id).resolve()
+    if reports_dir != base_reports_dir and base_reports_dir not in reports_dir.parents:
+        raise HTTPException(status_code=400, detail="Invalid workspace_id path")
     if not reports_dir.exists():
         # Also check legacy flat reports dir
-        reports_dir = _ROOT / "reports"
+        reports_dir = base_reports_dir
     reports = []
     if reports_dir.exists():
         for f in sorted(reports_dir.glob("*.md"), key=lambda p: p.stat().st_mtime, reverse=True):


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/18](https://github.com/Nileneb/MayringCoder/security/code-scanning/18)

Safest fix: resolve the user-derived path against a trusted base (`_ROOT / "reports"`), normalize via `.resolve()`, and ensure the resolved target remains inside the base directory before using it. If validation fails, return 400. This preserves functionality (workspace-specific reports with legacy fallback) while preventing traversal.

In `src/api_server.py`, update `list_reports`:

- Define `base_reports_dir = (_ROOT / "reports").resolve()`.
- Build `candidate_dir = (base_reports_dir / workspace_id).resolve()`.
- Verify containment with `candidate_dir == base_reports_dir or base_reports_dir in candidate_dir.parents`.
- If invalid, raise `HTTPException(status_code=400, detail="Invalid workspace_id path")`.
- Use `candidate_dir` as `reports_dir`; keep existing legacy fallback to `base_reports_dir` if workspace folder does not exist.

No new imports are required (Path/HTTPException already present).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Validate workspace-derived report paths against a trusted base directory to prevent directory traversal while preserving legacy flat reports fallback.