### PR TITLE
feat: Task-Feedback-Matrix + Image-Pipeline-Tests (#90, #91)

### DIFF
--- a/src/api/routes/wiki.py
+++ b/src/api/routes/wiki.py
@@ -338,14 +338,20 @@ async def wiki_diff(
 @router.get("/wiki/feedback-matrix")
 async def wiki_feedback_matrix(
     limit: int = 50,
+    query_filter: str | None = None,
+    mode: str = "chunk",
     workspace_id: str = Depends(get_workspace),
 ) -> dict:
     """Return per-chunk feedback aggregation (positive/negative/neutral counts + net_score)."""
     try:
         from src.api.dependencies import get_conn
-        from src.wiki_v2.store import get_feedback_matrix
-        matrix = get_feedback_matrix(get_conn(), limit=limit)
-        return {"workspace_id": workspace_id, "limit": limit, "matrix": matrix}
+        from src.wiki_v2.store import get_feedback_matrix, get_task_feedback_matrix
+        conn = get_conn()
+        if mode == "task":
+            data = get_task_feedback_matrix(conn, limit=limit, query_filter=query_filter)
+            return {"workspace_id": workspace_id, "mode": "task", "tasks": data}
+        data = get_feedback_matrix(conn, limit=limit)
+        return {"workspace_id": workspace_id, "mode": "chunk", "chunks": data}
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
 

--- a/src/wiki_v2/store.py
+++ b/src/wiki_v2/store.py
@@ -267,3 +267,53 @@ def get_feedback_matrix(memory_conn: DBAdapter, limit: int = 50) -> list[dict]:
             "net_score": net,
         })
     return result
+
+
+def get_task_feedback_matrix(
+    memory_conn: DBAdapter,
+    limit: int = 50,
+    query_filter: str | None = None,
+) -> list[dict]:
+    """Return feedback grouped by query/task context.
+
+    Each entry represents one query session with the list of chunks
+    that were rated (positive/negative/neutral) during that query.
+
+    Returns:
+        List of {query, chunks: [{chunk_id, source_id, signal, created_at}]}
+    """
+    where = "WHERE json_extract(cf.metadata, '$.query_context') IS NOT NULL"
+    params: list = []
+    if query_filter:
+        where += " AND json_extract(cf.metadata, '$.query_context') LIKE ?"
+        params.append(f"%{query_filter}%")
+
+    rows = memory_conn.execute(
+        f"""
+        SELECT
+            json_extract(cf.metadata, '$.query_context') AS query,
+            cf.chunk_id,
+            COALESCE(c.source_id, '') AS source_id,
+            cf.signal,
+            cf.created_at
+        FROM chunk_feedback cf
+        LEFT JOIN chunks c ON c.chunk_id = cf.chunk_id
+        {where}
+        ORDER BY cf.created_at DESC
+        LIMIT ?
+        """,
+        params + [limit],
+    ).fetchall()
+
+    tasks: dict[str, dict] = {}
+    for r in rows:
+        query = r[0] if isinstance(r, tuple) else r["query"]
+        if query not in tasks:
+            tasks[query] = {"query": query, "chunks": []}
+        tasks[query]["chunks"].append({
+            "chunk_id": r[1] if isinstance(r, tuple) else r["chunk_id"],
+            "source_id": r[2] if isinstance(r, tuple) else r["source_id"],
+            "signal": r[3] if isinstance(r, tuple) else r["signal"],
+            "created_at": r[4] if isinstance(r, tuple) else r["created_at"],
+        })
+    return list(tasks.values())

