### PR TITLE
Potential fix for code scanning alert no. 97: Uncontrolled data used in path expression

### DIFF
--- a/src/wiki_v2/_path_utils.py
+++ b/src/wiki_v2/_path_utils.py
@@ -22,7 +22,8 @@ def confined_path(root: Path, *parts: str) -> Path:
     root_r = Path(root).resolve()
     p = root_r
     for part in parts:
-        _s = os.path.basename(str(part).replace('/', '_').replace('\\', '_'))
+        _raw = os.path.basename(str(part).replace('/', '_').replace('\\', '_'))
+        _s = _SAFE_NAME_RE.sub('_', _raw).strip("._-")
         if not _s or _s in {".", ".."}:
             raise ValueError(f"Invalid path segment: {part!r}")
         p = (p / _s).resolve()


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/97](https://github.com/Nileneb/MayringCoder/security/code-scanning/97)

Use strict segment sanitization inside `confined_path` (same policy as `safe_workspace_id`/`safe_filename_part`) before joining, and reject segments that become empty or special after sanitization. This ensures all path parts are reduced to a safe filename token, not just basename-derived text.

Best fix (minimal behavioral change): in `src/wiki_v2/_path_utils.py`, update `confined_path` loop so each `part` is:
1. Converted to string.
2. Separator-normalized and `basename`-reduced.
3. Passed through `_SAFE_NAME_RE.sub('_', ...)`.
4. Trimmed of dangerous leading/trailing `._-` like workspace IDs.
5. Validated non-empty and not `"."`/`"..""`.

Then continue using `resolve()` and the existing `is_relative_to(root_r)` containment check. No other files are required for this CodeQL sink fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Sanitize and validate each path segment in confined_path so that uncontrolled input cannot produce unsafe or special path components.