### PR TITLE
Potential fix for code scanning alert no. 27: Uncontrolled data used in path expression

### DIFF
--- a/src/agents/pi.py
+++ b/src/agents/pi.py
@@ -124,10 +124,12 @@ def _execute_search_memory(
 
 
 def _sanitize_repo_slug_for_filename(slug: str) -> str:
-    """Return a validated filesystem-safe slug for cache wiki filenames."""
-    if not re.fullmatch(r"[A-Za-z0-9._-]+", slug):
+    """Return a strictly validated filesystem-safe slug for cache wiki filenames."""
+    slug = slug.strip()
+    # Allow only simple filename-safe repo slugs.
+    if not re.fullmatch(r"[A-Za-z0-9](?:[A-Za-z0-9._-]{0,62}[A-Za-z0-9])?", slug):
         return ""
-    if slug in {".", ".."} or slug.startswith("."):
+    if ".." in slug:
         return ""
     return slug
 
@@ -137,10 +139,11 @@ def _execute_search_wiki(args: dict, repo_slug_hint: str = "") -> str:
     slug = args.get("repo") or repo_slug_hint
     safe_slug = _sanitize_repo_slug_for_filename(str(slug)) if slug else ""
     cache_dir = Path("cache")
-    cache_root_resolved = cache_dir.resolve()
+    cache_root_resolved = cache_dir.resolve(strict=False)
     wiki_path: Path | None = None
     if safe_slug:
-        candidate = cache_root_resolved / f"{safe_slug}_wiki.md"
+        filename = f"{safe_slug}_wiki.md"
+        candidate = cache_root_resolved / filename
         try:
             candidate_resolved = candidate.resolve(strict=False)
             candidate_resolved.relative_to(cache_root_resolved)

--- a/src/agents/pi.py
+++ b/src/agents/pi.py
@@ -137,14 +137,14 @@ def _execute_search_wiki(args: dict, repo_slug_hint: str = "") -> str:
     slug = args.get("repo") or repo_slug_hint
     safe_slug = _sanitize_repo_slug_for_filename(str(slug)) if slug else ""
     cache_dir = Path("cache")
+    cache_root_resolved = cache_dir.resolve()
     wiki_path: Path | None = None
     if safe_slug:
-        candidate = cache_dir / f"{safe_slug}_wiki.md"
+        candidate = cache_root_resolved / f"{safe_slug}_wiki.md"
         try:
-            cache_root_resolved = cache_dir.resolve()
-            candidate_resolved = candidate.resolve()
+            candidate_resolved = candidate.resolve(strict=False)
             candidate_resolved.relative_to(cache_root_resolved)
-            wiki_path = candidate
+            wiki_path = candidate_resolved
         except (ValueError, OSError):
             wiki_path = None
 

--- a/src/agents/pi.py
+++ b/src/agents/pi.py
@@ -124,18 +124,31 @@ def _execute_search_memory(
 
 
 def _sanitize_repo_slug_for_filename(slug: str) -> str:
-    """Return a filesystem-safe slug for cache wiki filenames."""
-    return re.sub(r"[^A-Za-z0-9._-]", "", slug)
+    """Return a validated filesystem-safe slug for cache wiki filenames."""
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", slug):
+        return ""
+    if slug in {".", ".."} or slug.startswith("."):
+        return ""
+    return slug
 
 
 def _execute_search_wiki(args: dict, repo_slug_hint: str = "") -> str:
     """Execute search_wiki tool call — returns markdown context string."""
     slug = args.get("repo") or repo_slug_hint
     safe_slug = _sanitize_repo_slug_for_filename(str(slug)) if slug else ""
-    wiki_path = Path("cache") / f"{safe_slug}_wiki.md" if safe_slug else None
+    cache_dir = Path("cache")
+    wiki_path: Path | None = None
+    if safe_slug:
+        candidate = cache_dir / f"{safe_slug}_wiki.md"
+        try:
+            cache_root_resolved = cache_dir.resolve()
+            candidate_resolved = candidate.resolve()
+            candidate_resolved.relative_to(cache_root_resolved)
+            wiki_path = candidate
+        except (ValueError, OSError):
+            wiki_path = None
 
     if not wiki_path or not wiki_path.exists():
-        cache_dir = Path("cache")
         wiki_files = list(cache_dir.glob("*_wiki.md")) if cache_dir.exists() else []
         if not wiki_files:
             return "Kein Wiki vorhanden. Zuerst --generate-wiki ausführen."


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/27](https://github.com/Nileneb/MayringCoder/security/code-scanning/27)

Use defense-in-depth for path handling in `src/agents/pi.py`:

1. Keep sanitization, but make it strict (allow only safe characters and reject unsafe/empty results rather than silently transforming arbitrary input).
2. Build the target path under a fixed base directory (`cache`) and verify with `resolve()` that the final path stays inside that base directory before any existence/read checks.
3. If validation fails, ignore the user-provided repo slug and use the safe fallback behavior (first available `*_wiki.md`).

Best minimal fix without changing intended behavior:
- In `_sanitize_repo_slug_for_filename`, switch from “strip disallowed chars” to “validate and return empty if invalid”.
- In `_execute_search_wiki`, compute `cache_dir = Path("cache")`, resolve candidate path, and ensure it is a descendant of `cache_dir` using `relative_to()` in a `try/except ValueError` guard.
- Only use `wiki_path` when all checks pass and file exists; otherwise fallback to existing discovery logic.

This requires only edits in `src/agents/pi.py`; no new dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden wiki cache file path handling to mitigate uncontrolled data usage in path expressions.

Bug Fixes:
- Validate repository slugs strictly for wiki cache filenames and reject unsafe or malformed values.
- Constrain wiki cache lookups to resolved paths under the fixed cache directory and fall back to default discovery when validation fails.