--- a/tests/test_image_ingestion.py
+++ b/tests/test_image_ingestion.py
@@ -1,0 +1,190 @@
+"""Tests fuer die Visual-Model-Pipeline (Issue #91).
+
+Abgedeckt:
+- caption_image() fuer SVG (kein Ollama-Call)
+- caption_image() fuer PNG (Ollama wird aufgerufen)
+- Ollama-Fehler -> leerer String
+- ingest_image() erzeugt Chunk mit chunk_level='image_caption'
+"""
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from src.agents.vision import caption_image
+from src.memory.schema import Source
+from src.memory.store import init_memory_db, _init_schema
+
+
+# ---------------------------------------------------------------------------
+# caption_image — SVG
+# ---------------------------------------------------------------------------
+
+
+def test_caption_svg_returns_raw_text_no_ollama(tmp_path: Path) -> None:
+    svg_path = tmp_path / "diagram.svg"
+    svg_content = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>'
+    svg_path.write_text(svg_content, encoding="utf-8")
+
+    with patch("src.ollama_client.generate") as mock_gen:
+        result = caption_image(svg_path, ollama_url="http://localhost:11434")
+
+    mock_gen.assert_not_called()
+    assert result == svg_content
+
+
+# ---------------------------------------------------------------------------
+# caption_image — PNG via Ollama
+# ---------------------------------------------------------------------------
+
+
+def test_caption_png_calls_ollama(tmp_path: Path) -> None:
+    img_path = tmp_path / "chart.png"
+    img = Image.new("RGB", (32, 32), color=(0, 100, 200))
+    img.save(img_path, format="PNG")
+
+    with patch("src.ollama_client.generate", return_value="A blue square.") as mock_gen:
+        result = caption_image(img_path, ollama_url="http://localhost:11434", model="qwen2.5vl:3b")
+
+    mock_gen.assert_called_once()
+    assert result == "A blue square."
+
+
+def test_caption_png_ollama_error_returns_empty(tmp_path: Path) -> None:
+    img_path = tmp_path / "broken.png"
+    img = Image.new("RGB", (16, 16), color=(0, 0, 0))
+    img.save(img_path, format="PNG")
+
+    with patch("src.ollama_client.generate", side_effect=Exception("Connection refused")):
+        result = caption_image(img_path, ollama_url="http://localhost:11434")
+
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# ingest_image — chunk mit chunk_level='image_caption'
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_image_produces_image_caption_chunk(tmp_path: Path) -> None:
+    from src.memory.ingestion.image import ingest_image
+
+    img_path = tmp_path / "arch.png"
+    img = Image.new("RGB", (64, 64), color=(255, 0, 0))
+    img.save(img_path, format="PNG")
+
+    db_path = tmp_path / "test.db"
+    conn = init_memory_db(db_path)
+
+    source = Source(
+        source_id="repo:test/project:arch.png",
+        source_type="repo_file",
+        repo="test/project",
+        path="arch.png",
+    )
+
+    fake_caption = "A red architecture diagram."
+
+    with (
+        patch("src.agents.vision.caption_image", return_value=fake_caption),
+        patch("src.analysis.context._embed_texts", return_value=[[0.1] * 768]),
+        patch("src.memory.ingestion.core.resolve_dedup") as mock_dedup,
+    ):
+        mock_dedup.return_value = (MagicMock(), False)
+
+        result = ingest_image(
+            source=source,
+            image_path=img_path,
+            conn=conn,
+            chroma_collection=None,
+            ollama_url="http://localhost:11434",
+            model="nomic-embed-text",
+            vision_model="qwen2.5vl:3b",
+            workspace_id="test-ws",
+        )
+
+    from src.memory.store import get_chunk
+
+    assert len(result["chunk_ids"]) == 1
+    chunk_id = result["chunk_ids"][0]
+    stored = get_chunk(conn, chunk_id)
+    assert stored is not None
+    assert stored.chunk_level == "image_caption"
+    assert result["deduped"] == 0
+
+
+def test_ingest_image_svg_no_ollama_call(tmp_path: Path) -> None:
+    from src.memory.ingestion.image import ingest_image
+
+    svg_path = tmp_path / "flow.svg"
+    svg_content = '<svg xmlns="http://www.w3.org/2000/svg"><text>Flow</text></svg>'
+    svg_path.write_text(svg_content, encoding="utf-8")
+
+    db_path = tmp_path / "test.db"
+    conn = init_memory_db(db_path)
+
+    source = Source(
+        source_id="repo:test/project:flow.svg",
+        source_type="repo_file",
+        repo="test/project",
+        path="flow.svg",
+    )
+
+    with (
+        patch("src.ollama_client.generate") as mock_gen,
+        patch("src.analysis.context._embed_texts", return_value=[[0.1] * 768]),
+        patch("src.memory.ingestion.core.resolve_dedup") as mock_dedup,
+    ):
+        mock_dedup.return_value = (MagicMock(), False)
+
+        result = ingest_image(
+            source=source,
+            image_path=svg_path,
+            conn=conn,
+            chroma_collection=None,
+            ollama_url="http://localhost:11434",
+            model="nomic-embed-text",
+            vision_model="qwen2.5vl:3b",
+            workspace_id="test-ws",
+        )
+
+    mock_gen.assert_not_called()
+    assert len(result["chunk_ids"]) == 1
+
+
+def test_ingest_image_fallback_caption_on_empty_response(tmp_path: Path) -> None:
+    from src.memory.ingestion.image import ingest_image
+
+    img_path = tmp_path / "empty_caption.png"
+    img = Image.new("RGB", (16, 16), color=(128, 128, 128))
+    img.save(img_path, format="PNG")
+
+    db_path = tmp_path / "test.db"
+    conn = init_memory_db(db_path)
+
+    source = Source(
+        source_id="repo:test/project:empty_caption.png",
+        source_type="repo_file",
+        repo="test/project",
+        path="empty_caption.png",
+    )
+
+    with (
+        patch("src.agents.vision.caption_image", return_value=""),
+        patch("src.analysis.context._embed_texts", return_value=[[0.1] * 768]),
+        patch("src.memory.ingestion.core.resolve_dedup") as mock_dedup,
+    ):
+        mock_dedup.return_value = (MagicMock(), False)
+
+        result = ingest_image(
+            source=source,
+            image_path=img_path,
+            conn=conn,
+            chroma_collection=None,
+            ollama_url="http://localhost:11434",
+            model="nomic-embed-text",
+            workspace_id="test-ws",
+        )
+
+    assert len(result["chunk_ids"]) == 1

