### PR TITLE
Potential fix for code scanning alert no. 26: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/src/memory/retrieval.py
+++ b/src/memory/retrieval.py
@@ -30,7 +30,7 @@ def _cache_key(query: str, opts: dict, session_compacted: bool) -> str:
     """Stable hash key for query + retrieval-relevant opts."""
     relevant = {k: v for k, v in opts.items() if k != "include_text"}
     payload = _json.dumps({"q": query, "opts": relevant, "sc": session_compacted}, sort_keys=True)
-    return hashlib.md5(payload.encode()).hexdigest()
+    return hashlib.sha256(payload.encode()).hexdigest()
 
 
 def invalidate_query_cache() -> None:


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/26](https://github.com/Nileneb/MayringCoder/security/code-scanning/26)

Use a modern hash for cache-key generation in `src/memory/retrieval.py` by replacing MD5 with SHA-256.

Best fix (minimal functional change):
- In `_cache_key(...)` (around lines 29–33), replace:
  - `hashlib.md5(payload.encode()).hexdigest()`
  with:
  - `hashlib.sha256(payload.encode()).hexdigest()`
- No new imports are required because `hashlib` is already imported.
- This keeps behavior the same (deterministic string key) while removing weak-hash usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enhancements:
- Update query cache key generation to use SHA-256 instead of MD5 for hashing the payload.