### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/src/categorizer.py
+++ b/src/categorizer.py
@@ -131,15 +131,19 @@ def load_codebook_modular(profile: str = "generic") -> tuple[list[str], list[dic
     if not profiles_dir.exists() or not profiles_dir.is_dir():
         return load_exclude_patterns(), load_codebook()
 
-    allowed_profiles = {p.stem for p in profiles_dir.glob("*.yaml") if p.is_file()}
-    if profile not in allowed_profiles:
-        return load_exclude_patterns(), load_codebook()
+    allowed_profiles: dict[str, Path] = {}
+    for p in profiles_dir.glob("*.yaml"):
+        if not p.is_file():
+            continue
+        rp = p.resolve()
+        try:
+            rp.relative_to(profiles_dir)
+        except ValueError:
+            continue
+        allowed_profiles[p.stem] = rp
 
-    safe_profile = profile
-    profile_path = (profiles_dir / f"{safe_profile}.yaml").resolve()
-    try:
-        profile_path.relative_to(profiles_dir)
-    except ValueError:
+    profile_path = allowed_profiles.get(profile)
+    if profile_path is None:
         return load_exclude_patterns(), load_codebook()
 
     if not CODEBOOKS_DIR.exists() or not profile_path.exists():


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/4](https://github.com/Nileneb/MayringCoder/security/code-scanning/4)

General fix: enforce a strict allowlist and canonical path containment immediately before any filesystem access, and avoid using a path assembled from raw user data when an allowlisted concrete path is already available.

Best fix here (minimal functional change): in `src/categorizer.py` inside `load_codebook_modular`, replace reconstruction of `profile_path` from `safe_profile` with direct selection from discovered files in `profiles_dir`. Build a `dict[str, Path]` mapping `{stem: resolved_path}` from `profiles_dir.glob("*.yaml")`, validate membership, then use that resolved allowlisted `Path` for existence/read. This removes the remaining “constructed from tainted string” pattern and addresses all variants that flow into this function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enforce safer profile selection when loading modular codebooks by restricting filesystem access to a validated set of discovered YAML profile files.

Bug Fixes:
- Prevent use of user-controlled profile strings to construct filesystem paths by requiring selection from a prevalidated map of YAML profiles within the profiles directory.

Enhancements:
- Strengthen path validation by resolving discovered profile files and ensuring they remain within the expected profiles directory before use.