### PR TITLE
Potential fix for code scanning alert no. 115: Uncontrolled data used in path expression

### DIFF
--- a/src/api/routes/wiki.py
+++ b/src/api/routes/wiki.py
@@ -139,7 +139,12 @@ async def wiki_rebuild(
     """Rebuild wiki_v2 graph.json for a workspace: EdgeDetector + ClusterEngine + to_json()."""
     wid = request.workspace_id
     slug = request.repo_slug or wid
-    job_id = _make_job(wid)
+    try:
+        _wid_safe = safe_id(wid)
+        _slug_safe = safe_id(slug)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid workspace_id or repo_slug") from exc
+    job_id = _make_job(_wid_safe)
 
     async def _do_rebuild() -> None:
         try:
@@ -150,8 +155,6 @@ async def wiki_rebuild(
             from src.wiki_v2.edge_detector import EdgeDetector
             from src.wiki_v2.clustering import ClusterEngine
 
-            _wid_safe = safe_id(wid)
-            _slug_safe = safe_id(slug)
             db = WikiGraph(_wid_safe, _slug_safe, CACHE_DIR / "wiki_v2.db")
             oc_path = _cp(CACHE_DIR, f"{_slug_safe}_overview_cache.json")
             oc = _j.loads(oc_path.read_text()) if oc_path.exists() else {}


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/MayringCoder/security/code-scanning/115](https://github.com/Nileneb/MayringCoder/security/code-scanning/115)

General fix: validate untrusted request fields early using strict allowlist semantics and reject invalid inputs before they are used in any filesystem-related expression.

Best targeted fix here (without changing behavior): in `src/api/routes/wiki.py` inside `wiki_rebuild`, wrap `safe_id(...)` conversion in a `try/except ValueError` and convert invalid identifiers into `HTTPException(status_code=400, ...)`. This makes validation explicit at the API boundary and ensures no invalid/tainted value reaches path building, while preserving current logic for valid values.

Changes needed:
- File: `src/api/routes/wiki.py`
- Region: `wiki_rebuild(...)` around lines where `wid`, `slug`, and `job_id` are set.
- Add explicit sanitization/validation before `_make_job(...)` and before async task uses the values.
- No new dependencies required; `HTTPException` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden wiki rebuild request handling by validating and sanitizing workspace and repository identifiers at the API boundary and propagating the safe values into downstream processing.

Bug Fixes:
- Validate workspace and repository identifiers in wiki rebuild requests before using them in path-related operations, returning HTTP 400 for invalid values.

Enhancements:
- Reuse prevalidated identifiers throughout the wiki rebuild task to avoid redundant conversions and ensure consistent sanitization.