### PR TITLE
Potential fix for code scanning alert no. 28: Uncontrolled data used in path expression

### DIFF
--- a/src/agents/pi.py
+++ b/src/agents/pi.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 import time
 from pathlib import Path
@@ -122,10 +123,16 @@ def _execute_search_memory(
         return f"Memory-Suche fehlgeschlagen: {exc}"
 
 
+def _sanitize_repo_slug_for_filename(slug: str) -> str:
+    """Return a filesystem-safe slug for cache wiki filenames."""
+    return re.sub(r"[^A-Za-z0-9._-]", "", slug)
+
+
 def _execute_search_wiki(args: dict, repo_slug_hint: str = "") -> str:
     """Execute search_wiki tool call — returns markdown context string."""
     slug = args.get("repo") or repo_slug_hint
-    wiki_path = Path("cache") / f"{slug}_wiki.md" if slug else None
+    safe_slug = _sanitize_repo_slug_for_filename(str(slug)) if slug else ""
+    wiki_path = Path("cache") / f"{safe_slug}_wiki.md" if safe_slug else None
 
     if not wiki_path or not wiki_path.exists():
         cache_dir = Path("cache")


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/28](https://github.com/Nileneb/MayringCoder/security/code-scanning/28)

General fix: never use untrusted input directly in file paths. Constrain the input to an allowlist of safe characters and/or resolve the final path and verify it stays inside a trusted base directory.

Best single fix here (without changing intended behavior): sanitize `slug` into a safe filename token before building `wiki_path`. Since repo slugs are expected to look like names such as `app.linn.games`, allowing only alphanumerics, dot, underscore, and hyphen preserves existing functionality while blocking traversal characters (`/`, `\`, `..`, etc.). Then use sanitized slug for `cache/<slug>_wiki.md`.

Changes needed in `src/agents/pi.py`:
- Add `import re`.
- Add a small helper function to sanitize slug (`_sanitize_repo_slug_for_filename`).
- Update `_execute_search_wiki` to sanitize `slug` before path construction and use sanitized value only if non-empty.

No changes are required in `pi_server.py` for this sink fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent potential path traversal by sanitizing the repository slug before using it in wiki cache filenames.