### PR TITLE
fix: Sourcery-Feedback + #101 LLM-I/O logging + CLI _needs_llm

### DIFF
--- a/src/api/mcp_agent_tools.py
+++ b/src/api/mcp_agent_tools.py
@@ -83,7 +83,8 @@ def register_agent_tools(mcp: FastMCP) -> None:
         Args:
             source:      Repo URL (e.g. "https://github.com/nileneb/MayringCoder")
                          or text content (conversation summary, file content, insight)
-            source_type: "auto" | "repo" | "text"  (default: "auto")
+            source_type: "auto" | "repo" | "text" | "conversation_summary" | "session_knowledge"
+                         | "note" | "paper" (default: "auto")
             source_id:   Dedup key for text sources (e.g. "session-memory:2026-04-25-topic")
             workspace_id: Tenant namespace (default: from JWT)
 
@@ -121,9 +122,10 @@ def register_agent_tools(mcp: FastMCP) -> None:
             try:
                 import hashlib
                 sid = source_id or f"text:{ws}:{hashlib.sha256(source[:64].encode()).hexdigest()[:12]}"
+                _stype = source_type if source_type not in ("auto", "text") else "knowledge"
                 source_dict = {
                     "source_id": sid,
-                    "source_type": "knowledge",
+                    "source_type": _stype,
                     "repo": ws,
                     "path": sid,
                     "content_hash": "sha256:" + hashlib.sha256(source.encode()).hexdigest()[:16],

--- a/src/api/mcp_auth.py
+++ b/src/api/mcp_auth.py
@@ -50,17 +50,20 @@ class JWTAuthMiddleware:
 
     Token via: Authorization: Bearer <jwt>  or  X-Auth-Token: <jwt>
     Admin access: JWT claim `scope: ["admin"]`.
+
+    auth_enabled overrides the module-level _AUTH_ENABLED (useful for tests).
     """
 
-    def __init__(self, app: Any) -> None:
+    def __init__(self, app: Any, *, auth_enabled: bool | None = None) -> None:
         self._app = app
+        self._auth_enabled = _AUTH_ENABLED if auth_enabled is None else auth_enabled
 
     async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
         if scope["type"] != "http":
             await self._app(scope, receive, send)
             return
 
-        if not _AUTH_ENABLED:
+        if not self._auth_enabled:
             _TOKEN_CTX.set(None)
             _RAW_JWT_CTX.set(None)
             await self._app(scope, receive, send)

--- a/src/cli.py
+++ b/src/cli.py
@@ -242,7 +242,11 @@ def main() -> None:
 
     repo_url = args.repo or os.getenv("GITHUB_REPO", "")
     ollama_url = os.getenv("OLLAMA_URL", "http://localhost:11434")
-    _needs_llm = (
+    _is_non_llm_path = (
+        getattr(args, "populate_memory", False)
+        or getattr(args, "generate_training_data", None)
+    )
+    _needs_llm = not _is_non_llm_path and (
         args.mode in ("analyze", "overview")
         or (args.mode == "turbulence" and args.llm)
         or args.resolve_model_only

--- a/src/memory/ingestion/categorization.py
+++ b/src/memory/ingestion/categorization.py
@@ -175,6 +175,7 @@ def mayring_categorize(
     source_type: str = "repo_file",
     conn: Any = None,
     router: "ModelRouter | None" = None,
+    workspace_id: str = "default",
 ) -> "list[Chunk]":
     """Assign Mayring category labels to each chunk via LLM.
 
@@ -206,7 +207,9 @@ def mayring_categorize(
 
     for chunk in chunks:
         try:
+            import time
             prompt = f"Text chunk:\n\n{chunk.text[:1200]}"
+            _t0 = time.monotonic()
             response = _ollama_generate(
                 prompt=prompt,
                 ollama_url=ollama_url,
@@ -214,6 +217,21 @@ def mayring_categorize(
                 label=f"mayring:{chunk.chunk_id[:8]}",
                 system_prompt=system_prompt,
             )
+            _elapsed_ms = int((time.monotonic() - _t0) * 1000)
+            if conn is not None:
+                try:
+                    from src.memory.store import log_llm_call
+                    log_llm_call(
+                        conn=conn,
+                        call_type="categorization",
+                        model=model,
+                        prompt=prompt,
+                        response=response,
+                        duration_ms=_elapsed_ms,
+                        workspace_id=workspace_id,
+                    )
+                except Exception:
+                    pass
             # The hybrid prompt asks for `Kategorien: a, b, c` — extract that
             # line if present, otherwise treat the full response as a raw list
             # (backwards-compat with older deductive/inductive templates).

--- a/src/memory/ingestion/core.py
+++ b/src/memory/ingestion/core.py
@@ -176,6 +176,7 @@ def ingest(
                 source_type=source.source_type,
                 conn=conn,
                 router=router,
+                workspace_id=workspace_id,
             )
 
         new_chunk_ids: list[str] = []

--- a/tests/test_analyzer_hardening.py
+++ b/tests/test_analyzer_hardening.py
@@ -79,27 +79,29 @@ class TestParseLlmJsonDelimiters:
 # _ollama_generate — system_prompt parameter
 # ---------------------------------------------------------------------------
 
-class TestOllamaGenerateSystemPrompt:
-    def _make_mock_response(self, text="ok"):
-        """Create a mock httpx streaming context."""
-        line = json.dumps({"response": text, "done": True})
-        mock_resp = MagicMock()
-        mock_resp.iter_lines.return_value = iter([line])
-        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_resp.raise_for_status = MagicMock()
-        return mock_resp
+def _make_mock_response(text="ok"):
+    line = json.dumps({"response": text, "done": True})
+    mock_resp = MagicMock()
+    mock_resp.iter_lines.return_value = iter([line])
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.raise_for_status = MagicMock()
+    return mock_resp
 
+
+def _capturing_stream(captured: dict):
+    def fake_stream(method, url, json=None, timeout=None, verify=None, **kwargs):
+        captured["json"] = json
+        return _make_mock_response()
+    return fake_stream
+
+
+class TestOllamaGenerateSystemPrompt:
     def test_system_prompt_included_in_request(self):
         from src.analysis.analyzer import _ollama_generate
 
         captured = {}
-
-        def fake_stream(method, url, json=None, timeout=None, verify=None, **kwargs):
-            captured["json"] = json
-            return self._make_mock_response()
-
-        with patch("src.analysis.analyzer.httpx.stream", side_effect=fake_stream):
+        with patch("src.analysis.analyzer.httpx.stream", side_effect=_capturing_stream(captured)):
             _ollama_generate("user content", "http://localhost", "model", "test",
                              system_prompt="system instructions")
 
@@ -111,12 +113,7 @@ class TestOllamaGenerateSystemPrompt:
         from src.analysis.analyzer import _ollama_generate
 
         captured = {}
-
-        def fake_stream(method, url, json=None, timeout=None, verify=None, **kwargs):
-            captured["json"] = json
-            return self._make_mock_response()
-
-        with patch("src.analysis.analyzer.httpx.stream", side_effect=fake_stream):
+        with patch("src.analysis.analyzer.httpx.stream", side_effect=_capturing_stream(captured)):
             _ollama_generate("user content", "http://localhost", "model", "test")
 
         assert "system" not in captured["json"]
@@ -125,12 +122,7 @@ class TestOllamaGenerateSystemPrompt:
         from src.analysis.analyzer import _ollama_generate
 
         captured = {}
-
-        def fake_stream(method, url, json=None, timeout=None, verify=None, **kwargs):
-            captured["json"] = json
-            return self._make_mock_response()
-
-        with patch("src.analysis.analyzer.httpx.stream", side_effect=fake_stream):
+        with patch("src.analysis.analyzer.httpx.stream", side_effect=_capturing_stream(captured)):
             _ollama_generate("user content", "http://localhost", "model", "test",
                              system_prompt=None)
 

--- a/tests/test_jwt_auth.py
+++ b/tests/test_jwt_auth.py
@@ -239,12 +239,8 @@ async def _drive(mw, scope_type="http", token=None, bearer=False):
 
 
 def _load_middleware(monkeypatch, enabled: bool):
-    import src.api.mcp as mod
-    import src.api.mcp_auth as auth_mod
-    monkeypatch.setattr(mod, "_AUTH_ENABLED", enabled)
-    monkeypatch.setattr(auth_mod, "_AUTH_ENABLED", enabled)
     from src.api.mcp import _JWTAuthMiddleware
-    return _JWTAuthMiddleware(AsyncMock())
+    return _JWTAuthMiddleware(AsyncMock(), auth_enabled=enabled)
 
 
 class TestMiddlewareEnabled:

--- a/tests/test_web_ui_auth.py
+++ b/tests/test_web_ui_auth.py
@@ -67,9 +67,8 @@ def test_api_post_retries_on_401_with_fresh_token(monkeypatch):
             return _response({"error": "unauth"}, 401)
         return _response({"ok": True}, 200)
 
-    import src.api.web_ui_helpers as _wh
     monkeypatch.setattr(web_ui._httpx, "post", _post)
-    monkeypatch.setattr(_wh, "_api_url", "http://api-test")
+    web_ui.set_runtime_urls("http://localhost:11434", "http://api-test")
 
     out = web_ui._api_post("memory/search", {"query": "x"}, "old.jwt")
     assert out["ok"] is True
@@ -86,9 +85,8 @@ def test_api_post_gives_up_when_refresh_fails(monkeypatch):
             return _response({}, 401)  # refresh denied
         return _response({"error": "unauth"}, 401)
 
-    import src.api.web_ui_helpers as _wh
     monkeypatch.setattr(web_ui._httpx, "post", _post)
-    monkeypatch.setattr(_wh, "_api_url", "http://api-test")
+    web_ui.set_runtime_urls("http://localhost:11434", "http://api-test")
 
     out = web_ui._api_post("memory/search", {"query": "x"}, "old.jwt")
     assert "abgelaufen" in out["error"].lower() or "neu einloggen" in out["error"].lower()

--- a/tools/postcompact_hook.py
+++ b/tools/postcompact_hook.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""PostCompact hook — ingests Claude Code compact summary into MayringCoder memory.
+
+Called by ~/.claude/settings.json hooks.PostCompact.
+Receives {"summary": "..."} as JSON via stdin.
+Always exits 0 — never blocks the compact flow.
+"""
+import datetime
+import hashlib
+import json
+import os
+import sys
+import urllib.request
+
+data = json.loads(sys.stdin.read())
+summary = data.get("summary", "")
+if not summary.strip():
+    sys.exit(0)
+
+api = os.environ.get("MAYRING_API_URL", "https://mcp.linn.games").rstrip("/")
+jwt_file = os.path.expanduser("~/.config/mayring/hook.jwt")
+
+try:
+    with open(jwt_file) as f:
+        token = f.read().strip()
+except FileNotFoundError:
+    sys.exit(0)
+
+if not token:
+    sys.exit(0)
+
+ts = datetime.datetime.utcnow().strftime("%Y-%m-%d-%H%M%S")
+sid = f"conversation_summary:compact-{ts}-{hashlib.sha256(summary[:64].encode()).hexdigest()[:8]}"
+
+payload = json.dumps({
+    "source_id": sid,
+    "source_type": "conversation_summary",
+    "content": summary,
+    "categorize": True,
+}).encode()
+
+req = urllib.request.Request(
+    f"{api}/memory/put",
+    data=payload,
+    headers={"Content-Type": "application/json", "Authorization": f"Bearer {token}"},
+    method="POST",
+)
+try:
+    urllib.request.urlopen(req, timeout=15)
+except Exception:
+    pass


### PR DESCRIPTION
Sourcery:
- test_analyzer_hardening: fake_stream in _capturing_stream() helper konsolidiert, _make_mock_response als Modul-Funktion extrahiert
- JWTAuthMiddleware akzeptiert jetzt auth_enabled als Konstruktor-Parameter (kein doppeltes Modul-Patching mehr nötig in Tests)
- test_web_ui_auth: nutzt set_runtime_urls() statt _api_url direkt setzen

#101 LLM-I/O Logging:
- mayring_categorize() loggt jeden LLM-Call via log_llm_call() mit call_type="categorization", Prompt, Response, Duration
- workspace_id Parameter durchgereicht (core.py → categorization.py)
- Sichtbar unter GET /stats/summary → llm_calls_log

CLI:
- _needs_llm berücksichtigt jetzt _is_non_llm_path für populate_memory und generate_training_data → kein unnötiger model-selection Prompt mehr

## Summary by Sourcery

Log LLM categorization calls with workspace-aware metadata, refine CLI LLM usage detection, and harden authentication and analyzer tests.

Bug Fixes:
- Prevent unnecessary LLM model-selection prompts for non-LLM CLI paths.

Enhancements:
- Add detailed logging for Mayring categorization LLM calls, including timing and workspace context.
- Propagate workspace identifiers through ingestion to categorization for per-workspace analytics.
- Allow JWTAuthMiddleware to be configured with an explicit auth_enabled flag for easier testing.
- Refactor analyzer and web UI auth tests to share helpers and use public configuration APIs instead of module patching.

Tests:
- Simplify Ollama analyzer streaming tests with shared helper functions and improved mocking of HTTP streaming responses.