### PR TITLE
Potential fix for code scanning alert no. 99: Uncontrolled data used in path expression

### DIFF
--- a/src/api/web_ui.py
+++ b/src/api/web_ui.py
@@ -830,11 +830,12 @@ _BRAIN_HTML_UNUSED = """
 
 
 def _load_graph_data(workspace_id: str) -> dict | None:
-    import json, os
+    import json
     from src.config import WIKI_DIR
-    from src.wiki_v2._path_utils import confined_path
-    wid = os.path.basename(str(workspace_id or "").strip().replace('/', '_').replace('\\', '_'))
-    if not wid:
+    from src.wiki_v2._path_utils import confined_path, safe_workspace_id
+    try:
+        wid = safe_workspace_id(workspace_id)
+    except ValueError:
         return None
     path = confined_path(WIKI_DIR, wid, "graph.json")
     if not path.exists():

--- a/src/wiki_v2/_path_utils.py
+++ b/src/wiki_v2/_path_utils.py
@@ -7,7 +7,11 @@ _SAFE_NAME_RE = re.compile(r'[^A-Za-z0-9_\-]')
 
 
 def safe_workspace_id(wid: str) -> str:
-    return os.path.basename(wid.replace('/', '_').replace('\\', '_'))
+    s = os.path.basename(str(wid or "").replace('/', '_').replace('\\', '_'))
+    s = _SAFE_NAME_RE.sub('_', s).strip("._-")
+    if not s or s in {".", ".."}:
+        raise ValueError(f"Invalid workspace id: {wid!r}")
+    return s
 
 
 def safe_filename_part(name: str) -> str:


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/99](https://github.com/Nileneb/MayringCoder/security/code-scanning/99)

Use the existing shared sanitizer `safe_workspace_id` from `src/wiki_v2/_path_utils.py` in `_load_graph_data` instead of inline `basename` logic, and harden `safe_workspace_id` itself to enforce a strict character allowlist and reject empty/dot-only IDs.

Best single fix without changing functionality:
1. In `src/wiki_v2/_path_utils.py`, update `safe_workspace_id` to:
   - normalize input to string,
   - replace path separators,
   - apply `basename`,
   - replace non `[A-Za-z0-9_-]` chars with `_` (using existing `_SAFE_NAME_RE`),
   - strip leading/trailing `._-`,
   - reject empty / `"."` / `".."`.
2. In `src/api/web_ui.py` `_load_graph_data`, import and use `safe_workspace_id` + `confined_path`, and treat invalid IDs as `None`.

This keeps behavior (load `graph.json` under workspace folder) while making validation explicit, reusable, and analyzer-friendly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden workspace ID sanitization and reuse the shared sanitizer in graph loading to address uncontrolled path usage.

Bug Fixes:
- Ensure workspace IDs used to load graph data are sanitized via a shared `safe_workspace_id` helper instead of ad-hoc `basename` logic, preventing uncontrolled data in path expressions.

Enhancements:
- Strengthen `safe_workspace_id` to normalize input, enforce a strict safe-character set, strip unsafe leading/trailing characters, and reject empty or dot-only workspace IDs.