### PR TITLE
Potential fix for code scanning alert no. 32: Uncontrolled data used in path expression

### DIFF
--- a/src/memory/ambient.py
+++ b/src/memory/ambient.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -327,6 +328,17 @@ def load_ambient_snapshot(conn: Any, repo_slug: str = "") -> str | None:
     return row[0] if row else None
 
 
+def _safe_repo_slug(repo_slug: str) -> str:
+    """Return a filesystem-safe repo slug for cache filenames, else empty string."""
+    if not repo_slug:
+        return ""
+    if ".." in repo_slug or "/" in repo_slug or "\\" in repo_slug:
+        return ""
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", repo_slug):
+        return ""
+    return repo_slug
+
+
 def build_context(
     task: str,
     conn: Any,
@@ -344,9 +356,10 @@ def build_context(
 
     keyword_index: dict[str, list[str]] = {}
     cluster_embs: dict[str, list[float]] = {}
-    if repo_slug:
-        idx_path = Path("cache") / f"{repo_slug}_wiki_index.json"
-        emb_path = Path("cache") / f"{repo_slug}_wiki_clusters_emb.json"
+    safe_repo_slug = _safe_repo_slug(repo_slug)
+    if safe_repo_slug:
+        idx_path = Path("cache") / f"{safe_repo_slug}_wiki_index.json"
+        emb_path = Path("cache") / f"{safe_repo_slug}_wiki_clusters_emb.json"
         if idx_path.exists():
             try:
                 keyword_index = json.loads(idx_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/32](https://github.com/Nileneb/MayringCoder/security/code-scanning/32)

General fix: validate and constrain `repo_slug` before using it in any filesystem path. Best approach here is to sanitize to a safe slug format (e.g., alphanumeric, `_`, `-`, `.`), reject or ignore unsafe values, and only then build cache filenames.

Best minimal change in `src/memory/ambient.py`:
1. Add `import re`.
2. Add a small helper `_safe_repo_slug(repo_slug: str) -> str` that returns `""` unless the slug fully matches a strict safe pattern and excludes `..`, `/`, and `\`.
3. In `build_context`, derive `safe_repo_slug = _safe_repo_slug(repo_slug)` and use it for `idx_path`/`emb_path` construction and conditional check.

This keeps behavior intact for normal repo slugs while preventing attacker-controlled path manipulation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent path traversal and unsafe filesystem access by validating and constraining repo_slug before constructing cache filenames in build_context.