### PR TITLE
Potential fix for code scanning alert no. 30: Uncontrolled data used in path expression

### DIFF
--- a/src/agents/pi.py
+++ b/src/agents/pi.py
@@ -139,22 +139,19 @@ def _execute_search_wiki(args: dict, repo_slug_hint: str = "") -> str:
     slug = args.get("repo") or repo_slug_hint
     safe_slug = _sanitize_repo_slug_for_filename(str(slug)) if slug else ""
     cache_dir = Path("cache")
-    cache_root_resolved = cache_dir.resolve(strict=False)
+    wiki_files = list(cache_dir.glob("*_wiki.md")) if cache_dir.exists() else []
+    if not wiki_files:
+        return "Kein Wiki vorhanden. Zuerst --generate-wiki ausführen."
+
     wiki_path: Path | None = None
     if safe_slug:
-        filename = f"{safe_slug}_wiki.md"
-        candidate = cache_root_resolved / filename
-        try:
-            candidate_resolved = candidate.resolve(strict=False)
-            candidate_resolved.relative_to(cache_root_resolved)
-            wiki_path = candidate_resolved
-        except (ValueError, OSError):
-            wiki_path = None
+        expected_name = f"{safe_slug}_wiki.md"
+        for candidate in wiki_files:
+            if candidate.name == expected_name:
+                wiki_path = candidate
+                break
 
-    if not wiki_path or not wiki_path.exists():
-        wiki_files = list(cache_dir.glob("*_wiki.md")) if cache_dir.exists() else []
-        if not wiki_files:
-            return "Kein Wiki vorhanden. Zuerst --generate-wiki ausführen."
+    if wiki_path is None:
         wiki_path = wiki_files[0]
 
     topic = args.get("topic", "").lower()


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/30](https://github.com/Nileneb/MayringCoder/security/code-scanning/30)

General fix approach: avoid constructing file paths from untrusted input. Instead, enumerate allowed files from a trusted directory and select among those via exact, sanitized key matching.

Best fix here (without changing intended functionality):
- In `src/agents/pi.py`, inside `_execute_search_wiki`, remove creation/resolution of `candidate` from `safe_slug`.
- Build `wiki_files` once from `cache_dir.glob("*_wiki.md")` (trusted source).
- If `safe_slug` is present, select the file whose basename equals `f"{safe_slug}_wiki.md"` from that pre-enumerated list.
- Otherwise (or if not found), fall back to first wiki file as before.
- Keep existing `_sanitize_repo_slug_for_filename` (still useful for matching policy), but stop using sanitized input in path construction.

This preserves behavior (prefer repo-specific wiki when available; else fallback) while eliminating untrusted-data-to-path construction that CodeQL reports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent potential path traversal by selecting wiki files from a trusted, pre-globbed list based on sanitized keys instead of building paths from untrusted input.