### PR TITLE
Potential fix for code scanning alert no. 113: Incomplete URL substring sanitization

### DIFF
--- a/src/api/mcp_agent_tools.py
+++ b/src/api/mcp_agent_tools.py
@@ -131,15 +131,18 @@ def register_agent_tools(mcp: FastMCP) -> None:
             text: {source_id, chunk_ids, workspace_id}
         """
         import httpx
+        from urllib.parse import urlparse
         ws = _enforce_tenant(workspace_id) or _effective_workspace_id()
         _api = os.getenv("MAYRING_API_URL", "http://localhost:8090").rstrip("/")
         _jwt = _current_raw_jwt()
         headers = {"Authorization": f"Bearer {_jwt}"} if _jwt else {}
 
+        parsed = urlparse(source) if source_type == "auto" else None
+        host = (parsed.hostname or "").lower() if parsed else ""
         is_repo = source_type == "repo" or (
-            source_type == "auto" and (
-                source.startswith("https://github.com")
-                or source.startswith("https://gitlab.com")
+            source_type == "auto"
+            and (
+                (parsed and parsed.scheme == "https" and host in {"github.com", "gitlab.com"})
                 or source.startswith("git@")
             )
         )


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/113](https://github.com/Nileneb/MayringCoder/security/code-scanning/113)

Use `urllib.parse.urlparse` to parse `source` when `source_type == "auto"`, then decide repo-ness by checking:
- scheme is `https`
- hostname is exactly `github.com` or `gitlab.com`
- keep existing `git@` support for SSH-style repo specs

This preserves existing functionality (GitHub/GitLab HTTPS and `git@...` are still detected) while removing fragile raw-string prefix checks.

**File to change:** `src/api/mcp_agent_tools.py`  
**Region:** inside `ingest(...)`, around current `is_repo` assignment (lines 139–145 in snippet).  
**Needed additions:** local import `from urllib.parse import urlparse` inside `ingest` (keeps change scoped and avoids touching global imports).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix unsafe and incomplete URL-based repository detection for auto sources by validating parsed HTTPS hostnames against an allowlist while preserving existing SSH-style detection.