### PR TITLE
fix(tests): behebe 72 pre-existing failures (#93–#100)

### DIFF
--- a/src/analysis/context.py
+++ b/src/analysis/context.py
@@ -3,4 +3,4 @@ from src.analysis.context_rag import *
 from src.analysis.context_embedfilter import *
 
 # Re-export private helpers that callers import by name
-from src.analysis.context_rag import _chroma_dir, _embed_texts
+from src.analysis.context_rag import _chroma_dir, _embed_texts, _HAS_CHROMADB

--- a/src/analysis/extractor.py
+++ b/src/analysis/extractor.py
@@ -1,3 +1,7 @@
 from src.analysis.extractor_signatures import *
 from src.analysis.extractor_core import *
 from src.analysis.extractor_validation import *
+
+# Private helpers not covered by wildcard imports (used in tests + callers)
+from src.analysis.extractor_core import _regex_extract_findings
+from src.analysis.extractor_validation import _build_second_opinion_question, _QUESTION_TEMPLATES

--- a/src/api/mcp.py
+++ b/src/api/mcp.py
@@ -48,6 +48,10 @@ from src.api.mcp_memory_tools import register_memory_tools
 from src.api.mcp_agent_tools import register_agent_tools
 from src.api.mcp_oauth import PathNormMiddleware, build_starlette_routes
 
+# Backward-compat aliases for tests that import with underscore prefix
+_JWTAuthMiddleware = JWTAuthMiddleware
+_PathNormMiddleware = PathNormMiddleware
+
 _TRANSPORT  = os.getenv("MCP_TRANSPORT", "stdio")
 _HTTP_PORT  = int(os.getenv("MCP_HTTP_PORT", "8000"))
 _HTTP_HOST  = os.getenv("MCP_HTTP_HOST", "0.0.0.0")

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -37,6 +37,7 @@ except ImportError:
 from src.api.dependencies import get_conn as _get_conn
 from src.api.training import router as _training_router
 from src.api.routes import memory, wiki, jobs, duel, reports
+from src.api.job_queue import _JOBS, run_checker_job as _run_checker_job
 
 app = FastAPI(title="MayringCoder API", version="1.0.0")
 

--- a/src/api/web_ui.py
+++ b/src/api/web_ui.py
@@ -35,6 +35,9 @@ from src.api.web_ui_helpers import (
     _laravel_base,
     _laravel_headers,
     set_runtime_urls,
+    # Re-exports for test accessibility (functions defined in helpers)
+    _do_feedback, refresh_jwt, _do_search,
+    _do_ingest, _do_ingest_conversation, _get_conn, _api_post,
 )
 from src.api.web_ui_tabs import (
     build_memory_tab,

--- a/tests/test_analyzer_hardening.py
+++ b/tests/test_analyzer_hardening.py
@@ -95,7 +95,7 @@ class TestOllamaGenerateSystemPrompt:
 
         captured = {}
 
-        def fake_stream(method, url, json=None, timeout=None):
+        def fake_stream(method, url, json=None, timeout=None, verify=None, **kwargs):
             captured["json"] = json
             return self._make_mock_response()
 
@@ -112,7 +112,7 @@ class TestOllamaGenerateSystemPrompt:
 
         captured = {}
 
-        def fake_stream(method, url, json=None, timeout=None):
+        def fake_stream(method, url, json=None, timeout=None, verify=None, **kwargs):
             captured["json"] = json
             return self._make_mock_response()
 
@@ -126,7 +126,7 @@ class TestOllamaGenerateSystemPrompt:
 
         captured = {}
 
-        def fake_stream(method, url, json=None, timeout=None):
+        def fake_stream(method, url, json=None, timeout=None, verify=None, **kwargs):
             captured["json"] = json
             return self._make_mock_response()
 

--- a/tests/test_context_improvements.py
+++ b/tests/test_context_improvements.py
@@ -73,7 +73,7 @@ def mock_cache(tmp_path: Path):
     overview_path = cache_dir / overview_filename
     overview_path.write_text(json.dumps(overview_data, ensure_ascii=False), encoding="utf-8")
 
-    with patch("src.analysis.context.CACHE_DIR", cache_dir):
+    with patch("src.analysis.context_cache.CACHE_DIR", cache_dir):
         yield {
             "cache_dir": cache_dir,
             "overview_path": overview_path,

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -110,7 +110,7 @@ class TestBuildFileIndex:
         embedder.CACHE_DIR = tmp_path
 
         files = [_make_file("a.py"), _make_file("b.py")]
-        with patch("src.analysis.context._embed_texts", side_effect=_fake_embed):
+        with patch("src.analysis.context_embedfilter._embed_texts", side_effect=_fake_embed):
             index = build_file_index(files, "http://localhost:11434", repo_url="")
         assert len(index) == 2
         assert {e["filename"] for e in index} == {"a.py", "b.py"}
@@ -122,7 +122,7 @@ class TestBuildFileIndex:
         embedder.CACHE_DIR = tmp_path
 
         files = [_make_file("x.py", "hello")]
-        with patch("src.analysis.context._embed_texts", side_effect=_fake_embed):
+        with patch("src.analysis.context_embedfilter._embed_texts", side_effect=_fake_embed):
             index = build_file_index(files, "http://localhost:11434", repo_url="")
         assert isinstance(index[0]["embedding"], list)
         assert len(index[0]["embedding"]) == 2
@@ -130,8 +130,10 @@ class TestBuildFileIndex:
     def test_cache_is_written_and_reused(self, tmp_path):
         from src import config as cfg
         from src.analysis import context as embedder
+        import src.analysis.context_embedfilter as _emb_filter
         cfg.CACHE_DIR = tmp_path
         embedder.CACHE_DIR = tmp_path
+        _emb_filter.CACHE_DIR = tmp_path
 
         files = [_make_file("z.py", "code")]
         call_count = {"n": 0}
@@ -141,7 +143,7 @@ class TestBuildFileIndex:
             return _fake_embed(texts, url)
 
         repo = "https://github.com/test/repo"
-        with patch("src.analysis.context._embed_texts", side_effect=counting_embed):
+        with patch("src.analysis.context_embedfilter._embed_texts", side_effect=counting_embed):
             build_file_index(files, "http://localhost:11434", repo_url=repo)
             # Second call — should hit cache, not call embed again
             build_file_index(files, "http://localhost:11434", repo_url=repo)
@@ -151,8 +153,10 @@ class TestBuildFileIndex:
     def test_force_reindex_bypasses_cache(self, tmp_path):
         from src import config as cfg
         from src.analysis import context as embedder
+        import src.analysis.context_embedfilter as _emb_filter
         cfg.CACHE_DIR = tmp_path
         embedder.CACHE_DIR = tmp_path
+        _emb_filter.CACHE_DIR = tmp_path
 
         files = [_make_file("f.py")]
         call_count = {"n": 0}
@@ -162,7 +166,7 @@ class TestBuildFileIndex:
             return _fake_embed(texts, url)
 
         repo = "https://github.com/test/repo2"
-        with patch("src.analysis.context._embed_texts", side_effect=counting_embed):
+        with patch("src.analysis.context_embedfilter._embed_texts", side_effect=counting_embed):
             build_file_index(files, "http://localhost:11434", repo_url=repo)
             build_file_index(files, "http://localhost:11434", repo_url=repo, force=True)
 
@@ -171,8 +175,10 @@ class TestBuildFileIndex:
     def test_cache_invalidated_on_file_set_change(self, tmp_path):
         from src import config as cfg
         from src.analysis import context as embedder
+        import src.analysis.context_embedfilter as _emb_filter
         cfg.CACHE_DIR = tmp_path
         embedder.CACHE_DIR = tmp_path
+        _emb_filter.CACHE_DIR = tmp_path
 
         files_v1 = [_make_file("a.py")]
         files_v2 = [_make_file("a.py"), _make_file("b.py")]
@@ -183,7 +189,7 @@ class TestBuildFileIndex:
             return _fake_embed(texts, url)
 
         repo = "https://github.com/test/repo3"
-        with patch("src.analysis.context._embed_texts", side_effect=counting_embed):
+        with patch("src.analysis.context_embedfilter._embed_texts", side_effect=counting_embed):
             build_file_index(files_v1, "http://localhost:11434", repo_url=repo)
             build_file_index(files_v2, "http://localhost:11434", repo_url=repo)
 
@@ -200,11 +206,13 @@ class TestFilterByEmbedding:
     def _run_filter(self, files, query, top_k=10, threshold=None, tmp_path=None):
         from src import config as cfg
         from src.analysis import context as embedder
+        import src.analysis.context_embedfilter as _emb_filter
         if tmp_path is not None:
             cfg.CACHE_DIR = tmp_path
             embedder.CACHE_DIR = tmp_path
+            _emb_filter.CACHE_DIR = tmp_path
 
-        with patch("src.analysis.context._embed_texts", side_effect=_fake_embed):
+        with patch("src.analysis.context_embedfilter._embed_texts", side_effect=_fake_embed):
             return filter_by_embedding(
                 files=files,
                 query=query,

--- a/tests/test_jwt_auth.py
+++ b/tests/test_jwt_auth.py
@@ -240,7 +240,9 @@ async def _drive(mw, scope_type="http", token=None, bearer=False):
 
 def _load_middleware(monkeypatch, enabled: bool):
     import src.api.mcp as mod
+    import src.api.mcp_auth as auth_mod
     monkeypatch.setattr(mod, "_AUTH_ENABLED", enabled)
+    monkeypatch.setattr(auth_mod, "_AUTH_ENABLED", enabled)
     from src.api.mcp import _JWTAuthMiddleware
     return _JWTAuthMiddleware(AsyncMock())
 

--- a/tests/test_rag_enrichment.py
+++ b/tests/test_rag_enrichment.py
@@ -106,9 +106,9 @@ class TestBuildRagQuery:
 
 class TestEnrichFindingsWithRag:
 
-    @patch("src.analysis.context._HAS_CHROMADB", True)
-    @patch("src.analysis.context._embed_texts")
-    @patch("src.analysis.context.chromadb")
+    @patch("src.analysis.context_rag._HAS_CHROMADB", True)
+    @patch("src.analysis.context_rag._embed_texts")
+    @patch("src.analysis.context_rag.chromadb")
     def test_stores_rag_context_and_query(self, mock_chromadb, mock_embed):
         # Setup mocks
         mock_embed.return_value = [[0.1] * 384]
@@ -124,7 +124,7 @@ class TestEnrichFindingsWithRag:
 
         results = [_result("a.py", [_finding("redundanz")])]
 
-        with patch("src.analysis.context._chroma_dir") as mock_dir:
+        with patch("src.analysis.context_rag._chroma_dir") as mock_dir:
             mock_dir.return_value = MagicMock(exists=MagicMock(return_value=True))
             enriched = enrich_findings_with_rag(results, "https://github.com/t/r", "http://localhost:11434")
 
@@ -133,13 +133,13 @@ class TestEnrichFindingsWithRag:
         assert "_rag_context" in finding
         assert "user.py" in finding["_rag_context"]
 
-    @patch("src.analysis.context._HAS_CHROMADB", True)
-    @patch("src.analysis.context._embed_texts")
-    @patch("src.analysis.context.chromadb")
+    @patch("src.analysis.context_rag._HAS_CHROMADB", True)
+    @patch("src.analysis.context_rag._embed_texts")
+    @patch("src.analysis.context_rag.chromadb")
     def test_empty_results_noop(self, mock_chromadb, mock_embed):
         results = [{"filename": "a.py", "category": "domain", "potential_smells": []}]
 
-        with patch("src.analysis.context._chroma_dir") as mock_dir:
+        with patch("src.analysis.context_rag._chroma_dir") as mock_dir:
             mock_dir.return_value = MagicMock(exists=MagicMock(return_value=True))
             mock_client = MagicMock()
             mock_chromadb.PersistentClient.return_value = mock_client
@@ -152,16 +152,16 @@ class TestEnrichFindingsWithRag:
         mock_embed.assert_not_called()
         assert enriched[0]["potential_smells"] == []
 
-    @patch("src.analysis.context._HAS_CHROMADB", False)
+    @patch("src.analysis.context_rag._HAS_CHROMADB", False)
     def test_no_chromadb_returns_unchanged(self):
         results = [_result()]
         enriched = enrich_findings_with_rag(results, "https://github.com/t/r", "http://localhost:11434")
         finding = enriched[0]["potential_smells"][0]
         assert "_rag_context" not in finding
 
-    @patch("src.analysis.context._HAS_CHROMADB", True)
-    @patch("src.analysis.context._embed_texts")
-    @patch("src.analysis.context.chromadb")
+    @patch("src.analysis.context_rag._HAS_CHROMADB", True)
+    @patch("src.analysis.context_rag._embed_texts")
+    @patch("src.analysis.context_rag.chromadb")
     def test_multiple_findings_batch_embedded(self, mock_chromadb, mock_embed):
         mock_embed.return_value = [[0.1] * 384, [0.2] * 384, [0.3] * 384]
 
@@ -181,7 +181,7 @@ class TestEnrichFindingsWithRag:
         ]
         results = [_result("a.py", findings)]
 
-        with patch("src.analysis.context._chroma_dir") as mock_dir:
+        with patch("src.analysis.context_rag._chroma_dir") as mock_dir:
             mock_dir.return_value = MagicMock(exists=MagicMock(return_value=True))
             enrich_findings_with_rag(results, "https://github.com/t/r", "http://localhost:11434")
 
@@ -190,9 +190,9 @@ class TestEnrichFindingsWithRag:
         queries_arg = mock_embed.call_args[0][0]
         assert len(queries_arg) == 3
 
-    @patch("src.analysis.context._HAS_CHROMADB", True)
-    @patch("src.analysis.context._embed_texts")
-    @patch("src.analysis.context.chromadb")
+    @patch("src.analysis.context_rag._HAS_CHROMADB", True)
+    @patch("src.analysis.context_rag._embed_texts")
+    @patch("src.analysis.context_rag.chromadb")
     def test_error_in_results_skipped(self, mock_chromadb, mock_embed):
         """Results with 'error' key should be skipped entirely."""
         mock_embed.return_value = []
@@ -205,7 +205,7 @@ class TestEnrichFindingsWithRag:
 
         results = [{"filename": "a.py", "error": "Timeout"}]
 
-        with patch("src.analysis.context._chroma_dir") as mock_dir:
+        with patch("src.analysis.context_rag._chroma_dir") as mock_dir:
             mock_dir.return_value = MagicMock(exists=MagicMock(return_value=True))
             enriched = enrich_findings_with_rag(results, "https://github.com/t/r", "http://localhost:11434")
 

--- a/tests/test_v2_ops_endpoints.py
+++ b/tests/test_v2_ops_endpoints.py
@@ -38,7 +38,7 @@ def _cmd_for(mock_run_job, call_index: int) -> list[str]:
 
 class TestV2Endpoints:
     def test_wiki_generate_spawns_job_with_flag(self, client):
-        with patch("src.api.server._run_checker_job", new_callable=AsyncMock) as m:
+        with patch("src.api.routes.jobs._run_checker_job", new_callable=AsyncMock) as m:
             r = _call(client, "/wiki/generate",
                       {"repo": "https://github.com/a/b", "wiki_type": "code"})
         assert r.status_code == 200
@@ -50,19 +50,19 @@ class TestV2Endpoints:
         assert cmd[cmd.index("--repo") + 1] == "https://github.com/a/b"
 
     def test_ambient_snapshot_spawns_generate_ambient(self, client):
-        with patch("src.api.server._run_checker_job", new_callable=AsyncMock) as m:
+        with patch("src.api.routes.jobs._run_checker_job", new_callable=AsyncMock) as m:
             r = _call(client, "/ambient/snapshot", {"repo": "https://github.com/a/b"})
         assert r.status_code == 200
         assert "--generate-ambient" in _cmd_for(m, 0)
 
     def test_predictive_rebuild_spawns_transitions_flag(self, client):
-        with patch("src.api.server._run_checker_job", new_callable=AsyncMock) as m:
+        with patch("src.api.routes.jobs._run_checker_job", new_callable=AsyncMock) as m:
             r = _call(client, "/predictive/rebuild-transitions", {"repo": None})
         assert r.status_code == 200
         assert "--rebuild-transitions" in _cmd_for(m, 0)
 
     def test_predictive_rebuild_respects_optional_repo(self, client):
-        with patch("src.api.server._run_checker_job", new_callable=AsyncMock) as m:
+        with patch("src.api.routes.jobs._run_checker_job", new_callable=AsyncMock) as m:
             r = _call(client, "/predictive/rebuild-transitions",
                       {"repo": "https://github.com/a/b"})
         assert r.status_code == 200
@@ -81,7 +81,7 @@ class TestPostIngestV2Chain:
             calls.append(list(args))
             srv._JOBS[job_id]["status"] = "done"
 
-        with patch("src.api.server._run_checker_job", side_effect=_fake_checker):
+        with patch("src.api.routes.jobs._run_checker_job", side_effect=_fake_checker):
             r = _call(client, "/populate", {"repo": "https://github.com/a/b"})
         assert r.status_code == 200
         job_id = r.json()["job_id"]
@@ -110,7 +110,7 @@ class TestPostIngestV2Chain:
             else:
                 srv._JOBS[job_id]["status"] = "done"
 
-        with patch("src.api.server._run_checker_job", side_effect=_fake_checker):
+        with patch("src.api.routes.jobs._run_checker_job", side_effect=_fake_checker):
             r = _call(client, "/populate", {"repo": "https://github.com/a/b"})
         assert r.status_code == 200
         job_id = r.json()["job_id"]
@@ -124,7 +124,7 @@ class TestPostIngestV2Chain:
         async def _fake_checker(job_id, args, workspace_id):
             srv._JOBS[job_id]["status"] = "error"
 
-        with patch("src.api.server._run_checker_job", side_effect=_fake_checker):
+        with patch("src.api.routes.jobs._run_checker_job", side_effect=_fake_checker):
             r = _call(client, "/populate", {"repo": "https://github.com/a/b"})
         assert r.status_code == 200
         job_id = r.json()["job_id"]
@@ -136,7 +136,7 @@ class TestPostIngestV2Chain:
         async def _fake_checker(job_id, args, workspace_id):
             srv._JOBS[job_id]["status"] = "done"
 
-        with patch("src.api.server._run_checker_job", side_effect=_fake_checker):
+        with patch("src.api.routes.jobs._run_checker_job", side_effect=_fake_checker):
             r = _call(client, "/issues/ingest",
                       {"repo": "https://github.com/a/b", "state": "open"})
         assert r.status_code == 200

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -153,13 +153,13 @@ class TestIngestTabWithoutOllama:
         fake_conn = MagicMock(spec=sqlite3.Connection)
 
         with (
-            patch.object(web_ui, "_MEMORY_READY", True),
-            patch.object(web_ui, "_conn", fake_conn),
-            patch("src.api.web_ui._get_conn", return_value=fake_conn),
-            patch("src.api.web_ui._get_chroma", return_value=None),
-            patch("src.api.web_ui.ingest", return_value=mock_ingest_result),
-            patch("src.api.web_ui.Source") as MockSource,
-            patch("src.api.web_ui.hashlib") as mock_hashlib,
+            patch("src.api.web_ui_helpers._MEMORY_READY", True),
+            patch("src.api.web_ui_helpers._conn", fake_conn),
+            patch("src.api.web_ui_helpers._get_conn", return_value=fake_conn),
+            patch("src.api.web_ui_helpers._get_chroma", return_value=None),
+            patch("src.api.web_ui_helpers.ingest", return_value=mock_ingest_result),
+            patch("src.api.web_ui_helpers.Source") as MockSource,
+            patch("src.api.web_ui_helpers.hashlib") as mock_hashlib,
         ):
             # Setup hashlib mock
             mock_hash = MagicMock()
@@ -191,7 +191,7 @@ class TestIngestTabWithoutOllama:
         """Empty text + no file → error JSON."""
         import src.api.web_ui as web_ui
 
-        with patch.object(web_ui, "_MEMORY_READY", True):
+        with patch("src.api.web_ui_helpers._MEMORY_READY", True):
             raw = web_ui._do_ingest(
                 text_input="",
                 file_upload=None,
@@ -233,10 +233,10 @@ class TestSearchFallbackSymbolic:
         fake_conn = MagicMock(spec=sqlite3.Connection)
 
         with (
-            patch.object(web_ui, "_MEMORY_READY", True),
-            patch("src.api.web_ui._get_conn", return_value=fake_conn),
-            patch("src.api.web_ui._get_chroma", return_value=None),
-            patch("src.api.web_ui.search", return_value=[fake_record]),
+            patch("src.api.web_ui_helpers._MEMORY_READY", True),
+            patch("src.api.web_ui_helpers._get_conn", return_value=fake_conn),
+            patch("src.api.web_ui_helpers._get_chroma", return_value=None),
+            patch("src.api.web_ui_helpers.search", return_value=[fake_record]),
         ):
             status, rows = web_ui._do_search(
                 query="foo",
@@ -252,7 +252,7 @@ class TestSearchFallbackSymbolic:
         """Empty query → hint message, no rows."""
         import src.api.web_ui as web_ui
 
-        with patch.object(web_ui, "_MEMORY_READY", True):
+        with patch("src.api.web_ui_helpers._MEMORY_READY", True):
             status, rows = web_ui._do_search("", 8, False)
 
         assert "eingeben" in status.lower() or "suchbegriff" in status.lower()
@@ -262,7 +262,7 @@ class TestSearchFallbackSymbolic:
         """_MEMORY_READY=False → error message, no rows."""
         import src.api.web_ui as web_ui
 
-        with patch.object(web_ui, "_MEMORY_READY", False):
+        with patch("src.api.web_ui_helpers._MEMORY_READY", False):
             status, rows = web_ui._do_search("something", 8, True)
 
         assert "nicht geladen" in status.lower() or "memory" in status.lower()
@@ -291,7 +291,7 @@ class TestFeedbackWrite:
     def test_feedback_positive_via_http(self):
         """Positive signal → _api_post called with correct payload."""
         import src.api.web_ui as web_ui
-        with patch("src.api.web_ui._api_post", return_value={"recorded": True}) as mock_post:
+        with patch("src.api.web_ui_helpers._api_post", return_value={"recorded": True}) as mock_post:
             result = web_ui._do_feedback("chk_aabbccdd", "positive", "", "tok")
         mock_post.assert_called_once_with(
             "memory/feedback",
@@ -303,7 +303,7 @@ class TestFeedbackWrite:
     def test_feedback_with_label_via_http(self):
         """Label is passed in metadata."""
         import src.api.web_ui as web_ui
-        with patch("src.api.web_ui._api_post", return_value={"recorded": True}) as mock_post:
+        with patch("src.api.web_ui_helpers._api_post", return_value={"recorded": True}) as mock_post:
             web_ui._do_feedback("chk_test", "negative", "irrelevant duplicate", "tok")
         mock_post.assert_called_once_with(
             "memory/feedback",
@@ -314,7 +314,7 @@ class TestFeedbackWrite:
     def test_feedback_api_error(self):
         """API error → error message forwarded."""
         import src.api.web_ui as web_ui
-        with patch("src.api.web_ui._api_post", return_value={"error": "server exploded"}):
+        with patch("src.api.web_ui_helpers._api_post", return_value={"error": "server exploded"}):
             result = web_ui._do_feedback("chk_x", "neutral", "", "tok")
         assert "fehler" in result.lower()
 
@@ -335,10 +335,10 @@ class TestModelSelector:
             captured.append(model)
             return {"source_id": "x", "chunk_ids": [], "indexed": False, "deduped": 0, "superseded": 0}
 
-        with patch("src.api.web_ui.ingest", side_effect=fake_ingest), \
-             patch("src.api.web_ui._get_conn", return_value=MagicMock()), \
-             patch("src.api.web_ui._get_chroma", return_value=None), \
-             patch("src.api.web_ui._MEMORY_READY", True):
+        with patch("src.api.web_ui_helpers.ingest", side_effect=fake_ingest), \
+             patch("src.api.web_ui_helpers._get_conn", return_value=MagicMock()), \
+             patch("src.api.web_ui_helpers._get_chroma", return_value=None), \
+             patch("src.api.web_ui_helpers._MEMORY_READY", True):
             _do_ingest("hello world", None, "test.txt", "owner/repo",
                        categorize=False, mode="hybrid", codebook="auto",
                        model="mistral:7b", ollama_available=True)
@@ -354,10 +354,10 @@ class TestModelSelector:
             captured_opts.append(opts or {})
             return {"source_id": "x", "chunk_ids": [], "indexed": False, "deduped": 0, "superseded": 0}
 
-        with patch("src.api.web_ui.ingest", side_effect=fake_ingest), \
-             patch("src.api.web_ui._get_conn", return_value=MagicMock()), \
-             patch("src.api.web_ui._get_chroma", return_value=None), \
-             patch("src.api.web_ui._MEMORY_READY", True):
+        with patch("src.api.web_ui_helpers.ingest", side_effect=fake_ingest), \
+             patch("src.api.web_ui_helpers._get_conn", return_value=MagicMock()), \
+             patch("src.api.web_ui_helpers._get_chroma", return_value=None), \
+             patch("src.api.web_ui_helpers._MEMORY_READY", True):
             _do_ingest("hello world", None, "test.txt", "owner/repo",
                        categorize=True, mode="deductive", codebook="social",
                        model="llama3", ollama_available=True)
@@ -383,10 +383,10 @@ class TestConversationTab:
             captured.append({"session_id": session_id, "run_id": run_id, "text": summary_text})
             return {"source_id": "conv:x", "chunk_ids": ["c1"], "indexed": False, "deduped": 0, "superseded": 0}
 
-        with patch("src.api.web_ui.ingest_conversation_summary", side_effect=fake_ingest_conv), \
-             patch("src.api.web_ui._get_conn", return_value=MagicMock()), \
-             patch("src.api.web_ui._get_chroma", return_value=None), \
-             patch("src.api.web_ui._MEMORY_READY", True):
+        with patch("src.api.web_ui_helpers.ingest_conversation_summary", side_effect=fake_ingest_conv), \
+             patch("src.api.web_ui_helpers._get_conn", return_value=MagicMock()), \
+             patch("src.api.web_ui_helpers._get_chroma", return_value=None), \
+             patch("src.api.web_ui_helpers._MEMORY_READY", True):
             result = _do_ingest_conversation(
                 summary_text="## Summary\n\nWas wir gemacht haben.",
                 session_id="sess-abc",
@@ -401,7 +401,7 @@ class TestConversationTab:
 
     def test_do_ingest_conversation_empty_text_returns_error(self) -> None:
         from src.api.web_ui import _do_ingest_conversation
-        with patch("src.api.web_ui._MEMORY_READY", True):
+        with patch("src.api.web_ui_helpers._MEMORY_READY", True):
             result = _do_ingest_conversation("", "sess-1", "", "model", True)
         assert "error" in result.lower() or "Kein" in result
 
@@ -422,13 +422,13 @@ class TestE2EAnalysisFlow:
         search_result = RetrievalRecord(chunk_id="chk_e2e001", score_final=0.85, score_symbolic=0.6, source_id="repo:test:e2e.py", text="def authenticate(user): pass", category_labels=["auth"], reasons=["token_overlap", "embedding_similarity"])
 
         with (
-            patch.object(web_ui, "_MEMORY_READY", True),
-            patch("src.api.web_ui._get_conn", return_value=fake_conn),
-            patch("src.api.web_ui._get_chroma", return_value=None),
-            patch("src.api.web_ui.ingest", return_value=ingest_result),
-            patch("src.api.web_ui.Source") as MockSource,
-            patch("src.api.web_ui.hashlib") as mock_hashlib,
-            patch("src.api.web_ui.search", return_value=[search_result]),
+            patch("src.api.web_ui_helpers._MEMORY_READY", True),
+            patch("src.api.web_ui_helpers._get_conn", return_value=fake_conn),
+            patch("src.api.web_ui_helpers._get_chroma", return_value=None),
+            patch("src.api.web_ui_helpers.ingest", return_value=ingest_result),
+            patch("src.api.web_ui_helpers.Source") as MockSource,
+            patch("src.api.web_ui_helpers.hashlib") as mock_hashlib,
+            patch("src.api.web_ui_helpers.search", return_value=[search_result]),
         ):
             mock_hash = MagicMock()
             mock_hash.hexdigest.return_value = "b" * 64
@@ -446,7 +446,7 @@ class TestE2EAnalysisFlow:
 
     def test_feedback_after_search(self):
         import src.api.web_ui as web_ui
-        with patch("src.api.web_ui._api_post", return_value={"recorded": True}) as mock_fb:
+        with patch("src.api.web_ui_helpers._api_post", return_value={"recorded": True}) as mock_fb:
             result = web_ui._do_feedback("chk_e2e001", "positive", "relevant", "tok")
         mock_fb.assert_called_once_with(
             "memory/feedback",
@@ -471,11 +471,11 @@ class TestE2EConversationFlow:
         search_hit = RetrievalRecord(chunk_id="chk_conv_001", score_final=0.72, source_id="conv:sess-e2e", text="Wir haben HTTP-Transport implementiert.", category_labels=["Zusammenfassung"], reasons=["token_overlap"])
 
         with (
-            patch.object(web_ui, "_MEMORY_READY", True),
-            patch("src.api.web_ui._get_conn", return_value=fake_conn),
-            patch("src.api.web_ui._get_chroma", return_value=None),
-            patch("src.api.web_ui.ingest_conversation_summary", return_value=conv_result),
-            patch("src.api.web_ui.search", return_value=[search_hit]),
+            patch("src.api.web_ui_helpers._MEMORY_READY", True),
+            patch("src.api.web_ui_helpers._get_conn", return_value=fake_conn),
+            patch("src.api.web_ui_helpers._get_chroma", return_value=None),
+            patch("src.api.web_ui_helpers.ingest_conversation_summary", return_value=conv_result),
+            patch("src.api.web_ui_helpers.search", return_value=[search_hit]),
         ):
             raw = web_ui._do_ingest_conversation(summary_text="## Summary\nWir haben HTTP-Transport implementiert.", session_id="sess-e2e", run_id="run-001", model="", ollama_available=False)
             assert "conv:sess-e2e" in raw
@@ -493,14 +493,14 @@ class TestE2EErrorCases:
 
     def test_ingest_with_no_content_and_no_file(self):
         import src.api.web_ui as web_ui
-        with patch.object(web_ui, "_MEMORY_READY", True):
+        with patch("src.api.web_ui_helpers._MEMORY_READY", True):
             raw = web_ui._do_ingest("", None, "", "", False, "hybrid", "auto", "", False)
         result = json.loads(raw)
         assert "error" in result
 
     def test_search_with_memory_not_loaded(self):
         import src.api.web_ui as web_ui
-        with patch.object(web_ui, "_MEMORY_READY", False):
+        with patch("src.api.web_ui_helpers._MEMORY_READY", False):
             status, rows = web_ui._do_search("test", 5, True)
         assert rows == []
         assert "memory" in status.lower() or "nicht" in status.lower()

--- a/tests/test_web_ui_auth.py
+++ b/tests/test_web_ui_auth.py
@@ -67,8 +67,9 @@ def test_api_post_retries_on_401_with_fresh_token(monkeypatch):
             return _response({"error": "unauth"}, 401)
         return _response({"ok": True}, 200)
 
+    import src.api.web_ui_helpers as _wh
     monkeypatch.setattr(web_ui._httpx, "post", _post)
-    web_ui._api_url = "http://api-test"
+    monkeypatch.setattr(_wh, "_api_url", "http://api-test")
 
     out = web_ui._api_post("memory/search", {"query": "x"}, "old.jwt")
     assert out["ok"] is True
@@ -85,8 +86,9 @@ def test_api_post_gives_up_when_refresh_fails(monkeypatch):
             return _response({}, 401)  # refresh denied
         return _response({"error": "unauth"}, 401)
 
+    import src.api.web_ui_helpers as _wh
     monkeypatch.setattr(web_ui._httpx, "post", _post)
-    web_ui._api_url = "http://api-test"
+    monkeypatch.setattr(_wh, "_api_url", "http://api-test")
 
     out = web_ui._api_post("memory/search", {"query": "x"}, "old.jwt")
     assert "abgelaufen" in out["error"].lower() or "neu einloggen" in out["error"].lower()


### PR DESCRIPTION
- #93: fake_stream-Signaturen um verify=None, **kwargs erweitert
- #94: JWTAuthMiddleware-Test patcht jetzt mcp_auth._AUTH_ENABLED (nicht mcp)
- #97: _QUESTION_TEMPLATES + _regex_extract_findings explizit re-exportiert
- #99: context_embedfilter.CACHE_DIR in embedder-Tests isoliert
- #95: web_ui.py re-exportiert Helfer-Funktionen; Patch-Targets auf helpers.*
- #98/#100: context_cache.CACHE_DIR in Tests korrekt gepatcht; _HAS_CHROMADB aus context_rag re-exportiert; RAG-Patches auf context_rag.* umgeleitet
- #96: _JOBS + _run_checker_job als Modul-Exports in server.py; v2-Tests patchen jetzt routes.jobs._run_checker_job

Ergebnis: 1038 passed, 0 failed, 7 skipped (ChromaDB not installed)

## Summary by Sourcery

Align API, auth, and analysis modules with their test expectations to eliminate a large set of pre-existing test failures.

Bug Fixes:
- Adjust JWT auth middleware tests and exports so auth feature flags and middleware aliases are patched consistently.
- Update web UI tests to patch helper functions and state via the dedicated helpers module instead of the main web UI module.
- Fix RAG enrichment tests by patching context RAG internals (_HAS_CHROMADB, embeddings, Chroma client, and cache directory) on the correct module.
- Ensure v2 operations endpoint tests patch the background job runner from the routes.jobs module instead of the server module.
- Update embedding, cache, and filter tests to use the context_embedfilter and context_cache modules and share the correct CACHE_DIR.
- Extend HTTP client test doubles to accept SSL and extra keyword arguments so analyzer hardening tests correctly simulate streaming calls.
- Make web UI auth tests operate on the helper module’s API URL state to reflect the current implementation.

Enhancements:
- Re-export JWT and path normalization middleware under underscore-prefixed aliases to preserve backwards compatibility for tests relying on those names.
- Expose job queue state and checker job runner from the API server via imports to support job-related tests.

Tests:
- Repair numerous failing tests across web UI, auth, RAG enrichment, embedding, v2 ops endpoints, analyzer hardening, and context caching to restore a fully passing test suite (except for Chromadb-dependent skips).