### PR TITLE
Potential fix for code scanning alert no. 11: Uncontrolled data used in path expression

### DIFF
--- a/src/memory_ingest.py
+++ b/src/memory_ingest.py
@@ -492,32 +492,25 @@ def _resolve_codebook(codebook: str, source_type: str) -> list[str]:
     """
     _RESERVED = {"auto", "code", "social", "original"}
 
+    codebook = str(codebook).strip().lower()
     if codebook == "auto":
         codebook = _SOURCE_TYPE_TO_CODEBOOK.get(source_type, "original")
 
     # Profile-based resolution: try modular codebook for non-reserved names
     # that are not in _CODEBOOK_PATHS (e.g. "laravel", "python", "generic").
     if codebook not in _RESERVED and codebook not in _CODEBOOK_PATHS:
-        safe_codebook = str(codebook).strip()
         # Allow only simple profile identifiers; block traversal/absolute-path input.
-        if not re.fullmatch(r"[A-Za-z0-9_-]+", safe_codebook):
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", codebook):
             return list(_ORIGINAL_MAYRING_CATEGORIES)
         # Explicit allowlist prevents user-controlled arbitrary profile path selection.
-        if safe_codebook not in _ALLOWED_MODULAR_CODEBOOK_PROFILES:
+        if codebook not in _ALLOWED_MODULAR_CODEBOOK_PROFILES:
             return list(_ORIGINAL_MAYRING_CATEGORIES)
         try:
             from src.categorizer import load_codebook_modular
-            _profiles_dir = (Path(__file__).parent.parent / "codebooks" / "profiles").resolve()
-            _profile_path = (_profiles_dir / f"{safe_codebook}.yaml").resolve()
-            try:
-                _profile_path.relative_to(_profiles_dir)
-            except ValueError:
-                return list(_ORIGINAL_MAYRING_CATEGORIES)
-            if _profile_path.exists():
-                _exclude_pats, _cats = load_codebook_modular(safe_codebook)
-                names = [cat["name"] for cat in _cats if "name" in cat]
-                if names:
-                    return names
+            _exclude_pats, _cats = load_codebook_modular(codebook)
+            names = [cat["name"] for cat in _cats if "name" in cat]
+            if names:
+                return names
         except Exception:
             pass
         # Unknown profile — fall through to original categories fallback below


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/11](https://github.com/Nileneb/MayringCoder/security/code-scanning/11)

General fix: enforce strict canonicalization/allowlisting before any path-dependent operation, and avoid constructing path expressions from raw user-derived values.

Best targeted fix here (without changing functionality): in `src/memory_ingest.py` inside `_resolve_codebook`, normalize `codebook` early to a canonical, trusted profile identifier and only then proceed. Specifically:
- Convert to string, strip, lowercase once.
- Reject anything not in reserved/codebook paths/allowed modular profiles.
- For modular profiles, use the validated canonical value for loader calls.
- Remove unnecessary direct construction/check of `_profile_path` from user-derived string (the loader should resolve known profile names only after allowlist pass).

This preserves behavior (known profiles still load, unknown values still fall back), while preventing tainted data from being used in path expressions at this call site and addressing all alert variants in one place.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent uncontrolled user-derived path usage in codebook profile resolution by enforcing strict canonicalization and allowlisting of profile identifiers.