### PR TITLE
Potential fix for code scanning alert no. 117: Incomplete URL substring sanitization

### DIFF
--- a/src/api/mcp_memory_tools.py
+++ b/src/api/mcp_memory_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from urllib.parse import urlparse
 
 from mcp.server.fastmcp import FastMCP
 
@@ -133,11 +134,15 @@ def register_memory_tools(mcp: FastMCP) -> None:
         _jwt = _current_raw_jwt()
         headers = {"Authorization": f"Bearer {_jwt}"} if _jwt else {}
 
+        parsed_source = urlparse(source)
+        source_host = (parsed_source.hostname or "").lower()
         is_repo = source_type == "repo" or (
             source_type == "auto" and (
-                source.startswith("https://github.com")
-                or source.startswith("https://gitlab.com")
-                or source.startswith("git@")
+                source.startswith("git@")
+                or (
+                    parsed_source.scheme in {"http", "https"}
+                    and source_host in {"github.com", "gitlab.com"}
+                )
             )
         )
 


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/117](https://github.com/Nileneb/MayringCoder/security/code-scanning/117)

Use URL parsing to determine whether `source` is a GitHub/GitLab repo URL by checking the parsed scheme and hostname, instead of checking raw string prefixes.

Best minimal fix in `src/api/mcp_memory_tools.py`:
1. Add `from urllib.parse import urlparse`.
2. In `ingest`, parse `source` once (`parsed = urlparse(source)`), normalize `hostname = (parsed.hostname or "").lower()`.
3. Replace current `startswith`-based `is_repo` expression with:
   - `source_type == "repo"` OR
   - `source_type == "auto"` and either:
     - SSH form (`source.startswith("git@")`) or
     - parsed URL has scheme `http/https` and hostname exactly `github.com` or `gitlab.com`.

This preserves existing functionality (auto-detect HTTP(S) GitHub/GitLab and `git@`), while removing incomplete URL substring/prefix sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix incomplete URL prefix sanitization when auto-detecting GitHub or GitLab repository sources by relying on URL parsing and strict host matching.