### PR TITLE
Potential fix for code scanning alert no. 24: Uncontrolled data used in path expression

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -246,21 +246,24 @@ async def list_reports(
     if not safe_workspace_id or safe_workspace_id != workspace_id:
         raise HTTPException(status_code=400, detail="Invalid workspace_id")
     base_reports_dir = (_ROOT / "reports").resolve()
-    reports_dir = (base_reports_dir / safe_workspace_id).resolve()
-    try:
-        reports_dir.relative_to(base_reports_dir)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid workspace_id path")
-    if not reports_dir.exists():
-        # Also check legacy flat reports dir
-        reports_dir = base_reports_dir
+
     reports = []
-    if reports_dir.exists():
-        markdown_files = [
+    if base_reports_dir.exists():
+        workspace_prefix = f"{safe_workspace_id}_"
+        candidate_dirs = [base_reports_dir]
+        candidate_dirs.extend(
             p
-            for p in reports_dir.iterdir()
-            if p.is_file() and re.fullmatch(r"[A-Za-z0-9_.-]+\.md", p.name)
-        ]
-        for f in sorted(markdown_files, key=lambda p: p.stat().st_mtime, reverse=True):
-            reports.append({"name": f.name, "size": f.stat().st_size})
+            for p in base_reports_dir.iterdir()
+            if p.is_dir() and re.fullmatch(r"[A-Za-z0-9_-]{1,64}", p.name)
+        )
+        for candidate_dir in candidate_dirs:
+            markdown_files = [
+                p
+                for p in candidate_dir.iterdir()
+                if p.is_file()
+                and re.fullmatch(r"[A-Za-z0-9_.-]+\.md", p.name)
+                and p.name.startswith(workspace_prefix)
+            ]
+            for f in sorted(markdown_files, key=lambda p: p.stat().st_mtime, reverse=True):
+                reports.append({"name": f.name, "size": f.stat().st_size})
     return {"workspace_id": safe_workspace_id, "reports": reports, "count": len(reports)}


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/24](https://github.com/Nileneb/MayringCoder/security/code-scanning/24)

General fix: avoid constructing filesystem paths directly from user-controlled values. Instead, operate within fixed trusted directories and apply strict allowlist validation/filtering logic in-memory.

Best concrete fix here (in `src/api_server.py`, inside `list_reports`):  
- Keep workspace ID validation as-is.  
- Stop building `reports_dir = (base_reports_dir / safe_workspace_id).resolve()` from user input.  
- Replace per-workspace directory traversal with:
  1. Listing markdown files in trusted `base_reports_dir` (legacy behavior).
  2. Optionally listing markdown files in trusted subdirectories discovered from `base_reports_dir.iterdir()` where folder names match `[A-Za-z0-9_-]{1,64}` (no user input in path creation).
  3. Filter report filenames to those that start with `"{safe_workspace_id}_"` so response remains workspace-scoped.
- Return filtered/sorted metadata as before.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Restrict report listing to trusted report directories while maintaining workspace-scoped results.

Bug Fixes:
- Prevent uncontrolled user input from influencing filesystem paths when listing workspace reports.

Enhancements:
- Support listing workspace-specific reports from both the legacy flat reports directory and validated subdirectories under the main reports folder.