### PR TITLE
feat(wiki): Paper-Regelset + Post-Ingest-Rebuild (#53)

### DIFF
--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import threading as _threading
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -23,6 +24,21 @@ from src.api.routes.models import (
 router = APIRouter(tags=["memory"])
 
 _OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434")
+
+
+def _bg_wiki_rebuild(workspace_id: str) -> None:
+    try:
+        from src.wiki_v2.graph import WikiGraph
+        from src.wiki_v2.edge_detector import EdgeDetector
+        from src.wiki_v2.clustering import ClusterEngine
+        conn = _get_conn()
+        wiki_db = WikiGraph(workspace_id=workspace_id, repo_slug="")
+        edges = EdgeDetector().detect_from_overview({}, conn, workspace_id, "")
+        for e in edges:
+            wiki_db.add_edge(e)
+        ClusterEngine().cluster(wiki_db, strategy="louvain")
+    except Exception:
+        pass
 
 def _model(task: str = "mayring_code") -> str:
     from src.model_router import ModelRouter
@@ -86,6 +102,12 @@ async def memory_put(
         result = _run_ingest(source_dict, request.content, _get_conn(), _get_chroma(),
                              _OLLAMA_URL, _model("mayring_code"), {"categorize": request.categorize},
                              workspace_id)
+        if source_dict.get("source_type") == "paper":
+            _threading.Thread(
+                target=_bg_wiki_rebuild,
+                args=(workspace_id,),
+                daemon=True,
+            ).start()
         return {"workspace_id": workspace_id, **result}
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))

--- a/src/cli.py
+++ b/src/cli.py
@@ -99,7 +99,7 @@ def _cmd_generate_wiki(args: argparse.Namespace, repo_url: str, ollama_url: str,
         slug = _repo_slug_fn(repo_url) if repo_url else wid
         oc = load_overview_cache_raw(repo_url) or {} if repo_url else {}
         db = WikiGraph(wid, slug, CACHE_DIR / "wiki_v2.db")
-        detector = EdgeDetector()
+        detector = EdgeDetector(ollama_url=ollama_url, model=model)
         edges = detector.detect_from_overview(oc, get_conn(), wid, slug)
         node_ids = set(oc.keys()) | {e.source for e in edges} | {e.target for e in edges}
         for nid in sorted(node_ids):

--- a/src/memory/store.py
+++ b/src/memory/store.py
@@ -538,3 +538,26 @@ def log_llm_call(
          datetime.now(timezone.utc).isoformat()),
     )
     conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# wiki_paper_cache helpers
+# ---------------------------------------------------------------------------
+
+def get_paper_cache(conn: DBAdapter, source_id: str, rule_name: str) -> list | None:
+    row = conn.execute(
+        "SELECT extracted FROM wiki_paper_cache WHERE source_id = ? AND rule_name = ?",
+        (source_id, rule_name),
+    ).fetchone()
+    if row is None:
+        return None
+    return json.loads(row["extracted"])
+
+
+def set_paper_cache(conn: DBAdapter, source_id: str, rule_name: str, extracted: list) -> None:
+    conn.execute(
+        "INSERT OR REPLACE INTO wiki_paper_cache(source_id, rule_name, extracted, created_at)"
+        " VALUES (?, ?, ?, ?)",
+        (source_id, rule_name, json.dumps(extracted, ensure_ascii=False), _now_iso()),
+    )
+    conn.commit()

--- a/src/wiki_v2/edge_detector.py
+++ b/src/wiki_v2/edge_detector.py
@@ -50,6 +50,10 @@ def _cosine(a: list, b: list) -> float:
 class EdgeDetector:
     """Erkennt typisierte Edges zwischen Dateien für den Wiki-Graph."""
 
+    def __init__(self, ollama_url: str = "", model: str = "qwen2.5-coder:7b") -> None:
+        self._ollama_url = ollama_url
+        self._model = model
+
     def detect_from_overview(
         self,
         overview_cache: dict,
@@ -66,6 +70,25 @@ class EdgeDetector:
         if conn is not None:
             edges += self._detect_label_cooccurrence(conn, overview_cache, workspace_id, repo_slug)
         edges += self._detect_event_dispatch(overview_cache, workspace_id, repo_slug)
+        if conn is not None:
+            from src.wiki_v2.paper_rules import detect_from_papers
+            from src.memory.schema import Chunk
+            paper_rows = conn.fetchall(
+                """SELECT c.chunk_id, c.source_id, c.text, c.workspace_id, c.created_at,
+                          c.is_active, c.text_hash, c.dedup_key,
+                          c.category_labels, c.category_source, c.category_confidence
+                   FROM chunks c
+                   JOIN sources s ON c.source_id = s.source_id
+                   WHERE s.source_type = 'paper'
+                     AND c.workspace_id = ?
+                     AND c.is_active = 1""",
+                (workspace_id,),
+            )
+            if paper_rows:
+                paper_chunks = [Chunk.from_dict(dict(r)) for r in paper_rows]
+                edges += detect_from_papers(
+                    paper_chunks, conn, self._ollama_url, self._model, workspace_id, repo_slug
+                )
         return self._deduplicate(edges)
 
     def detect_test_coverage(

--- a/src/wiki_v2/paper_rules.py
+++ b/src/wiki_v2/paper_rules.py
@@ -1,0 +1,188 @@
+"""Paper-specific edge detection rules for wiki_v2.
+
+Rules 1 (citation) and 4 (keyword_cooccurrence) are LLM-free.
+Rules 2 (shared_concept), 3 (method_chain), 5 (dataset) use a mini-LLM
+prompt on compressed chunk text, cached in wiki_paper_cache.
+"""
+from __future__ import annotations
+
+import json
+import re
+import urllib.request
+from typing import Any
+
+from src.memory.schema import Chunk
+from src.wiki_v2.models import WikiEdge
+
+_DOI_RE = re.compile(r"10\.\d{4,}/\S+")
+_BRACKET_REF_RE = re.compile(r"\[(\w[\w\s,\.]+\d{4}[a-z]?)\]")
+_AUTHOR_YEAR_RE = re.compile(r"\(([A-Z][a-z]+(?:\s+et\s+al\.)?),?\s+\d{4}\)")
+
+_MINI_LLM_MAX_CHARS = 2000
+_TOP_CHUNKS = 8
+
+PAPER_EDGE_TYPES = ["citation", "shared_concept", "method_chain", "keyword_cooccurrence", "dataset_coupling"]
+
+
+def _compress_chunks(chunks: list[Chunk], char_budget: int = _MINI_LLM_MAX_CHARS) -> str:
+    return "\n\n".join(c.text for c in chunks[:_TOP_CHUNKS] if c.text)[:char_budget]
+
+
+def _call_ollama(text: str, instruction: str, ollama_url: str, model: str) -> list[str]:
+    prompt = (
+        f"Aufgabe: {instruction}\n\nText:\n{text}\n\n"
+        f"Antworte NUR mit einer JSON-Liste von Strings, z.B. [\"Begriff1\"]. Keine Erklärungen."
+    )
+    payload = json.dumps({"model": model, "prompt": prompt, "stream": False}).encode()
+    req = urllib.request.Request(
+        f"{ollama_url.rstrip('/')}/api/generate",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        resp = urllib.request.urlopen(req, timeout=30)
+        raw = json.loads(resp.read()).get("response", "[]")
+        m = re.search(r"\[.*?\]", raw, re.DOTALL)
+        if m:
+            return json.loads(m.group())
+    except Exception:
+        pass
+    return []
+
+
+def _chunks_by_source(chunks: list[Chunk]) -> dict[str, list[Chunk]]:
+    out: dict[str, list[Chunk]] = {}
+    for c in chunks:
+        out.setdefault(c.source_id, []).append(c)
+    return out
+
+
+def detect_citations(chunks: list[Chunk], workspace_id: str, repo_slug: str) -> list[WikiEdge]:
+    by_source = _chunks_by_source(chunks)
+    refs: dict[str, set[str]] = {}
+    for sid, sc in by_source.items():
+        combined = " ".join(c.text for c in sc)
+        found: set[str] = set()
+        for m in _DOI_RE.finditer(combined):
+            found.add(m.group().lower())
+        for m in _BRACKET_REF_RE.finditer(combined):
+            found.add(m.group(1).lower().strip())
+        for m in _AUTHOR_YEAR_RE.finditer(combined):
+            found.add(m.group(1).lower().strip())
+        refs[sid] = found
+
+    source_ids = list(by_source)
+    edges: list[WikiEdge] = []
+    for i, sid_a in enumerate(source_ids):
+        for sid_b in source_ids[i + 1:]:
+            overlap = refs.get(sid_a, set()) & refs.get(sid_b, set())
+            if overlap:
+                edges.append(WikiEdge(
+                    source=sid_a, target=sid_b, repo_slug=repo_slug, workspace_id=workspace_id,
+                    type="citation", weight=1.0, context=", ".join(sorted(overlap)[:3]),
+                ))
+    return edges
+
+
+def detect_keyword_overlap(
+    chunks: list[Chunk], workspace_id: str, repo_slug: str, min_shared: int = 1,
+) -> list[WikiEdge]:
+    by_source = _chunks_by_source(chunks)
+    source_ids = list(by_source)
+    labels: dict[str, set[str]] = {
+        sid: {lbl.strip() for c in sc for lbl in (c.category_labels or []) if lbl.strip()}
+        for sid, sc in by_source.items()
+    }
+    edges: list[WikiEdge] = []
+    for i, sid_a in enumerate(source_ids):
+        for sid_b in source_ids[i + 1:]:
+            shared = labels.get(sid_a, set()) & labels.get(sid_b, set())
+            if len(shared) >= min_shared:
+                edges.append(WikiEdge(
+                    source=sid_a, target=sid_b, repo_slug=repo_slug, workspace_id=workspace_id,
+                    type="keyword_cooccurrence", weight=0.5, context=", ".join(sorted(shared)[:5]),
+                ))
+    return edges
+
+
+def _llm_pair_edges(
+    chunks: list[Chunk], conn: Any, ollama_url: str, model: str,
+    workspace_id: str, repo_slug: str,
+    rule_name: str, instruction: str, edge_type: str, weight: float,
+) -> list[WikiEdge]:
+    from src.memory.store import get_paper_cache, set_paper_cache
+    by_source = _chunks_by_source(chunks)
+    per_source: dict[str, set[str]] = {}
+    for sid, sc in by_source.items():
+        cached = get_paper_cache(conn, sid, rule_name)
+        if cached is not None:
+            per_source[sid] = set(cached)
+            continue
+        extracted = _call_ollama(_compress_chunks(sc), instruction, ollama_url, model)
+        set_paper_cache(conn, sid, rule_name, extracted)
+        per_source[sid] = set(extracted)
+
+    source_ids = list(by_source)
+    edges: list[WikiEdge] = []
+    for i, sid_a in enumerate(source_ids):
+        for sid_b in source_ids[i + 1:]:
+            shared = per_source.get(sid_a, set()) & per_source.get(sid_b, set())
+            if shared:
+                edges.append(WikiEdge(
+                    source=sid_a, target=sid_b, repo_slug=repo_slug, workspace_id=workspace_id,
+                    type=edge_type, weight=weight, context=", ".join(sorted(shared)[:5]),
+                ))
+    return edges
+
+
+def detect_shared_concepts(chunks, conn, ollama_url, model, workspace_id, repo_slug):
+    return _llm_pair_edges(
+        chunks, conn, ollama_url, model, workspace_id, repo_slug,
+        "shared_concept",
+        "Liste die domänenspezifischen Fachbegriffe aus diesem Text",
+        "shared_concept", 0.8,
+    )
+
+
+def detect_method_chains(chunks, conn, ollama_url, model, workspace_id, repo_slug):
+    return _llm_pair_edges(
+        chunks, conn, ollama_url, model, workspace_id, repo_slug,
+        "method_chain",
+        "Welche externen Methoden, Frameworks oder Ansätze werden hier referenziert oder genutzt?",
+        "method_chain", 0.7,
+    )
+
+
+def detect_dataset_pairs(chunks, conn, ollama_url, model, workspace_id, repo_slug):
+    return _llm_pair_edges(
+        chunks, conn, ollama_url, model, workspace_id, repo_slug,
+        "dataset",
+        "Welche konkreten Datensätze, Corpora oder empirischen Datenquellen werden genannt?",
+        "dataset_coupling", 0.6,
+    )
+
+
+def detect_from_papers(
+    chunks: list[Chunk],
+    conn: Any | None,
+    ollama_url: str,
+    model: str,
+    workspace_id: str,
+    repo_slug: str,
+) -> list[WikiEdge]:
+    if not chunks:
+        return []
+    edges: list[WikiEdge] = []
+    edges += detect_citations(chunks, workspace_id, repo_slug)
+    edges += detect_keyword_overlap(chunks, workspace_id, repo_slug)
+    if conn is not None and ollama_url:
+        edges += detect_shared_concepts(chunks, conn, ollama_url, model, workspace_id, repo_slug)
+        edges += detect_method_chains(chunks, conn, ollama_url, model, workspace_id, repo_slug)
+        edges += detect_dataset_pairs(chunks, conn, ollama_url, model, workspace_id, repo_slug)
+    seen: dict[tuple, WikiEdge] = {}
+    for e in edges:
+        key = (min(e.source, e.target), max(e.source, e.target), e.type, e.workspace_id)
+        if key not in seen or e.weight > seen[key].weight:
+            seen[key] = e
+    return list(seen.values())

--- a/tests/test_wiki_paper_rules.py
+++ b/tests/test_wiki_paper_rules.py
@@ -1,0 +1,26 @@
+"""Tests for wiki paper rules and cache helpers."""
+from src.memory.db_adapter import DBAdapter
+from src.memory.store import _init_schema, get_paper_cache, set_paper_cache
+
+
+def _db():
+    db = DBAdapter.memory()
+    _init_schema(db)
+    return db
+
+
+def test_paper_cache_miss_returns_none():
+    assert get_paper_cache(_db(), "src1", "shared_concept") is None
+
+
+def test_paper_cache_roundtrip():
+    db = _db()
+    set_paper_cache(db, "src1", "shared_concept", ["Mayring", "Inhaltsanalyse"])
+    assert get_paper_cache(db, "src1", "shared_concept") == ["Mayring", "Inhaltsanalyse"]
+
+
+def test_paper_cache_overwrite():
+    db = _db()
+    set_paper_cache(db, "src1", "shared_concept", ["A"])
+    set_paper_cache(db, "src1", "shared_concept", ["B", "C"])
+    assert get_paper_cache(db, "src1", "shared_concept") == ["B", "C"]

--- a/tests/test_wiki_paper_rules.py
+++ b/tests/test_wiki_paper_rules.py
@@ -1,5 +1,6 @@
 """Tests for wiki paper rules and cache helpers."""
 from src.memory.db_adapter import DBAdapter
+from src.memory.schema import Chunk
 from src.memory.store import _init_schema, get_paper_cache, set_paper_cache
 
 
@@ -24,3 +25,51 @@ def test_paper_cache_overwrite():
     set_paper_cache(db, "src1", "shared_concept", ["A"])
     set_paper_cache(db, "src1", "shared_concept", ["B", "C"])
     assert get_paper_cache(db, "src1", "shared_concept") == ["B", "C"]
+
+
+from src.wiki_v2.paper_rules import detect_citations, detect_keyword_overlap
+
+
+def _chunk(chunk_id, source_id, text, workspace_id="ws"):
+    c = Chunk(chunk_id=chunk_id, source_id=source_id, text=text,
+              text_hash="h", dedup_key="d", created_at="2026-01-01", workspace_id=workspace_id)
+    return c
+
+
+def test_citation_two_papers_sharing_author_year():
+    c1 = _chunk("c1", "paper_a", "As shown in [Mayring 2000] this method")
+    c2 = _chunk("c2", "paper_b", "[Mayring 2000] qualitative content analysis")
+    edges = detect_citations([c1, c2], workspace_id="ws", repo_slug="r")
+    assert any(e.type == "citation" for e in edges)
+    assert any(e.source in ("paper_a", "paper_b") for e in edges)
+
+
+def test_keyword_overlap_finds_shared_labels():
+    c1 = _chunk("c1", "paper_a", "text")
+    c1.category_labels = ["qualitative_analysis", "coding"]
+    c2 = _chunk("c2", "paper_b", "text2")
+    c2.category_labels = ["qualitative_analysis", "grounded_theory"]
+    edges = detect_keyword_overlap([c1, c2], workspace_id="ws", repo_slug="r")
+    assert any(e.type == "keyword_cooccurrence" for e in edges)
+    assert any(e.source == "paper_a" and e.target == "paper_b" for e in edges)
+
+
+def test_keyword_overlap_weight_is_0_5():
+    c1 = _chunk("c1", "src_a", "x")
+    c1.category_labels = ["research_method"]
+    c2 = _chunk("c2", "src_b", "y")
+    c2.category_labels = ["research_method"]
+    edges = detect_keyword_overlap([c1, c2], workspace_id="ws", repo_slug="r")
+    assert all(abs(e.weight - 0.5) < 0.001 for e in edges)
+
+
+def test_detect_from_papers_no_ollama_skips_llm_rules():
+    """Without ollama_url, only citation + keyword rules run — no crash."""
+    from src.wiki_v2.paper_rules import detect_from_papers
+    c1 = _chunk("c1", "src_a", "text with [Smith 2020]")
+    c1.category_labels = ["research"]
+    c2 = _chunk("c2", "src_b", "text with [Smith 2020]")
+    c2.category_labels = ["research"]
+    edges = detect_from_papers([c1, c2], conn=None, ollama_url="", model="", workspace_id="ws", repo_slug="r")
+    assert isinstance(edges, list)
+    assert len(edges) > 0


### PR DESCRIPTION
## Summary
- **`src/wiki_v2/paper_rules.py`** (neu): 5 Paper-Edge-Regeln — citation (Regex), keyword_cooccurrence (Regex), shared_concept/method_chain/dataset_coupling (Mini-LLM, gecacht in `wiki_paper_cache`)
- **`src/wiki_v2/edge_detector.py`**: `__init__` mit `ollama_url`+`model`; `detect_from_overview()` lädt automatisch Paper-Chunks aus DB und führt paper rules aus
- **`src/memory/store.py`**: `get_paper_cache()` + `set_paper_cache()` Helpers
- **`src/api/routes/memory.py`**: Post-paper-ingest background wiki rebuild (fire-and-forget Thread)

**Fix vs. Spec:** `WikiGraph.open()` existiert nicht — `WikiGraph(workspace_id, repo_slug="")` Konstruktor direkt verwendet

## Test plan
- [ ] `pytest tests/test_wiki_paper_rules.py -v` → alle 7 grün
- [ ] `pytest tests/ -q` → nur 7 pre-existing TestIndexOverviewFunctionDocs Fehler, keine neuen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add paper-specific wiki edge detection and trigger automatic wiki rebuild after paper ingestion.

New Features:
- Introduce paper-specific edge detection rules that infer citation, keyword overlap, shared concepts, method chains, and dataset coupling between papers.
- Cache mini-LLM paper extraction results in the database to avoid redundant processing.
- Extend edge detection to load paper chunks from the database and include paper-based edges in wiki graph generation.
- Trigger a background wiki rebuild after ingesting new paper sources via the memory API.

Enhancements:
- Allow configuring the edge detector with an Ollama URL and model for mini-LLM calls from both CLI and server.

Tests:
- Add tests for paper cache helpers and core paper edge detection rules including citation and keyword overlap behavior.