### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/src/memory_ingest.py
+++ b/src/memory_ingest.py
@@ -477,6 +477,9 @@ _CODEBOOK_PATHS: dict[str, Path] = {
 }
 
 
+_ALLOWED_MODULAR_CODEBOOK_PROFILES = {"generic", "python", "laravel"}
+
+
 def _resolve_codebook(codebook: str, source_type: str) -> list[str]:
     """Return list of category names for the given codebook/source_type.
 
@@ -498,6 +501,9 @@ def _resolve_codebook(codebook: str, source_type: str) -> list[str]:
         safe_codebook = str(codebook).strip()
         # Allow only simple profile identifiers; block traversal/absolute-path input.
         if not re.fullmatch(r"[A-Za-z0-9_-]+", safe_codebook):
+            return list(_ORIGINAL_MAYRING_CATEGORIES)
+        # Explicit allowlist prevents user-controlled arbitrary profile path selection.
+        if safe_codebook not in _ALLOWED_MODULAR_CODEBOOK_PROFILES:
             return list(_ORIGINAL_MAYRING_CATEGORIES)
         try:
             from src.categorizer import load_codebook_modular


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/7](https://github.com/Nileneb/MayringCoder/security/code-scanning/7)

General fix: validate and normalize untrusted option values at trust boundaries and again before sensitive use. For path-related choices, prefer explicit allowlists over permissive patterns.

Best fix here (without changing intended behavior): in `src/memory_ingest.py`, tighten `_resolve_codebook` so only known-safe profile identifiers are accepted for modular profile loading. Keep reserved names and `_CODEBOOK_PATHS` behavior intact, but reject arbitrary user-provided profile names unless they are in an internal allowlist. This removes user-controlled freedom in path selection and satisfies static analysis while preserving existing fallback to `_ORIGINAL_MAYRING_CATEGORIES`.

Change region: function `_resolve_codebook` around lines 490–520.  
Needed changes:
- Add a module-level allowlist constant for modular profile names (for example `{"generic", "python", "laravel"}` based on the docstring/examples).
- In `_resolve_codebook`, after `safe_codebook` normalization, require membership in that allowlist before constructing `_profile_path`.
- Keep existing regex and `relative_to` containment checks as defense-in-depth.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Add an explicit allowlist of supported modular codebook profiles and fall back to the original categories when an unsupported profile name is provided, mitigating uncontrolled path expression risks.