### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/src/categorizer.py
+++ b/src/categorizer.py
@@ -128,7 +128,15 @@ def load_codebook_modular(profile: str = "generic") -> tuple[list[str], list[dic
         return load_exclude_patterns(), load_codebook()
 
     profiles_dir = (CODEBOOKS_DIR / "profiles").resolve()
-    profile_path = (profiles_dir / f"{profile}.yaml").resolve()
+    if not profiles_dir.exists() or not profiles_dir.is_dir():
+        return load_exclude_patterns(), load_codebook()
+
+    allowed_profiles = {p.stem for p in profiles_dir.glob("*.yaml") if p.is_file()}
+    if profile not in allowed_profiles:
+        return load_exclude_patterns(), load_codebook()
+
+    safe_profile = profile
+    profile_path = (profiles_dir / f"{safe_profile}.yaml").resolve()
     try:
         profile_path.relative_to(profiles_dir)
     except ValueError:


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/8](https://github.com/Nileneb/MayringCoder/security/code-scanning/8)

General fix: avoid using raw user input in path expressions by mapping input to an allowlisted canonical identifier before path construction, and reject/fallback otherwise.

Best fix here (minimal behavior change): in `src/categorizer.py` inside `load_codebook_modular`, after existing syntactic validation, enumerate available profile YAML filenames under `codebooks/profiles`, and only proceed if `profile` exactly matches one of those stems. Then build `profile_path` from this canonicalized value. This addresses all variants because every tainted flow eventually hits this function.

Changes needed:
- File: `src/categorizer.py`
- Region: `load_codebook_modular` around lines 127–133.
- Add:
  - resolved `profiles_dir` early
  - existence/type check for directory
  - `allowed_profiles` set from `profiles_dir.glob("*.yaml")`
  - membership check for `profile`
  - canonical variable `safe_profile`
  - use `safe_profile` in path construction

No new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent use of uncontrolled user input in profile path construction by validating requested profiles against the set of available YAML files.