### PR TITLE
Potential fix for code scanning alert no. 97: Uncontrolled data used in path expression

### DIFF
--- a/src/wiki_v2/_path_utils.py
+++ b/src/wiki_v2/_path_utils.py
@@ -18,7 +18,9 @@ def confined_path(root: Path, *parts: str) -> Path:
     root_r = Path(root).resolve()
     p = root_r
     for part in parts:
-        _s = os.path.basename(str(part).replace('/', '_').replace('\\', '_'))
+        _s = safe_filename_part(str(part))
+        if not _s or _s in {".", ".."}:
+            raise ValueError(f"Invalid path segment: {part!r}")
         p = (p / _s).resolve()
     if not p.is_relative_to(root_r):
         raise ValueError(f"Path traversal: {parts!r} escapes {root!r}")


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/97](https://github.com/Nileneb/MayringCoder/security/code-scanning/97)

Best fix: enforce strict filename-segment allowlisting before joining into paths, and keep the root-containment check after resolution.

In `src/wiki_v2/_path_utils.py`, update `confined_path` to sanitize each `part` using the existing `safe_filename_part` (regex allowlist), reject empty/`.`/`..` segments, then join and resolve once per segment (or once at end) and keep `is_relative_to(root_r)` enforcement. This preserves behavior (still maps unsafe chars to `_`) while removing reliance on weak `basename+replace` logic and addressing all taint variants that flow into this utility.

No changes are required in `server.py`/`web_ui.py` for this specific sink if `_cp` uses `confined_path`; central hardening here fixes all reported variants at the flagged location.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Sanitize each path segment with the existing safe filename allowlist and reject empty or traversal segments before resolving paths to close the uncontrolled data in path expression vulnerability.