### PR TITLE
fix(marketplace): drop redundant claude_ai_Memory SSE binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,12 +221,22 @@ python3 ~/Desktop/MayringCoder/tools/oauth_install.py \
 - Plugin-Manifest (`.claude-plugin/plugin.json`)
 - Hooks (`SessionStart`, `UserPromptSubmit`, `PostCompact`, `Stop`)
 - Skills (`github-issue-analysis`)
-- MCP-Server-Bindings (`claude_ai_Memory` SSE + `memory-agents` lokales MCP)
+- **Lokaler `memory-agents` MCP-Server** (Pi-Agent: `pi_task`, `ingest`,
+  `duel`, `benchmark_tasks`)
 
-**Was ist Bootstrap-Aufgabe (manuell, einmalig):**
-- venv mit `requirements-client.txt`
+**Was NICHT über den Marketplace kommt — und auch nicht soll:**
+- Der **Cloud-Memory-MCP** (`mcp.linn.games/sse`, Tools
+  `mcp__claude_ai_Memory__*`) wird separat über dein **Claude.ai-Profil**
+  verbunden — das Plugin registriert ihn bewusst NICHT in `.mcp.json`,
+  sonst hättest du auf jedem Rechner doppelte Bindings.
+
+**Was ist Bootstrap-Aufgabe (manuell, einmalig pro Maschine):**
+- venv mit `requirements-client.txt` (~380 MB, für den lokalen `memory-agents`-MCP)
 - Repo-Klon nach `$HOME/Desktop/MayringCoder` (für `cwd` des memory-agents-MCP)
-- JWT via OAuth (`hook.jwt` in `~/.config/mayring/`)
+- JWT via OAuth — gebraucht für die **Hooks** (`postcompact_hook.py`,
+  `memory_sync.py` schicken Conversation-Summaries via HTTP an
+  `mcp.linn.games/memory/put`); NICHT für den SSE-Memory-Server, den dein
+  Cloud-Profil schon authentifiziert
 
 Alternativ kann `claude-plugin/install.sh` aus dem geklonten Repo (oder aus dem
 installierten Plugin-Verzeichnis) das Bootstrapping zentralisieren — er erkennt

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -1,12 +1,5 @@
 {
   "mcpServers": {
-    "claude_ai_Memory": {
-      "type": "sse",
-      "url": "https://mcp.linn.games/sse",
-      "headers": {
-        "Authorization": "Bearer ${MAYRING_JWT}"
-      }
-    },
     "memory-agents": {
       "command": "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python",
       "args": [

--- a/claude-plugin/CLAUDE.md
+++ b/claude-plugin/CLAUDE.md
@@ -1,6 +1,14 @@
 # MayringCoder Memory-Workflow
 
-MCP-Server: `mcp.linn.games/sse` | Workspace-ID: `system` (intern) oder Projekt-Slug
+Memory-Server (`mcp.linn.games/sse`) wird über das **Claude.ai-Cloud-Profil**
+des Users verbunden — nicht über dieses Plugin. Die `mcp__claude_ai_Memory__*`
+Tools unten kommen also von dort, nicht aus `.mcp.json`.
+
+Das Plugin selbst liefert ausschließlich den **lokalen** `memory-agents`
+MCP-Server (Pi-Agent: `pi_task`, `ingest`, `duel`, `benchmark_tasks`),
+plus die Hooks für Session-Lifecycle und Conversation-Capture.
+
+Workspace-ID: `system` (intern) oder Projekt-Slug
 
 ## 1. Sessionbeginn / neuer Task
 ```


### PR DESCRIPTION
## Why

PR #116 hat versehentlich `claude_ai_Memory` (SSE-Endpoint `mcp.linn.games/sse`) im plugin-eigenen `.mcp.json` registriert. **Der gleiche MCP-Server ist beim User aber bereits über das Claude.ai-Cloud-Profil verbunden** — auf jedem Rechner, wo das Plugin installiert wird, hat man dann zwei parallele Bindings auf den gleichen Endpoint. Redundant + verwirrend (zwei Auth-Wege, zwei `mcp__claude_ai_Memory__*` Tool-Mengen).

## Fix

- **`claude-plugin/.mcp.json`**: `claude_ai_Memory`-SSE-Block raus. Plugin liefert jetzt nur noch den lokalen `memory-agents` MCP (Pi-Agent: `pi_task`, `ingest`, `duel`, `benchmark_tasks`).
- **`claude-plugin/CLAUDE.md`**: Header präzisiert — die `mcp__claude_ai_Memory__*` Tools im Workflow kommen vom Cloud-Profil, nicht aus diesem Plugin.
- **`README.md`** (Marketplace-Sektion): explizit getrennt, was über den Marketplace kommt vs. was über das Cloud-Profil läuft. JWT-Zweck korrigiert: gebraucht für die **Hooks** (`postcompact_hook.py` + `memory_sync.py` schicken Summaries via HTTP an `/memory/put`), NICHT für den SSE-Server.

## Was über den Marketplace bleibt

- Plugin-Manifest, Hooks, Skills
- Lokaler `memory-agents` MCP-Server (Pi-Agent)

## Was nicht (und auch nicht soll)

- Cloud-`claude_ai_Memory` SSE — kommt vom Claude.ai-Profil

## Summary by Sourcery

Remove the redundant Cloud Memory MCP binding from the plugin and clarify the separation between the local memory-agents server and the Claude.ai cloud profile.

Enhancements:
- Ensure the plugin only exposes the local memory-agents MCP server instead of also registering the Cloud claude_ai_Memory SSE endpoint.

Documentation:
- Clarify in README and CLAUDE.md which MCP servers and tools are provided by the marketplace plugin versus the Claude.ai cloud profile, and document that the JWT is used for HTTP hook calls rather than SSE authentication.