### PR TITLE
Potential fix for code scanning alert no. 18: Uncontrolled data used in path expression

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -256,6 +256,11 @@ async def list_reports(
         reports_dir = base_reports_dir
     reports = []
     if reports_dir.exists():
-        for f in sorted(reports_dir.glob("*.md"), key=lambda p: p.stat().st_mtime, reverse=True):
+        markdown_files = [
+            p
+            for p in reports_dir.iterdir()
+            if p.is_file() and re.fullmatch(r"[A-Za-z0-9_.-]+\.md", p.name)
+        ]
+        for f in sorted(markdown_files, key=lambda p: p.stat().st_mtime, reverse=True):
             reports.append({"name": f.name, "size": f.stat().st_size})
     return {"workspace_id": safe_workspace_id, "reports": reports, "count": len(reports)}


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/18](https://github.com/Nileneb/MayringCoder/security/code-scanning/18)

General approach: keep user input validation, but ensure filesystem enumeration is anchored to a trusted path and filtered by strict filename rules rather than globbing from a tainted-derived directory object.

Best fix here (without changing behavior): in `list_reports` in `src/api_server.py`, keep current workspace validation and containment checks, then replace `reports_dir.glob("*.md")` with iteration over `reports_dir.iterdir()` and manually accept only regular files whose names match a safe regex like `^[A-Za-z0-9_.-]+\.md$`. This preserves `.md` listing behavior while making the sink less path-expression-sensitive.

Edits needed:
- File: `src/api_server.py`
- Region: `list_reports` function around lines 258–261.
- No new imports required (`re` already present).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent uncontrolled path expressions when listing report markdown files by only considering regular files with strictly validated filenames.