### PR TITLE
fix(watcher): MCP_SERVICE_TOKEN als Auth für Server-Daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ AgentTemplates/
 */.claude
 /docs
 Todo-research.md
-.CLAUDE.md
+.CLAUDE.md.worktrees/

--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -1,5 +1,7 @@
-"""FastAPI auth dependency — RS256 JWT only."""
+"""FastAPI auth dependency — RS256 JWT or MCP_SERVICE_TOKEN."""
 from __future__ import annotations
+
+import os
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -8,17 +10,28 @@ from src.api.jwt_auth import TokenInfo, validate_jwt_token
 
 _bearer = HTTPBearer(auto_error=False)
 
+# Service-to-service token: loaded once at startup.
+# On the server this is set in .env.production; on laptops it's empty,
+# so users always need a proper RS256 JWT.
+_SERVICE_TOKEN = os.getenv("MCP_SERVICE_TOKEN", "")
+
 
 async def get_token_info(
     creds: HTTPAuthorizationCredentials | None = Depends(_bearer),
 ) -> TokenInfo:
-    """Validate Bearer JWT and return TokenInfo (workspace_id + scopes)."""
+    """Validate Bearer token — accepts RS256 JWT (users) or MCP_SERVICE_TOKEN (server daemons).
+
+    Service token → workspace_id 'system', scope '*'.
+    """
     if not creds:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing Bearer token",
         )
-    info = validate_jwt_token(creds.credentials)
+    token = creds.credentials
+    if _SERVICE_TOKEN and token == _SERVICE_TOKEN:
+        return TokenInfo(workspace_id="system", scopes=("*",))
+    info = validate_jwt_token(token)
     if not info:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/tools/conversation_watcher.py
+++ b/tools/conversation_watcher.py
@@ -224,7 +224,7 @@ class RemoteHttpSink(WatcherSink):
         if not api_url:
             raise ValueError("RemoteHttpSink needs api_url")
         if not jwt:
-            raise ValueError("RemoteHttpSink needs JWT (env MAYRING_JWT)")
+            raise ValueError("RemoteHttpSink needs auth token (env MAYRING_JWT or MCP_SERVICE_TOKEN)")
         self._base = api_url.rstrip("/")
         self._jwt = jwt
         self._client = httpx.Client(
@@ -454,7 +454,8 @@ def main(argv=None) -> None:
     model = args.model or os.getenv("OLLAMA_MODEL", "")
     projects_dir = Path(args.projects_dir) if args.projects_dir else _PROJECTS_DIR
     api_url = args.api_url or os.getenv("MAYRING_API_URL", "")
-    jwt = args.jwt or os.getenv("MAYRING_JWT", "")
+    # MAYRING_JWT for user laptops; MCP_SERVICE_TOKEN fallback for server daemons.
+    jwt = args.jwt or os.getenv("MAYRING_JWT", "") or os.getenv("MCP_SERVICE_TOKEN", "")
 
     sink = build_sink(api_url, jwt)
     mode_label = "remote-http" if isinstance(sink, RemoteHttpSink) else "local-db"


### PR DESCRIPTION
## Problem

Der Server-Watcher braucht ein `MAYRING_JWT` zum Authentifizieren — das läuft ab, muss manuell erneuert werden und passt nicht zu einem Service-Daemon.

## Lösung: Dual-Auth (passt zum bestehenden Muster im Codebase)

| Kontext | Auth | workspace_id |
|---------|------|--------------|
| User-Laptop (`mayring-watcher.yml`) | `MAYRING_JWT` (RS256) | aus JWT-Claims |
| Server-Daemon (`docker-compose.mayring.yml`) | `MCP_SERVICE_TOKEN` | hardcoded `system` |

**`src/api/auth.py`:** Prüft Bearer-Token vor JWT-Validierung gegen `MCP_SERVICE_TOKEN`. Bei Match → `TokenInfo(workspace_id="system")`.

**`tools/conversation_watcher.py`:** `MAYRING_JWT || MCP_SERVICE_TOKEN` Fallback. `MCP_SERVICE_TOKEN` ist bereits in `.env.production` (via deploy workflow).

## Ergebnis

Server-Watcher startet ohne `MAYRING_JWT` — nutzt automatisch den Service-Token. Keine manuelle JWT-Rotation mehr nötig.

## Summary by Sourcery

Support dual authentication for the conversation watcher by accepting either a user JWT or a service token and wiring the watcher to use the appropriate token automatically.

New Features:
- Allow server daemons to authenticate using a static MCP_SERVICE_TOKEN that maps to a system workspace with full scope.

Enhancements:
- Extend API auth middleware to treat MCP_SERVICE_TOKEN as a valid Bearer token alongside RS256 JWTs.
- Update conversation watcher configuration to fall back from MAYRING_JWT to MCP_SERVICE_TOKEN and clarify error messaging around required auth tokens.