### PR TITLE
Potential fix for code scanning alert no. 21: Uncontrolled data used in path expression

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -239,6 +240,8 @@ async def list_reports(
     workspace_id: str = Depends(get_workspace),
 ) -> dict:
     """List analysis reports for this workspace."""
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,64}", workspace_id):
+        raise HTTPException(status_code=400, detail="Invalid workspace_id")
     base_reports_dir = (_ROOT / "reports").resolve()
     reports_dir = (base_reports_dir / workspace_id).resolve()
     if reports_dir != base_reports_dir and base_reports_dir not in reports_dir.parents:


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/21](https://github.com/Nileneb/MayringCoder/security/code-scanning/21)

General fix: validate/canonicalize untrusted path components *before* using them in path expressions, ideally by restricting to a safe identifier format (allowlist), then keep the existing resolved-path containment guard as defense-in-depth.

Best fix here (without changing intended functionality): in `src/api_server.py`, inside `list_reports`, validate `workspace_id` as a simple slug-like ID (e.g., letters, digits, `_`, `-`, length-bounded), reject invalid values with `400`, then construct `reports_dir` using the validated value. Keep the existing `.resolve()` + parent check. This removes path separators, traversal tokens, and absolute-path behavior at the source while preserving tenant report listing behavior.

Changes needed:
- Add `import re` near existing imports.
- In `list_reports` (around lines 242–244), add regex validation for `workspace_id` before building `reports_dir`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Reject invalid workspace_id values in list_reports with a 400 response before constructing filesystem paths to mitigate path traversal risks.