### PR TITLE
Potential fix for code scanning alert no. 69: Uncontrolled data used in path expression

### DIFF
--- a/src/api/web_ui.py
+++ b/src/api/web_ui.py
@@ -855,10 +855,11 @@ def _build_brain_figure(workspace_id: str):
                         margin=dict(l=0, r=0, t=0, b=0), height=680)
         return f
 
-    if not workspace_id or not _re_b.fullmatch(r"[a-zA-Z0-9_\-.]+", workspace_id):
+    _wid = str(workspace_id or "").strip()
+    if not _wid or not _re_b.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*", _wid):
         return _empty_fig("Ungültige Workspace-ID")
 
-    _safe_wid = _os_b.path.basename(workspace_id)
+    _safe_wid = _wid
     cache_root = CACHE_DIR.resolve()
     cluster_path = (cache_root / f"{_safe_wid}_wiki_clusters.json").resolve()
     try:

--- a/src/api/web_ui.py
+++ b/src/api/web_ui.py
@@ -859,7 +859,12 @@ def _build_brain_figure(workspace_id: str):
         return _empty_fig("Ungültige Workspace-ID")
 
     _safe_wid = _os_b.path.basename(workspace_id)
-    cluster_path = CACHE_DIR / f"{_safe_wid}_wiki_clusters.json"
+    cache_root = CACHE_DIR.resolve()
+    cluster_path = (cache_root / f"{_safe_wid}_wiki_clusters.json").resolve()
+    try:
+        cluster_path.relative_to(cache_root)
+    except ValueError:
+        return _empty_fig("Ungültiger Workspace-Pfad")
 
     if not cluster_path.exists():
         return _empty_fig("Kein Wiki — 'Wiki generieren' klicken")


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/69](https://github.com/Nileneb/MayringCoder/security/code-scanning/69)

General fix approach: when using user input in file paths, resolve the final path and verify it remains under a trusted base directory before reading/writing.

Best fix here (without changing functionality): in `src/api/web_ui.py` inside `_build_brain_figure`, resolve `CACHE_DIR` and the computed `cluster_path` to absolute canonical paths and enforce that `cluster_path` is a descendant of `CACHE_DIR` via `relative_to`. If containment fails, return the existing empty/error figure. This preserves current behavior for valid workspace IDs while making path safety explicit and resilient.

Needed changes:
- No new imports required (already using `Path`).
- Edit only `_build_brain_figure` around lines 861–864 to:
  - compute `cache_root = CACHE_DIR.resolve()`
  - compute `cluster_path = (cache_root / f"{_safe_wid}_wiki_clusters.json").resolve()`
  - check `cluster_path.relative_to(cache_root)` in a `try/except ValueError`
  - return `_empty_fig("Ungültiger Workspace-Pfad")` on failure


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden workspace cluster file loading by validating workspace IDs and constraining resolved file paths to the cache directory to address an uncontrolled path usage issue.

Bug Fixes:
- Prevent path traversal when constructing cluster file paths by resolving paths against the cache root and enforcing that they remain within the trusted cache directory.

Enhancements:
- Tighten workspace ID validation to a more restrictive pattern and normalize input before use.