### PR TITLE
feat: DB-Adapter, Shared Memory, Feedback Loop, OAuth, Memory Sync (#67 #86 #102 #104 #107)

### DIFF
--- a/claude-plugin/hooks/stop_hook.py
+++ b/claude-plugin/hooks/stop_hook.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Stop hook — marks injected-but-unrated memory chunks as neutral.
+
+Called by ~/.claude/settings.json hooks.Stop after every Claude turn.
+Queries /memory/unrated-chunks and calls /memory/feedback(signal=neutral)
+for each chunk Claude saw but didn't explicitly rate.
+Always exits 0 — never blocks Claude.
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+_JWT_FILE = os.path.expanduser("~/.config/mayring/hook.jwt")
+_API_URL = os.environ.get("MAYRING_API_URL", "https://mcp.linn.games").rstrip("/")
+_TIMEOUT = 5
+_LOOKBACK_MINUTES = 60
+
+
+def _read_token() -> str:
+    try:
+        with open(_JWT_FILE) as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return ""
+
+
+def _get(path: str, token: str) -> dict:
+    req = urllib.request.Request(
+        f"{_API_URL}{path}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        resp = urllib.request.urlopen(req, timeout=_TIMEOUT)
+        return json.loads(resp.read())
+    except Exception:
+        return {}
+
+
+def _post_feedback(chunk_id: str, token: str) -> None:
+    payload = json.dumps({"chunk_id": chunk_id, "signal": "neutral"}).encode()
+    req = urllib.request.Request(
+        f"{_API_URL}/memory/feedback",
+        data=payload,
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {token}"},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=_TIMEOUT)
+    except Exception:
+        pass
+
+
+token = _read_token()
+if not token:
+    sys.exit(0)
+
+data = _get(f"/memory/unrated-chunks?minutes={_LOOKBACK_MINUTES}", token)
+chunk_ids: list[str] = data.get("chunk_ids", [])
+
+for chunk_id in chunk_ids:
+    _post_feedback(chunk_id, token)

--- a/claude-plugin/install.sh
+++ b/claude-plugin/install.sh
@@ -27,6 +27,7 @@ fi
 SETTINGS="$HOME/.claude/settings.json"
 HOOK_SCRIPT="$DEST/hooks/start_watcher.py"
 COMPACT_SCRIPT="$HOME/Desktop/MayringCoder/tools/postcompact_hook.py"
+STOP_SCRIPT="$DEST/hooks/stop_hook.py"
 
 python3 - <<PYEOF
 import json, os, sys
@@ -34,9 +35,13 @@ import json, os, sys
 settings_path = os.path.expanduser("$SETTINGS")
 hook_script = "$HOOK_SCRIPT"
 compact_script = "$COMPACT_SCRIPT"
+stop_script = "$STOP_SCRIPT"
 
-with open(settings_path) as f:
-    cfg = json.load(f)
+try:
+    with open(settings_path) as f:
+        cfg = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    cfg = {}
 
 hooks = cfg.setdefault("hooks", {})
 
@@ -69,6 +74,21 @@ if not already_compact:
     print("Hook hinzugefügt: PostCompact → postcompact_hook.py")
 else:
     print("Hook bereits vorhanden: PostCompact")
+
+# Stop — unbeurteilte injizierte Chunks → signal=neutral
+hooks.setdefault("Stop", [])
+stop_hook = {"type": "command", "command": f"python3 {stop_script}"}
+stop_entry = {"matcher": "", "hooks": [stop_hook]}
+already_stop = any(
+    any(h.get("command", "").endswith("stop_hook.py")
+        for h in e.get("hooks", []))
+    for e in hooks["Stop"]
+)
+if not already_stop:
+    hooks["Stop"].append(stop_entry)
+    print("Hook hinzugefügt: Stop → stop_hook.py")
+else:
+    print("Hook bereits vorhanden: Stop")
 
 with open(settings_path, "w") as f:
     json.dump(cfg, f, indent=2)

--- a/claude-plugin/install.sh
+++ b/claude-plugin/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+TOOLS_DIR="$(dirname "$PLUGIN_DIR")/tools"
 
 # Plugin-Dateien
 DEST="$HOME/.claude/plugins/mayring-coder"
@@ -26,7 +27,7 @@ fi
 # Hooks in ~/.claude/settings.json eintragen (UserPromptSubmit + PostCompact)
 SETTINGS="$HOME/.claude/settings.json"
 HOOK_SCRIPT="$DEST/hooks/start_watcher.py"
-COMPACT_SCRIPT="$HOME/Desktop/MayringCoder/tools/postcompact_hook.py"
+COMPACT_SCRIPT="$TOOLS_DIR/postcompact_hook.py"
 STOP_SCRIPT="$DEST/hooks/stop_hook.py"
 
 python3 - <<PYEOF
@@ -91,7 +92,7 @@ else:
     print("Hook bereits vorhanden: Stop")
 
 # UserPromptSubmit — memory_sync background hook
-SYNC_SCRIPT = "/home/nileneb/Desktop/MayringCoder/tools/memory_sync.py"
+SYNC_SCRIPT = "$TOOLS_DIR/memory_sync.py"
 sync_hook = {"type": "command", "command": f"python3 {SYNC_SCRIPT}"}
 sync_entry = {"matcher": "", "hooks": [sync_hook]}
 already_sync = any(
@@ -112,7 +113,7 @@ PYEOF
 
 # Auth-Token einrichten via OAuth PKCE (vollautomatisch, kein Copy-Paste)
 HOOK_JWT="$HOME/.config/mayring/hook.jwt"
-OAUTH_SCRIPT="$HOME/Desktop/MayringCoder/tools/oauth_install.py"
+OAUTH_SCRIPT="$TOOLS_DIR/oauth_install.py"
 echo ""
 if [ -f "$HOOK_JWT" ] && [ -s "$HOOK_JWT" ]; then
     echo "Token bereits vorhanden: $HOOK_JWT"

--- a/claude-plugin/install.sh
+++ b/claude-plugin/install.sh
@@ -95,29 +95,15 @@ with open(settings_path, "w") as f:
     f.write("\n")
 PYEOF
 
-# Auth-Token einrichten (von app.linn.games, NICHT MCP_SERVICE_TOKEN)
+# Auth-Token einrichten via OAuth PKCE (vollautomatisch, kein Copy-Paste)
 HOOK_JWT="$HOME/.config/mayring/hook.jwt"
+OAUTH_SCRIPT="$HOME/Desktop/MayringCoder/tools/oauth_install.py"
 echo ""
 if [ -f "$HOOK_JWT" ] && [ -s "$HOOK_JWT" ]; then
     echo "Token bereits vorhanden: $HOOK_JWT"
 else
-    echo "=== Mayring JWT einrichten ==="
-    echo "1. Öffne: https://app.linn.games/mayring/watcher"
-    xdg-open "https://app.linn.games/mayring/watcher" 2>/dev/null || \
-        open "https://app.linn.games/mayring/watcher" 2>/dev/null || true
-    echo "2. Melde dich an und kopiere deinen JWT."
-    echo ""
-    read -rsp "JWT hier einfügen (unsichtbar): " JWT_INPUT
-    echo
-    if [ -n "$JWT_INPUT" ]; then
-        mkdir -p "$(dirname "$HOOK_JWT")"
-        printf '%s' "$JWT_INPUT" > "$HOOK_JWT"
-        chmod 600 "$HOOK_JWT"
-        echo "Token gespeichert: $HOOK_JWT"
-    else
-        echo "Kein Token eingegeben — später eintragen:"
-        echo "  printf '%s' '<JWT>' > ~/.config/mayring/hook.jwt && chmod 600 ~/.config/mayring/hook.jwt"
-    fi
+    echo "=== Mayring JWT einrichten (OAuth-Login) ==="
+    python3 "$OAUTH_SCRIPT" --jwt-file "$HOOK_JWT"
 fi
 echo ""
-echo "Watcher-Log: ~/.cache/mayryngcoder/watcher.log"
+echo "Watcher-Log: ~/.cache/mayringcoder/watcher.log"

--- a/claude-plugin/install.sh
+++ b/claude-plugin/install.sh
@@ -90,6 +90,21 @@ if not already_stop:
 else:
     print("Hook bereits vorhanden: Stop")
 
+# UserPromptSubmit — memory_sync background hook
+SYNC_SCRIPT = "/home/nileneb/Desktop/MayringCoder/tools/memory_sync.py"
+sync_hook = {"type": "command", "command": f"python3 {SYNC_SCRIPT}"}
+sync_entry = {"matcher": "", "hooks": [sync_hook]}
+already_sync = any(
+    any(h.get("command", "").endswith("memory_sync.py")
+        for h in e.get("hooks", []))
+    for e in hooks["UserPromptSubmit"]
+)
+if not already_sync:
+    hooks["UserPromptSubmit"].append(sync_entry)
+    print("Hook hinzugefügt: UserPromptSubmit → memory_sync.py")
+else:
+    print("Hook bereits vorhanden: memory_sync.py")
+
 with open(settings_path, "w") as f:
     json.dump(cfg, f, indent=2)
     f.write("\n")

--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -4,6 +4,9 @@ Used by both server.py and mcp.py to avoid code duplication.
 """
 
 from __future__ import annotations
+
+import os
+from pathlib import Path
 from typing import Any
 
 from src.memory.db_adapter import DBAdapter
@@ -19,7 +22,13 @@ def get_conn() -> DBAdapter:
     """Return the shared SQLite memory DB connection (lazy singleton)."""
     global _conn
     if _conn is None:
-        _conn = init_memory_db()
+        local_db = os.environ.get("MAYRING_LOCAL_DB", "")
+        if local_db:
+            from src.memory.store import _init_schema
+            _conn = DBAdapter.create(local_db)
+            _init_schema(_conn)
+        else:
+            _conn = init_memory_db()
     return _conn
 
 
@@ -27,5 +36,10 @@ def get_chroma() -> Any:
     """Return the shared ChromaDB 'memory_chunks' collection (lazy singleton)."""
     global _chroma
     if _chroma is None:
-        _chroma = get_or_create_chroma_collection()
+        chroma_dir_override = os.environ.get("MAYRING_LOCAL_CHROMA", "")
+        if chroma_dir_override:
+            from src.memory.store import get_chroma_collection
+            _chroma = get_chroma_collection("memory_chunks", path=Path(chroma_dir_override))
+        else:
+            _chroma = get_or_create_chroma_collection()
     return _chroma

--- a/src/api/routes/sync.py
+++ b/src/api/routes/sync.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+
+from src.api.auth import get_workspace
+from src.api.dependencies import get_chroma as _get_chroma, get_conn as _get_conn
+
+router = APIRouter(prefix="/memory", tags=["sync"])
+
+
+class ChunkSyncItem(BaseModel):
+    chunk_id: str
+    source_id: str
+    text: str
+    workspace_id: str
+    created_at: str
+    is_active: bool
+    text_hash: str | None
+    dedup_key: str | None
+    embedding: list[float] | None
+
+
+class MemorySyncResponse(BaseModel):
+    cursor: str
+    chunks: list[ChunkSyncItem]
+
+
+@router.get("/changes", response_model=MemorySyncResponse)
+def get_changes(
+    since: str = Query(..., description="ISO 8601 cursor — only chunks created after this"),
+    workspace_id: str = Query(...),
+    limit: int = Query(500, le=2000),
+    _ws: str = Depends(get_workspace),
+) -> MemorySyncResponse:
+    db = _get_conn()
+    rows = db.execute(
+        """
+        SELECT c.chunk_id, c.source_id, c.text, c.workspace_id,
+               c.created_at, c.is_active, c.text_hash, c.dedup_key
+        FROM chunks c
+        JOIN sources s ON c.source_id = s.source_id
+        WHERE c.created_at > ?
+          AND (s.visibility = 'public'
+               OR (s.visibility = 'private' AND c.workspace_id = ?))
+        ORDER BY c.created_at ASC
+        LIMIT ?
+        """,
+        (since, workspace_id, limit),
+    ).fetchall()
+
+    if not rows:
+        return MemorySyncResponse(cursor=since, chunks=[])
+
+    chunk_ids = [r[0] for r in rows]
+    embedding_map: dict[str, list[float] | None] = {cid: None for cid in chunk_ids}
+    try:
+        col = _get_chroma()
+        result = col.get(ids=chunk_ids, include=["embeddings"])
+        for cid, emb in zip(result["ids"], result["embeddings"]):
+            if emb is not None:
+                embedding_map[cid] = list(emb)
+    except Exception:
+        pass
+
+    items = [
+        ChunkSyncItem(
+            chunk_id=r[0],
+            source_id=r[1],
+            text=r[2],
+            workspace_id=r[3],
+            created_at=r[4],
+            is_active=bool(r[5]),
+            text_hash=r[6],
+            dedup_key=r[7],
+            embedding=embedding_map.get(r[0]),
+        )
+        for r in rows
+    ]
+    new_cursor = items[-1].created_at if items else since
+    return MemorySyncResponse(cursor=new_cursor, chunks=items)

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -37,6 +37,7 @@ except ImportError:
 from src.api.dependencies import get_conn as _get_conn
 from src.api.training import router as _training_router
 from src.api.routes import memory, wiki, jobs, duel, reports
+from src.api.routes.sync import router as _sync_router
 from src.api.job_queue import _JOBS, run_checker_job as _run_checker_job
 
 app = FastAPI(title="MayringCoder API", version="1.0.0")
@@ -54,6 +55,7 @@ app.include_router(wiki.router)
 app.include_router(jobs.router)
 app.include_router(duel.router)
 app.include_router(reports.router)
+app.include_router(_sync_router)
 
 
 @app.get("/health")

--- a/tests/test_feedback_loop.py
+++ b/tests/test_feedback_loop.py
@@ -1,0 +1,138 @@
+"""Tests for the Memory Feedback Loop — positive/negative feedback changes retrieval ranking."""
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from src.memory.db_adapter import DBAdapter
+from src.memory.schema import Chunk, Source
+from src.memory.store import _init_schema, add_feedback, get_feedback_score, insert_chunk, upsert_source
+
+
+def _db() -> DBAdapter:
+    db = DBAdapter.memory()
+    _init_schema(db)
+    return db
+
+
+def _make_chunk(chunk_id: str, source_id: str, text: str, db: DBAdapter) -> Chunk:
+    src = Source(source_id=source_id, source_type="note", repo="r", path="p")
+    upsert_source(db, src, workspace_id="ws")
+    now = datetime.datetime.utcnow().isoformat()
+    chunk = Chunk(
+        chunk_id=chunk_id, source_id=source_id, text=text,
+        text_hash=f"h-{chunk_id}", dedup_key=f"d-{chunk_id}",
+        created_at=now, workspace_id="ws",
+    )
+    insert_chunk(db, chunk)
+    return chunk
+
+
+# ---------------------------------------------------------------------------
+# get_feedback_score
+# ---------------------------------------------------------------------------
+
+def test_feedback_score_defaults_to_neutral():
+    db = _db()
+    assert get_feedback_score(db, "nonexistent") == 0.5
+
+
+def test_feedback_score_all_positive():
+    db = _db()
+    _make_chunk("chk1", "src1", "text", db)
+    for _ in range(5):
+        add_feedback(db, "chk1", "positive")
+    assert get_feedback_score(db, "chk1") == 1.0
+
+
+def test_feedback_score_all_negative():
+    db = _db()
+    _make_chunk("chk2", "src2", "text", db)
+    for _ in range(3):
+        add_feedback(db, "chk2", "negative")
+    assert get_feedback_score(db, "chk2") == 0.0
+
+
+def test_feedback_score_mixed():
+    db = _db()
+    _make_chunk("chk3", "src3", "text", db)
+    add_feedback(db, "chk3", "positive")
+    add_feedback(db, "chk3", "negative")
+    score = get_feedback_score(db, "chk3")
+    assert score == 0.5
+
+
+# ---------------------------------------------------------------------------
+# _rerank: positive feedback → higher score_final
+# ---------------------------------------------------------------------------
+
+def test_positive_feedback_boosts_ranking():
+    """Chunk with 5x positive feedback must outrank identical chunk with no feedback."""
+    from src.memory.retrieval import _rerank
+
+    db = _db()
+    chunk_fb = _make_chunk("chk-fb", "src-fb", "authentication flow context", db)
+    chunk_nofb = _make_chunk("chk-nofb", "src-nofb", "authentication flow context", db)
+
+    for _ in range(5):
+        add_feedback(db, "chk-fb", "positive")
+
+    # Equal vector + symbolic scores — only feedback should differ
+    vector_scores = {"chk-fb": 0.6, "chk-nofb": 0.6}
+    symbolic_scores = {"chk-fb": 0.4, "chk-nofb": 0.4}
+
+    ranked = _rerank(
+        [chunk_fb, chunk_nofb],
+        vector_scores, symbolic_scores,
+        top_k=2, conn=db,
+    )
+
+    assert ranked[0].chunk_id == "chk-fb", "positively-rated chunk must rank first"
+    assert ranked[0].score_final > ranked[1].score_final
+
+
+def test_negative_feedback_lowers_ranking():
+    """Chunk with 5x negative feedback must rank below chunk with no feedback."""
+    from src.memory.retrieval import _rerank
+
+    db = _db()
+    chunk_neg = _make_chunk("chk-neg", "src-neg", "some context", db)
+    chunk_clean = _make_chunk("chk-clean", "src-clean", "some context", db)
+
+    for _ in range(5):
+        add_feedback(db, "chk-neg", "negative")
+
+    vector_scores = {"chk-neg": 0.6, "chk-clean": 0.6}
+    symbolic_scores = {"chk-neg": 0.4, "chk-clean": 0.4}
+
+    ranked = _rerank(
+        [chunk_neg, chunk_clean],
+        vector_scores, symbolic_scores,
+        top_k=2, conn=db,
+    )
+
+    assert ranked[0].chunk_id == "chk-clean", "negatively-rated chunk must rank last"
+    assert ranked[0].score_final > ranked[1].score_final
+
+
+def test_neutral_feedback_has_no_effect():
+    """Neutral-marked chunk ranks the same as chunk with no feedback."""
+    from src.memory.retrieval import _rerank
+
+    db = _db()
+    chunk_neutral = _make_chunk("chk-neutral", "src-neutral", "text", db)
+    chunk_none = _make_chunk("chk-none", "src-none", "text", db)
+
+    add_feedback(db, "chk-neutral", "neutral")
+
+    vector_scores = {"chk-neutral": 0.5, "chk-none": 0.5}
+    symbolic_scores = {"chk-neutral": 0.3, "chk-none": 0.3}
+
+    ranked = _rerank(
+        [chunk_neutral, chunk_none],
+        vector_scores, symbolic_scores,
+        top_k=2, conn=db,
+    )
+
+    assert abs(ranked[0].score_final - ranked[1].score_final) < 0.01

--- a/tests/test_memory_sync_endpoint.py
+++ b/tests/test_memory_sync_endpoint.py
@@ -1,0 +1,90 @@
+"""Tests for GET /memory/changes — chunk export with embeddings."""
+from __future__ import annotations
+
+import datetime
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.server import app
+from src.api.auth import get_workspace
+import src.api.dependencies as _deps
+
+
+@pytest.fixture(autouse=True)
+def _override_workspace():
+    prev = app.dependency_overrides.get(get_workspace)
+    app.dependency_overrides[get_workspace] = lambda: "ws-test"
+    yield
+    if prev is None:
+        app.dependency_overrides.pop(get_workspace, None)
+    else:
+        app.dependency_overrides[get_workspace] = prev
+
+
+@pytest.fixture(autouse=True)
+def _reset_conn(tmp_path, monkeypatch):
+    from src.memory.db_adapter import DBAdapter
+    from src.memory.store import _init_schema
+    adapter = DBAdapter.create(tmp_path / "test.db", check_same_thread=False)
+    _init_schema(adapter)
+    monkeypatch.setattr(_deps, "_conn", adapter)
+    yield adapter
+    monkeypatch.setattr(_deps, "_conn", None)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _seed_chunk(conn, chunk_id: str, source_id: str, workspace_id: str,
+                visibility: str = "private", created_at: str | None = None,
+                is_active: int = 1) -> None:
+    from src.memory.store import upsert_source, insert_chunk
+    from src.memory.schema import Source, Chunk
+    upsert_source(conn, Source(source_id=source_id, source_type="note", repo="r", path="p"),
+                  workspace_id=workspace_id, visibility=visibility)
+    conn.execute(
+        """INSERT OR IGNORE INTO chunks
+           (chunk_id, source_id, text, workspace_id, created_at, is_active, text_hash, dedup_key)
+           VALUES (?,?,?,?,?,?,?,?)""",
+        (chunk_id, source_id, "test text", workspace_id,
+         created_at or datetime.datetime.utcnow().isoformat(), is_active, "h", "d"),
+    )
+    conn.commit()
+
+
+def test_changes_returns_chunks_since_cursor(client, _reset_conn):
+    _seed_chunk(_reset_conn, "chk1", "src1", "ws-test", created_at="2026-01-01T00:00:00")
+    resp = client.get("/memory/changes",
+                      params={"since": "2000-01-01T00:00:00", "workspace_id": "ws-test"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "cursor" in data
+    assert len(data["chunks"]) == 1
+    assert data["chunks"][0]["chunk_id"] == "chk1"
+
+
+def test_changes_embedding_key_present(client, _reset_conn):
+    _seed_chunk(_reset_conn, "chk2", "src2", "ws-test", created_at="2026-01-01T00:00:01")
+    resp = client.get("/memory/changes",
+                      params={"since": "2000-01-01T00:00:00", "workspace_id": "ws-test"})
+    for chunk in resp.json()["chunks"]:
+        assert "embedding" in chunk
+        assert chunk["embedding"] is None or isinstance(chunk["embedding"], list)
+
+
+def test_changes_respects_cursor(client, _reset_conn):
+    _seed_chunk(_reset_conn, "chk3", "src3", "ws-test", created_at="2020-01-01T00:00:00")
+    resp = client.get("/memory/changes",
+                      params={"since": "2099-01-01T00:00:00", "workspace_id": "ws-test"})
+    assert resp.json()["chunks"] == []
+
+
+def test_changes_includes_inactive_chunks(client, _reset_conn):
+    _seed_chunk(_reset_conn, "chk4", "src4", "ws-test",
+                created_at="2026-01-01T00:00:02", is_active=0)
+    resp = client.get("/memory/changes",
+                      params={"since": "2000-01-01T00:00:00", "workspace_id": "ws-test"})
+    chunks = resp.json()["chunks"]
+    assert any(not c["is_active"] for c in chunks)

--- a/tools/memory_sync.py
+++ b/tools/memory_sync.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Sync cloud memory to local SQLite + Chroma.
+
+Usage:
+    python3 tools/memory_sync.py [--workspace-id WS] [--db PATH] [--chroma PATH]
+    python3 tools/memory_sync.py --status
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+_API_URL = os.environ.get("MAYRING_API_URL", "https://mcp.linn.games").rstrip("/")
+_JWT_FILE = os.path.expanduser("~/.config/mayring/hook.jwt")
+_DEFAULT_DB = os.path.expanduser("~/.cache/mayringcoder/memory.db")
+_DEFAULT_CHROMA = os.path.expanduser("~/.cache/mayringcoder/chroma")
+_DEFAULT_WS = os.environ.get("MAYRING_WORKSPACE_ID", "default")
+_OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://three.linn.games")
+_EMBED_MODEL = "nomic-embed-text"
+_BATCH_SIZE = 200
+_TIMEOUT = 30
+
+
+def _read_token() -> str:
+    try:
+        return Path(_JWT_FILE).read_text().strip()
+    except FileNotFoundError:
+        return ""
+
+
+def _init_local_db(db_path: str) -> sqlite3.Connection:
+    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS chunks (
+            chunk_id TEXT PRIMARY KEY,
+            source_id TEXT NOT NULL,
+            text TEXT NOT NULL,
+            workspace_id TEXT NOT NULL DEFAULT 'default',
+            created_at TEXT NOT NULL,
+            is_active INTEGER NOT NULL DEFAULT 1,
+            text_hash TEXT,
+            dedup_key TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_chunks_created ON chunks(created_at);
+        CREATE TABLE IF NOT EXISTS sync_watermark (
+            workspace_id TEXT PRIMARY KEY,
+            cursor TEXT NOT NULL DEFAULT '2000-01-01T00:00:00'
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _get_cursor(conn: sqlite3.Connection, workspace_id: str) -> str:
+    row = conn.execute(
+        "SELECT cursor FROM sync_watermark WHERE workspace_id = ?", (workspace_id,)
+    ).fetchone()
+    return row["cursor"] if row else "2000-01-01T00:00:00"
+
+
+def _set_cursor(conn: sqlite3.Connection, workspace_id: str, cursor: str) -> None:
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_watermark(workspace_id, cursor) VALUES(?,?)",
+        (workspace_id, cursor),
+    )
+    conn.commit()
+
+
+def _fetch_changes(token: str, workspace_id: str, since: str) -> dict:
+    params = urllib.parse.urlencode({"since": since, "workspace_id": workspace_id})
+    req = urllib.request.Request(
+        f"{_API_URL}/memory/changes?{params}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    resp = urllib.request.urlopen(req, timeout=_TIMEOUT)
+    return json.loads(resp.read())
+
+
+def _local_embed(text: str) -> list[float] | None:
+    payload = json.dumps({"model": _EMBED_MODEL, "prompt": text}).encode()
+    req = urllib.request.Request(
+        f"{_OLLAMA_URL}/api/embeddings",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        resp = urllib.request.urlopen(req, timeout=20)
+        return json.loads(resp.read()).get("embedding")
+    except Exception:
+        return None
+
+
+def _upsert_chroma(chroma_path: str, chunks_with_embeddings: list[dict]) -> None:
+    try:
+        import chromadb  # type: ignore
+    except ImportError:
+        print("chromadb not installed — skipping Chroma sync", file=sys.stderr)
+        return
+
+    client = chromadb.PersistentClient(path=chroma_path)
+    col = client.get_or_create_collection("memory_chunks")
+
+    ids, embeddings, documents, metadatas = [], [], [], []
+    for c in chunks_with_embeddings:
+        if c["embedding"] is None:
+            continue
+        ids.append(c["chunk_id"])
+        embeddings.append(c["embedding"])
+        documents.append(c["text"])
+        metadatas.append({
+            "workspace_id": c["workspace_id"],
+            "source_id": c["source_id"],
+            "is_active": int(c["is_active"]),
+        })
+
+    if ids:
+        col.upsert(ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas)
+
+    inactive = [c["chunk_id"] for c in chunks_with_embeddings if not c["is_active"]]
+    if inactive:
+        existing = col.get(ids=inactive, include=["metadatas"])
+        for cid, meta in zip(existing["ids"], existing["metadatas"]):
+            meta["is_active"] = 0
+            col.update(ids=[cid], metadatas=[meta])
+
+
+def _upsert_sqlite(conn: sqlite3.Connection, chunks: list[dict]) -> None:
+    conn.executemany(
+        """
+        INSERT OR REPLACE INTO chunks
+            (chunk_id, source_id, text, workspace_id, created_at, is_active, text_hash, dedup_key)
+        VALUES (?,?,?,?,?,?,?,?)
+        """,
+        [
+            (
+                c["chunk_id"], c["source_id"], c["text"], c["workspace_id"],
+                c["created_at"], int(c["is_active"]), c.get("text_hash"), c.get("dedup_key"),
+            )
+            for c in chunks
+        ],
+    )
+    conn.commit()
+
+
+def sync(workspace_id: str, db_path: str, chroma_path: str) -> int:
+    token = _read_token()
+    if not token:
+        print("No JWT found at", _JWT_FILE, file=sys.stderr)
+        return 1
+
+    conn = _init_local_db(db_path)
+    cursor = _get_cursor(conn, workspace_id)
+
+    total = 0
+    while True:
+        try:
+            data = _fetch_changes(token, workspace_id, cursor)
+        except Exception as e:
+            print(f"Fetch error: {e}", file=sys.stderr)
+            return 1
+
+        chunks = data.get("chunks", [])
+        if not chunks:
+            break
+
+        for c in chunks:
+            if c["embedding"] is None and c["is_active"]:
+                c["embedding"] = _local_embed(c["text"])
+
+        _upsert_sqlite(conn, chunks)
+        _upsert_chroma(chroma_path, chunks)
+
+        new_cursor = data.get("cursor", cursor)
+        _set_cursor(conn, workspace_id, new_cursor)
+        total += len(chunks)
+        cursor = new_cursor
+
+        if len(chunks) < _BATCH_SIZE:
+            break
+
+    print(f"Synced {total} chunks (cursor: {cursor})")
+    return 0
+
+
+def status(workspace_id: str, db_path: str) -> None:
+    if not Path(db_path).exists():
+        print("No local DB found at", db_path)
+        return
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cursor_row = conn.execute(
+        "SELECT cursor FROM sync_watermark WHERE workspace_id = ?", (workspace_id,)
+    ).fetchone()
+    count = conn.execute(
+        "SELECT COUNT(*) FROM chunks WHERE workspace_id = ? AND is_active = 1", (workspace_id,)
+    ).fetchone()[0]
+    print(f"Workspace: {workspace_id}")
+    print(f"Cursor:    {cursor_row['cursor'] if cursor_row else 'never synced'}")
+    print(f"Chunks:    {count}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="MayringCoder memory sync")
+    parser.add_argument("--workspace-id", default=_DEFAULT_WS)
+    parser.add_argument("--db", default=_DEFAULT_DB)
+    parser.add_argument("--chroma", default=_DEFAULT_CHROMA)
+    parser.add_argument("--status", action="store_true")
+    args = parser.parse_args()
+
+    if args.status:
+        status(args.workspace_id, args.db)
+        return
+
+    sys.exit(sync(args.workspace_id, args.db, args.chroma))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/oauth_install.py
+++ b/tools/oauth_install.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""PKCE OAuth flow für MayringCoder Hook-Token-Setup.
+
+Browser öffnet → User loggt sich auf app.linn.games ein → Token wird
+automatisch gespeichert. Kein manuelles Copy-Paste nötig.
+
+Usage:
+    python3 tools/oauth_install.py
+    python3 tools/oauth_install.py --jwt-file /custom/path/hook.jwt
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import http.server
+import json
+import os
+import secrets
+import sys
+import threading
+import urllib.parse
+import urllib.request
+import webbrowser
+
+_MCP_URL = os.environ.get("MCP_OAUTH_BASE_URL", "https://mcp.linn.games").rstrip("/")
+_DEFAULT_JWT_FILE = os.path.expanduser("~/.config/mayring/hook.jwt")
+_CLIENT_ID = "mayring-hook-cli"
+_REDIRECT_PORT = 9876
+_REDIRECT_URI = f"http://localhost:{_REDIRECT_PORT}/callback"
+_TIMEOUT_SECONDS = 120
+
+
+def _pkce() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(48)
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def _save_token(token: str, jwt_file: str) -> None:
+    os.makedirs(os.path.dirname(jwt_file), exist_ok=True)
+    with open(jwt_file, "w") as f:
+        f.write(token)
+    os.chmod(jwt_file, 0o600)
+
+
+def _exchange_code(code: str, verifier: str) -> str:
+    payload = urllib.parse.urlencode({
+        "grant_type":   "authorization_code",
+        "code":         code,
+        "redirect_uri": _REDIRECT_URI,
+        "client_id":    _CLIENT_ID,
+        "code_verifier": verifier,
+    }).encode()
+    req = urllib.request.Request(
+        f"{_MCP_URL}/token",
+        data=payload,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    resp = urllib.request.urlopen(req, timeout=15)
+    data = json.loads(resp.read())
+    token = data.get("access_token", "")
+    if not token:
+        raise ValueError(f"Kein access_token in Server-Antwort: {data}")
+    return token
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="MayringCoder OAuth-Setup")
+    parser.add_argument("--jwt-file", default=_DEFAULT_JWT_FILE)
+    args = parser.parse_args()
+
+    verifier, challenge = _pkce()
+    state = secrets.token_urlsafe(16)
+    callback_result: dict = {}
+    server_done = threading.Event()
+
+    class CallbackHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            if not self.path.startswith("/callback"):
+                self.send_response(404)
+                self.end_headers()
+                return
+            parsed = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+            callback_result["code"]  = parsed.get("code",  [None])[0]
+            callback_result["state"] = parsed.get("state", [None])[0]
+            callback_result["error"] = parsed.get("error", [None])[0]
+            ok = bool(callback_result.get("code"))
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            if ok:
+                self.wfile.write(
+                    b"<h2>\xe2\x9c\x85 Login erfolgreich!</h2>"
+                    b"<p>Du kannst dieses Fenster schlie\xc3\x9fen.</p>"
+                )
+            else:
+                err = str(callback_result.get("error", "unbekannt")).encode()
+                self.wfile.write(b"<h2>\xe2\x9d\x8c Fehler beim Login</h2><p>" + err + b"</p>")
+            server_done.set()
+
+        def log_message(self, *_):
+            pass
+
+    try:
+        httpd = http.server.HTTPServer(("localhost", _REDIRECT_PORT), CallbackHandler)
+    except OSError:
+        print(f"Port {_REDIRECT_PORT} belegt — beende laufenden Prozess und versuche es erneut.")
+        sys.exit(1)
+
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    auth_url = f"{_MCP_URL}/authorize?" + urllib.parse.urlencode({
+        "response_type":         "code",
+        "client_id":             _CLIENT_ID,
+        "redirect_uri":          _REDIRECT_URI,
+        "scope":                 "mcp:memory",
+        "state":                 state,
+        "code_challenge":        challenge,
+        "code_challenge_method": "S256",
+    })
+
+    print("Browser wird geöffnet …")
+    webbrowser.open(auth_url)
+    print(f"Warte auf Login (max {_TIMEOUT_SECONDS}s) …")
+
+    if not server_done.wait(timeout=_TIMEOUT_SECONDS):
+        httpd.shutdown()
+        print("Timeout — kein Login empfangen. Starte das Script erneut.")
+        sys.exit(1)
+
+    httpd.shutdown()
+
+    if callback_result.get("error"):
+        print(f"OAuth-Fehler: {callback_result['error']}")
+        sys.exit(1)
+    if not callback_result.get("code"):
+        print("Kein Authorization-Code empfangen.")
+        sys.exit(1)
+    if callback_result.get("state") != state:
+        print("Sicherheitsfehler: State-Parameter stimmt nicht überein.")
+        sys.exit(1)
+
+    try:
+        token = _exchange_code(callback_result["code"], verifier)
+    except Exception as e:
+        print(f"Token-Austausch fehlgeschlagen: {e}")
+        sys.exit(1)
+
+    _save_token(token, args.jwt_file)
+    print(f"Token gespeichert: {args.jwt_file}")
+    print("Setup abgeschlossen.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **#67 DB-Adapter**: DBAdapter wrapper, type annotation sweep across memory/wiki/api
- **#86 Feedback Loop**: `chunk_feedback` table + `_rerank()` boost/penalty + Stop-hook für auto-neutral
- **#104 Shared Memory**: `visibility` (private/org/public) + `org_id` auf `sources`; tri-branch scope filter
- **#107 Memory Sync**: `GET /memory/changes` + `tools/memory_sync.py` — lokaler SQLite+Chroma Sync mit Embedding-Transfer
- **#108 Sourcery**: PRAGMA injection guard + subprocess path validation
- **OAuth PKCE**: `tools/oauth_install.py` ersetzt manuelles JWT Copy-Paste in install.sh
- **install.sh**: `TOOLS_DIR` aus `PLUGIN_DIR` abgeleitet — kein hardcoded Desktop-Pfad mehr
- **Pi-Agent**: `pi_server.py` HTTP-Proxy + Ollama fallback + qwen3.5:35b-a3b model routing

## Test plan
- [ ] `pytest tests/ -q` → 1067 passed, 7 pre-existing failures (TestIndexOverviewFunctionDocs)
- [ ] `python3 tools/memory_sync.py --status` → "No local DB found" auf frischem PC
- [ ] `bash claude-plugin/install.sh` von beliebigem Pfad → keine hardcoded-Pfad-Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce local memory sync pipeline, feedback-based ranking, and OAuth-based token setup for the MayringClaude plugin and API.

New Features:
- Add /memory/changes API endpoint to export memory chunks with optional embeddings for workspace-scoped synchronization.
- Add tools/memory_sync.py to sync cloud memory into a local SQLite and Chroma store with optional local embedding generation.
- Add a Stop hook script to automatically mark unrated injected memory chunks as neutral feedback after each Claude turn.
- Add OAuth PKCE CLI (tools/oauth_install.py) to obtain and store the hook JWT via browser-based login instead of manual copy-paste.

Enhancements:
- Allow overriding the shared SQLite and Chroma locations via MAYRING_LOCAL_DB and MAYRING_LOCAL_CHROMA environment variables for local setups.
- Extend the FastAPI server to register the new memory sync router.
- Improve Claude plugin install.sh to derive TOOLS_DIR dynamically, add Stop and memory_sync hooks, and handle missing or invalid settings.json gracefully.

Tests:
- Add tests for the memory feedback loop to verify that positive, negative, and neutral feedback influence retrieval ranking as intended.
- Add tests for the /memory/changes endpoint to validate cursor behavior, embedding presence, and inclusion of inactive chunks.