--- a/tests/test_task_feedback_matrix.py
+++ b/tests/test_task_feedback_matrix.py
@@ -1,0 +1,57 @@
+import json
+from src.memory.db_adapter import DBAdapter
+from src.memory.store import _init_schema, add_feedback
+from src.wiki_v2.store import get_task_feedback_matrix
+
+
+def _db():
+    db = DBAdapter.memory()
+    _init_schema(db)
+    return db
+
+
+def _insert_chunk(db, chunk_id, source_id="src/api/auth.py"):
+    db.execute(
+        "INSERT OR IGNORE INTO sources(source_id, source_type, repo, path, content_hash, captured_at)"
+        " VALUES (?, 'repo_file', 'test', ?, 'h', '2026-01-01')",
+        (source_id, source_id),
+    )
+    db.execute(
+        "INSERT OR IGNORE INTO chunks(chunk_id, source_id, text, text_hash, dedup_key, created_at, is_active)"
+        " VALUES (?, ?, 'text', 'h', 'd', '2026-01-01', 1)",
+        (chunk_id, source_id),
+    )
+    db.commit()
+
+
+def test_task_feedback_matrix_groups_by_query():
+    db = _db()
+    _insert_chunk(db, "chk_a", "src/api/auth.py")
+    _insert_chunk(db, "chk_b", "src/api/jwt.py")
+    add_feedback(db, "chk_a", "positive", {"query_context": "fix auth bug"})
+    add_feedback(db, "chk_b", "negative", {"query_context": "fix auth bug"})
+    add_feedback(db, "chk_a", "positive", {"query_context": "optimize search"})
+
+    result = get_task_feedback_matrix(db, limit=50)
+    queries = [t["query"] for t in result]
+    assert "fix auth bug" in queries
+    assert "optimize search" in queries
+    auth_task = next(t for t in result if t["query"] == "fix auth bug")
+    assert len(auth_task["chunks"]) == 2
+
+
+def test_task_feedback_matrix_skips_no_query():
+    db = _db()
+    _insert_chunk(db, "chk_c")
+    add_feedback(db, "chk_c", "positive", {})
+    result = get_task_feedback_matrix(db, limit=50)
+    assert all(t["query"] for t in result)
+
+
+def test_task_feedback_matrix_query_filter():
+    db = _db()
+    _insert_chunk(db, "chk_d")
+    add_feedback(db, "chk_d", "positive", {"query_context": "memory search performance"})
+    result = get_task_feedback_matrix(db, limit=50, query_filter="memory")
+    assert len(result) >= 1
+    assert all("memory" in t["query"].lower() for t in result)


### PR DESCRIPTION
## Summary
- `get_task_feedback_matrix()` in `src/wiki_v2/store.py` — Feedback gruppiert nach query_context statt by chunk
- `GET /wiki/feedback-matrix?mode=task` Parameter am Endpoint (`src/api/routes/wiki.py`)
- Tests für beide Store-Funktionen (`tests/test_task_feedback_matrix.py`, 3 PASS)
- Tests für bestehende Image-Pipeline (`tests/test_image_ingestion.py`, 6 PASS, mock ohne Ollama)

## Test plan
- [x] `tests/test_task_feedback_matrix.py` — 3/3 PASS
- [x] `tests/test_image_ingestion.py` — 6/6 PASS
- [x] Gesamt-Suite: 1083 passed, 7 pre-existing failures (TestIndexOverviewFunctionDocs) unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add task-centric feedback aggregation and tests for both feedback matrix and image ingestion pipelines.

New Features:
- Introduce task-based feedback matrix retrieval grouped by query context in the wiki store.
- Expose a feedback-matrix API mode switch to return either per-chunk or per-task feedback including optional query filtering.

Tests:
- Add tests covering task feedback matrix behavior including grouping, filtering, and handling of missing query context.
- Add tests for image captioning and ingestion covering SVG passthrough, PNG captioning via Ollama, error handling, and image-caption chunk creation.