### PR TITLE
feat(mcp): Option A — Split MCP servers (#107)

### DIFF
--- a/claude-plugin/install.sh
+++ b/claude-plugin/install.sh
@@ -113,7 +113,9 @@ with open(settings_path, "w") as f:
 PYEOF
 
 # Lokalen MCP-Agent-Server in ~/.claude/settings.json eintragen (memory-agents)
-VENV_PYTHON="$MAYRING_DIR/.venv/bin/python"
+# Konfigurierbarer Pfad zum Python-Interpreter des virtuellen Environments:
+# Standard ist "$MAYRING_DIR/.venv/bin/python", kann aber via MAYRING_VENV_PYTHON überschrieben werden.
+VENV_PYTHON="${MAYRING_VENV_PYTHON:-"$MAYRING_DIR/.venv/bin/python"}"
 python3 - <<MCPEOF
 import json, os, sys
 

--- a/claude-plugin/install.sh
+++ b/claude-plugin/install.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd)"
-TOOLS_DIR="$(dirname "$PLUGIN_DIR")/tools"
+MAYRING_DIR="$(dirname "$PLUGIN_DIR")"
+TOOLS_DIR="$MAYRING_DIR/tools"
 
 # Plugin-Dateien
 DEST="$HOME/.claude/plugins/mayring-coder"
@@ -110,6 +111,37 @@ with open(settings_path, "w") as f:
     json.dump(cfg, f, indent=2)
     f.write("\n")
 PYEOF
+
+# Lokalen MCP-Agent-Server in ~/.claude/settings.json eintragen (memory-agents)
+VENV_PYTHON="$MAYRING_DIR/.venv/bin/python"
+python3 - <<MCPEOF
+import json, os, sys
+
+settings_path = os.path.expanduser("$SETTINGS")
+mayring_dir = "$MAYRING_DIR"
+venv_python = "$VENV_PYTHON"
+
+try:
+    with open(settings_path) as f:
+        cfg = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    cfg = {}
+
+mcp_servers = cfg.setdefault("mcpServers", {})
+if "memory-agents" not in mcp_servers:
+    mcp_servers["memory-agents"] = {
+        "command": venv_python,
+        "args": ["-m", "src.api.local_mcp"],
+        "cwd": mayring_dir,
+    }
+    print("MCP-Server hinzugefügt: memory-agents (lokaler Agent-Server)")
+else:
+    print("MCP-Server bereits vorhanden: memory-agents")
+
+with open(settings_path, "w") as f:
+    json.dump(cfg, f, indent=2)
+    f.write("\n")
+MCPEOF
 
 # Auth-Token einrichten via OAuth PKCE (vollautomatisch, kein Copy-Paste)
 HOOK_JWT="$HOME/.config/mayring/hook.jwt"

--- a/src/api/local_mcp.py
+++ b/src/api/local_mcp.py
@@ -1,0 +1,50 @@
+"""Local MCP server — agent tools only (pi_task, duel, benchmark_tasks).
+
+Talks to local Ollama and uses the synced local memory DB
+(populated by tools/memory_sync.py from the cloud).
+
+Add to Claude Code MCP settings alongside the cloud memory server:
+{
+    "mcpServers": {
+        "claude.ai Memory": { ...cloud SSE config... },
+        "memory-agents": {
+            "command": "/path/to/MayringCoder/.venv/bin/python",
+            "args": ["-m", "src.api.local_mcp"],
+            "cwd": "/path/to/MayringCoder"
+        }
+    }
+}
+
+Environment variables (all optional, sensible defaults):
+  OLLAMA_URL          Local Ollama endpoint (default: http://localhost:11434)
+  MAYRING_LOCAL_DB    Synced SQLite path   (default: ~/.cache/mayringcoder/memory.db)
+  MAYRING_LOCAL_CHROMA Synced Chroma dir   (default: ~/.cache/mayringcoder/chroma)
+  PI_AGENT_URL        Set to "direct" to bypass pi_server (default: direct)
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from mcp.server.fastmcp import FastMCP
+
+_ROOT = Path(__file__).parent.parent.parent
+load_dotenv(_ROOT / ".env")
+
+_local_cache = Path.home() / ".cache" / "mayringcoder"
+
+os.environ.setdefault("OLLAMA_URL", "http://localhost:11434")
+os.environ.setdefault("MAYRING_LOCAL_DB", str(_local_cache / "memory.db"))
+os.environ.setdefault("MAYRING_LOCAL_CHROMA", str(_local_cache / "chroma"))
+os.environ.setdefault("PI_AGENT_URL", "direct")
+
+from src.api.mcp_agent_tools import register_agent_tools  # noqa: E402
+
+mcp = FastMCP("memory-agents")
+register_agent_tools(mcp)
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/api/mcp.py
+++ b/src/api/mcp.py
@@ -45,7 +45,6 @@ load_dotenv(_ROOT / ".env")
 
 from src.api.mcp_auth import JWTAuthMiddleware, _AUTH_ENABLED, _OAUTH_BASE_URL
 from src.api.mcp_memory_tools import register_memory_tools
-from src.api.mcp_agent_tools import register_agent_tools
 from src.api.mcp_oauth import PathNormMiddleware, build_starlette_routes
 
 # Backward-compat aliases for tests that import with underscore prefix
@@ -63,7 +62,7 @@ mcp = FastMCP(
 )
 
 register_memory_tools(mcp)
-register_agent_tools(mcp)
+# Agent tools (pi_task, duel, etc.) live in local_mcp.py — see Issue #107
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- `src/api/local_mcp.py` — neuer lokaler MCP-Server (stdio, kein Auth), exposiert nur `pi_task` / `duel` / `benchmark_tasks`, verbindet sich zu lokalem Ollama (`localhost:11434`), nutzt synced Local-DB (`~/.cache/mayringcoder/memory.db`)
- `src/api/mcp.py` — `register_agent_tools` entfernt, Cloud-MCP hat jetzt nur noch Memory-Tools
- `claude-plugin/install.sh` — trägt `memory-agents` MCP-Server automatisch in `~/.claude/settings.json` ein

## Claude Code Config nach Install
```json
{
  "mcpServers": {
    "claude.ai Memory": { "...cloud SSE..." },
    "memory-agents": {
      "command": "/path/to/.venv/bin/python",
      "args": ["-m", "src.api.local_mcp"],
      "cwd": "/path/to/MayringCoder"
    }
  }
}
```

## Test plan
- [x] `local_mcp.py` importiert fehlerfrei
- [x] cloud `mcp.py` hat kein `register_agent_tools` mehr
- [x] Test-Suite: 1074 passed, 7 pre-existing failures unverändert

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a dedicated local MCP server for agent tools and wire it into the Claude plugin configuration while keeping the cloud MCP focused on memory tools.

New Features:
- Add a standalone local MCP server entry point that exposes only agent tools and targets a local Ollama instance with a synced local memory backend.
- Automatically register the local "memory-agents" MCP server in Claude's settings.json during plugin installation.

Enhancements:
- Restrict the cloud MCP server to memory-related tools and document that agent tools are served by the new local MCP server.