### PR TITLE
feat(plugin): unified marketplace install via SessionStart bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,54 +194,33 @@ cp .env.example .env
 
 ## Install as a Claude Code Plugin (via Marketplace)
 
-Wenn du auf einem zweiten Rechner nur den **Memory-Plugin-Teil** willst (Hooks +
-SSE-Memory-MCP + lokales pi_task-MCP), kommt das jetzt sauber über den
-eingebauten Marketplace-Mechanismus:
-
 ```bash
-# 1. Marketplace registrieren (lädt aus diesem Repo)
 /plugin marketplace add Nileneb/MayringCoder
 /plugin install mayring-coder@MayringCoder
-
-# 2. Repo lokal klonen — der memory-agents MCP-Server braucht das volle
-#    src/-Tree als cwd (Konvention: $HOME/Desktop/MayringCoder).
-git clone https://github.com/Nileneb/MayringCoder ~/Desktop/MayringCoder
-
-# 3. venv im Plugin-Verzeichnis bootstrappen (~380 MB Deps).
-PLUGIN=~/.claude/plugins/marketplaces/MayringCoder/plugins/mayring-coder
-python3 -m venv "$PLUGIN/.venv"
-"$PLUGIN/.venv/bin/pip" install -r ~/Desktop/MayringCoder/requirements-client.txt
-
-# 4. JWT für mcp.linn.games via OAuth (Browser öffnet sich).
-python3 ~/Desktop/MayringCoder/tools/oauth_install.py \
-        --jwt-file ~/.config/mayring/hook.jwt
 ```
 
-**Was kommt automatisch über den Marketplace:**
-- Plugin-Manifest (`.claude-plugin/plugin.json`)
-- Hooks (`SessionStart`, `UserPromptSubmit`, `PostCompact`, `Stop`)
+Beim nächsten `claude`-Start bootstrappt der `SessionStart`-Hook automatisch:
+1. venv unter `${CLAUDE_PLUGIN_ROOT}/.venv/` mit `requirements-client.txt`
+2. JWT für `mcp.linn.games/memory/*` via OAuth-PKCE (Browser öffnet sich)
+
+Erstmal-Bootstrap dauert ~30–60s, danach 0 Overhead.
+
+**Was kommt automatisch:**
+- Plugin-Manifest, Hooks (`SessionStart`, `UserPromptSubmit`, `PostCompact`, `Stop`)
 - Skills (`github-issue-analysis`)
-- **Lokaler `memory-agents` MCP-Server** (Pi-Agent: `pi_task`, `ingest`,
-  `duel`, `benchmark_tasks`)
+- Lokaler `memory-agents` MCP-Server (Pi-Agent: `pi_task`, `ingest`, `duel`, `benchmark_tasks`)
 
-**Was NICHT über den Marketplace kommt — und auch nicht soll:**
-- Der **Cloud-Memory-MCP** (`mcp.linn.games/sse`, Tools
-  `mcp__claude_ai_Memory__*`) wird separat über dein **Claude.ai-Profil**
-  verbunden — das Plugin registriert ihn bewusst NICHT in `.mcp.json`,
-  sonst hättest du auf jedem Rechner doppelte Bindings.
+**Was NICHT über den Marketplace kommt:**
+- Der Cloud-Memory-MCP (`mcp.linn.games/sse`, Tools `mcp__claude_ai_Memory__*`) wird
+  separat über dein **Claude.ai-Profil** verbunden — das Plugin registriert ihn bewusst
+  NICHT in `.mcp.json`, sonst hättest du auf jedem Rechner doppelte Bindings.
 
-**Was ist Bootstrap-Aufgabe (manuell, einmalig pro Maschine):**
-- venv mit `requirements-client.txt` (~380 MB, für den lokalen `memory-agents`-MCP)
-- Repo-Klon nach `$HOME/Desktop/MayringCoder` (für `cwd` des memory-agents-MCP)
-- JWT via OAuth — gebraucht für die **Hooks** (`postcompact_hook.py`,
-  `memory_sync.py` schicken Conversation-Summaries via HTTP an
-  `mcp.linn.games/memory/put`); NICHT für den SSE-Memory-Server, den dein
-  Cloud-Profil schon authentifiziert
-
-Alternativ kann `claude-plugin/install.sh` aus dem geklonten Repo (oder aus dem
-installierten Plugin-Verzeichnis) das Bootstrapping zentralisieren — er erkennt
-automatisch, ob er in einem klassischen Klon, im Marketplace-Pfad oder
-standalone läuft.
+### Lokales Dev-Setup (statt Marketplace)
+Wenn du am Plugin selbst entwickelst und kein Marketplace nutzt:
+```bash
+git clone https://github.com/Nileneb/MayringCoder
+bash MayringCoder/claude-plugin/install.sh   # eager venv + JWT
+```
 
 **Run the full 3-stage pipeline:**
 

--- a/claude-plugin/.mcp.json
+++ b/claude-plugin/.mcp.json
@@ -6,9 +6,9 @@
         "-m",
         "src.api.local_mcp"
       ],
-      "cwd": "${HOME}/Desktop/MayringCoder",
+      "cwd": "${CLAUDE_PLUGIN_ROOT}/..",
       "env": {
-        "PYTHONPATH": "${HOME}/Desktop/MayringCoder"
+        "PYTHONPATH": "${CLAUDE_PLUGIN_ROOT}/.."
       }
     }
   }

--- a/claude-plugin/hooks/session_start.py
+++ b/claude-plugin/hooks/session_start.py
@@ -43,8 +43,12 @@ def _repo_root(plugin_root: str) -> str:
     return plugin_root
 
 
+def _venv_python(venv_dir: str) -> str:
+    return os.path.join(venv_dir, "bin", "python")
+
+
 def _venv_is_healthy(venv_dir: str) -> bool:
-    py = os.path.join(venv_dir, "bin", "python")
+    py = _venv_python(venv_dir)
     pip = os.path.join(venv_dir, "bin", "pip")
     if not (os.path.isfile(py) and os.path.isfile(pip)):
         return False
@@ -58,18 +62,24 @@ def _ensure_venv(plugin_root: str, repo_root: str) -> None:
     if _venv_is_healthy(venv_dir):
         return
     if not os.path.isfile(requirements):
+        print(
+            f"MayringCoder bootstrap: skipped (no {requirements}); is the marketplace clone complete?",
+            file=sys.stderr,
+        )
         return
     print(
         f"MayringCoder bootstrap: creating venv at {venv_dir} (one-time, ~30-60s)",
         file=sys.stderr,
     )
     try:
-        subprocess.run(
+        # Trusted args: sys.executable is Python's own path; venv_dir derives
+        # from CLAUDE_PLUGIN_ROOT (or this file's location). No user-controlled input.
+        subprocess.run(  # nosec B603
             [sys.executable, "-m", "venv", "--clear", venv_dir],
             check=True,
             capture_output=True,
         )
-        subprocess.run(
+        subprocess.run(  # nosec B603
             [os.path.join(venv_dir, "bin", "pip"), "install", "-q", "-r", requirements],
             check=True,
             capture_output=True,
@@ -82,25 +92,31 @@ def _ensure_venv(plugin_root: str, repo_root: str) -> None:
         )
 
 
-def _ensure_jwt(repo_root: str) -> None:
+def _ensure_jwt(repo_root: str, python_executable: str) -> None:
     if os.path.isfile(JWT_FILE) and os.path.getsize(JWT_FILE) > 0:
         return
     oauth_script = os.path.join(repo_root, "tools", "oauth_install.py")
     if not os.path.isfile(oauth_script):
+        print(
+            f"MayringCoder bootstrap: JWT setup skipped (no {oauth_script}); marketplace clone incomplete?",
+            file=sys.stderr,
+        )
         return
     print(
         "MayringCoder bootstrap: opening browser for hook JWT (OAuth PKCE)",
         file=sys.stderr,
     )
     try:
-        subprocess.run(
-            [sys.executable, oauth_script, "--jwt-file", JWT_FILE],
+        # Trusted args: python_executable is the venv (or sys.executable);
+        # oauth_script and JWT_FILE are module-controlled paths.
+        subprocess.run(  # nosec B603
+            [python_executable, oauth_script, "--jwt-file", JWT_FILE],
             check=True,
             timeout=180,
         )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         print(
-            f"MayringCoder bootstrap: JWT setup skipped — run manually: python3 {oauth_script}",
+            f"MayringCoder bootstrap: JWT setup skipped — run manually: {python_executable} {oauth_script}",
             file=sys.stderr,
         )
 
@@ -109,7 +125,9 @@ def _bootstrap_if_needed() -> None:
     plugin_root = _plugin_root()
     repo_root = _repo_root(plugin_root)
     _ensure_venv(plugin_root, repo_root)
-    _ensure_jwt(repo_root)
+    venv_dir = os.path.join(plugin_root, ".venv")
+    python_executable = _venv_python(venv_dir) if _venv_is_healthy(venv_dir) else sys.executable
+    _ensure_jwt(repo_root, python_executable)
 
 
 def _load_token() -> str:

--- a/claude-plugin/hooks/session_start.py
+++ b/claude-plugin/hooks/session_start.py
@@ -92,13 +92,17 @@ def _ensure_venv(plugin_root: str, repo_root: str) -> None:
         )
 
 
+def _have_jwt() -> bool:
+    return os.path.isfile(JWT_FILE) and os.path.getsize(JWT_FILE) > 0
+
+
 def _ensure_jwt(repo_root: str, python_executable: str) -> None:
-    if os.path.isfile(JWT_FILE) and os.path.getsize(JWT_FILE) > 0:
+    if _have_jwt():
         return
     oauth_script = os.path.join(repo_root, "tools", "oauth_install.py")
     if not os.path.isfile(oauth_script):
         print(
-            f"MayringCoder bootstrap: JWT setup skipped (no {oauth_script}); marketplace clone incomplete?",
+            "MayringCoder bootstrap: JWT setup skipped (oauth_install.py missing in repo)",
             file=sys.stderr,
         )
         return
@@ -107,8 +111,8 @@ def _ensure_jwt(repo_root: str, python_executable: str) -> None:
         file=sys.stderr,
     )
     try:
-        # Trusted args: python_executable is the venv (or sys.executable);
-        # oauth_script and JWT_FILE are module-controlled paths.
+        # Trusted argv: python_executable resolves from venv-or-sys.executable,
+        # oauth_script + JWT_FILE are module constants — no user input.
         subprocess.run(  # nosec B603
             [python_executable, oauth_script, "--jwt-file", JWT_FILE],
             check=True,
@@ -116,7 +120,7 @@ def _ensure_jwt(repo_root: str, python_executable: str) -> None:
         )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         print(
-            f"MayringCoder bootstrap: JWT setup skipped — run manually: {python_executable} {oauth_script}",
+            "MayringCoder bootstrap: JWT setup failed — run tools/oauth_install.py manually",
             file=sys.stderr,
         )
 

--- a/claude-plugin/hooks/session_start.py
+++ b/claude-plugin/hooks/session_start.py
@@ -1,27 +1,128 @@
 #!/usr/bin/env python3
-"""SessionStart hook: Memory-Kontext aus mcp.linn.games in den System-Prompt injizieren.
+"""SessionStart hook: idempotent bootstrap + Memory-Kontext-Injection.
 
-Sendet zusätzlich zur Initial-Query den Inhalt des aktuellsten Plans aus
-~/.claude/plans/ als task_context — das gibt dem PI-Advisor-Reranker eine
-reichere Beschreibung der anstehenden Arbeit als nur die generische
-'session start'-Query.
+Two-phase per session:
+  1) Bootstrap (only when something is missing): create venv, install
+     requirements-client.txt, run OAuth-PKCE for the hook JWT.
+  2) Memory inject: query mcp.linn.games /search and print the result block
+     so Claude sees relevant context for the user's first prompt.
 """
+from __future__ import annotations
+
 import glob
 import json
 import os
+import subprocess
 import sys
 import urllib.request
 import urllib.error
 
 
 PLANS_DIR = os.path.expanduser("~/.claude/plans")
-TASK_CONTEXT_BUDGET = 800  # chars from the plan file's Context section
+TASK_CONTEXT_BUDGET = 800
+JWT_FILE = os.path.expanduser("~/.config/mayring/hook.jwt")
+
+
+def _plugin_root() -> str:
+    """Resolve the plugin's root directory.
+
+    Prefers the runtime-provided CLAUDE_PLUGIN_ROOT; falls back to the
+    grandparent of this file (claude-plugin/ when laid out via the marketplace).
+    """
+    env = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env:
+        return env
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _repo_root(plugin_root: str) -> str:
+    """The repo containing src/api/local_mcp.py — typically plugin_root/.."""
+    parent = os.path.abspath(os.path.join(plugin_root, ".."))
+    if os.path.isfile(os.path.join(parent, "src", "api", "local_mcp.py")):
+        return parent
+    return plugin_root
+
+
+def _venv_is_healthy(venv_dir: str) -> bool:
+    py = os.path.join(venv_dir, "bin", "python")
+    pip = os.path.join(venv_dir, "bin", "pip")
+    if not (os.path.isfile(py) and os.path.isfile(pip)):
+        return False
+    real = os.path.realpath(py)
+    return os.path.isfile(real)
+
+
+def _ensure_venv(plugin_root: str, repo_root: str) -> None:
+    venv_dir = os.path.join(plugin_root, ".venv")
+    requirements = os.path.join(repo_root, "requirements-client.txt")
+    if _venv_is_healthy(venv_dir):
+        return
+    if not os.path.isfile(requirements):
+        return
+    print(
+        f"MayringCoder bootstrap: creating venv at {venv_dir} (one-time, ~30-60s)",
+        file=sys.stderr,
+    )
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "venv", "--clear", venv_dir],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            [os.path.join(venv_dir, "bin", "pip"), "install", "-q", "-r", requirements],
+            check=True,
+            capture_output=True,
+        )
+        print("MayringCoder bootstrap: venv ready", file=sys.stderr)
+    except subprocess.CalledProcessError as e:
+        print(
+            f"MayringCoder bootstrap: venv setup failed — {e.stderr.decode(errors='ignore')[:300]}",
+            file=sys.stderr,
+        )
+
+
+def _ensure_jwt(repo_root: str) -> None:
+    if os.path.isfile(JWT_FILE) and os.path.getsize(JWT_FILE) > 0:
+        return
+    oauth_script = os.path.join(repo_root, "tools", "oauth_install.py")
+    if not os.path.isfile(oauth_script):
+        return
+    print(
+        "MayringCoder bootstrap: opening browser for hook JWT (OAuth PKCE)",
+        file=sys.stderr,
+    )
+    try:
+        subprocess.run(
+            [sys.executable, oauth_script, "--jwt-file", JWT_FILE],
+            check=True,
+            timeout=180,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        print(
+            f"MayringCoder bootstrap: JWT setup skipped — run manually: python3 {oauth_script}",
+            file=sys.stderr,
+        )
+
+
+def _bootstrap_if_needed() -> None:
+    plugin_root = _plugin_root()
+    repo_root = _repo_root(plugin_root)
+    _ensure_venv(plugin_root, repo_root)
+    _ensure_jwt(repo_root)
 
 
 def _load_token() -> str:
     token = os.getenv("MCP_SERVICE_TOKEN", "")
     if token:
         return token
+    try:
+        with open(JWT_FILE) as f:
+            content = f.read().strip()
+            if content:
+                return content
+    except OSError:
+        pass
     for env_file in [
         os.path.expanduser("~/app.linn.games/.env.mayring"),
         os.path.expanduser("~/.env.mayring"),
@@ -38,7 +139,6 @@ def _load_token() -> str:
 
 
 def _latest_plan_context() -> str:
-    """Return the Context section (or first chunk) of the most-recent plan file."""
     try:
         files = glob.glob(os.path.join(PLANS_DIR, "*.md"))
         if not files:
@@ -46,10 +146,8 @@ def _latest_plan_context() -> str:
         latest = max(files, key=os.path.getmtime)
         with open(latest) as f:
             content = f.read()
-        # Prefer the dedicated "## Context" block when present
         if "## Context" in content:
             after = content.split("## Context", 1)[1]
-            # Stop at next H2 to keep it focused
             if "\n## " in after:
                 after = after.split("\n## ", 1)[0]
             return after.strip()[:TASK_CONTEXT_BUDGET]
@@ -58,48 +156,52 @@ def _latest_plan_context() -> str:
         return ""
 
 
-payload = json.loads(sys.stdin.read() or "{}")
-token = _load_token()
-if not token:
-    sys.exit(0)
+def _inject_memory(payload: dict) -> None:
+    token = _load_token()
+    if not token:
+        return
 
-api = os.getenv("MAYRING_API_URL", "https://mcp.linn.games").rstrip("/")
+    api = os.getenv("MAYRING_API_URL", "https://mcp.linn.games").rstrip("/")
+    initial_message = (
+        payload.get("message")
+        or payload.get("prompt")
+        or payload.get("transcript", [{}])[0].get("content", "")
+        or "session start"
+    )
+    body_dict: dict = {
+        "query": str(initial_message)[:300],
+        "top_k": 5,
+        "include_text": True,
+        "char_budget": 3000,
+    }
+    task_context = _latest_plan_context()
+    if task_context:
+        body_dict["task_context"] = task_context
 
-initial_message = (
-    payload.get("message")
-    or payload.get("prompt")
-    or payload.get("transcript", [{}])[0].get("content", "")
-    or "session start"
-)
-query = str(initial_message)[:300]
+    body = json.dumps(body_dict).encode()
+    req = urllib.request.Request(
+        f"{api}/search",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=8) as resp:
+            result = json.loads(resp.read())
+        context = result.get("prompt_context", "").strip()
+        if context:
+            print(
+                f"## Automatisch injizierter Memory-Kontext\n\n{context}\n\n"
+                "⚠️  PFLICHT: Gib am Ende jedes Tasks Feedback via "
+                "`mcp__claude_ai_Memory__feedback` für jeden genutzten Chunk."
+            )
+    except Exception:
+        pass
 
-body_dict = {
-    "query": query,
-    "top_k": 5,
-    "include_text": True,
-    "char_budget": 3000,
-}
-task_context = _latest_plan_context()
-if task_context:
-    body_dict["task_context"] = task_context
 
-body = json.dumps(body_dict).encode()
-
-req = urllib.request.Request(
-    f"{api}/search",
-    data=body,
-    headers={
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-    },
-)
-try:
-    with urllib.request.urlopen(req, timeout=8) as resp:
-        result = json.loads(resp.read())
-    context = result.get("prompt_context", "").strip()
-    if context:
-        print(f"## Automatisch injizierter Memory-Kontext\n\n{context}\n\n"
-              "⚠️  PFLICHT: Gib am Ende jedes Tasks Feedback via "
-              "`mcp__claude_ai_Memory__feedback` für jeden genutzten Chunk.")
-except Exception:
-    pass
+if __name__ == "__main__":
+    _bootstrap_if_needed()
+    payload = json.loads(sys.stdin.read() or "{}")
+    _inject_memory(payload)

--- a/claude-plugin/install.sh
+++ b/claude-plugin/install.sh
@@ -35,7 +35,7 @@ echo "Installing client dependencies..."
 JWT_FILE="$HOME/.config/mayring/hook.jwt"
 if [ ! -s "$JWT_FILE" ]; then
     echo "Setting up Mayring hook JWT (OAuth PKCE)..."
-    python3 "$REPO_ROOT/tools/oauth_install.py" --jwt-file "$JWT_FILE"
+    "$VENV_DIR/bin/python" "$REPO_ROOT/tools/oauth_install.py" --jwt-file "$JWT_FILE"
 else
     echo "JWT already present: $JWT_FILE"
 fi

--- a/claude-plugin/install.sh
+++ b/claude-plugin/install.sh
@@ -1,207 +1,43 @@
 #!/bin/bash
-set -e
+# Local-dev helper for MayringCoder.
+#
+# The supported install path is the Claude Code marketplace:
+#   /plugin marketplace add Nileneb/MayringCoder
+#   /plugin install mayring-coder@MayringCoder
+#
+# After enabling the plugin, the SessionStart hook (claude-plugin/hooks/session_start.py)
+# bootstraps the venv and the OAuth JWT on the next Claude session — no manual
+# script needed.
+#
+# This script exists for the rare case where you want to set up the plugin
+# manually against a local clone of the repo (e.g. while developing the plugin
+# itself). It does the same work the SessionStart hook does, eagerly.
+set -euo pipefail
 
-# ── Repo-Erkennung ───────────────────────────────────────────────────────────
-# Vier Fälle:
-#   1. Klassisch: Script aus geklontem Repo (../src/api/local_mcp.py vorhanden)
-#   2. Marketplace-Install: Script läuft aus ~/.claude/plugins/marketplaces/.../mayring-coder/
-#      und Repo liegt schon unter $HOME/Desktop/MayringCoder (Marketplace-Konvention)
-#   3. Default-Dir: Repo bereits unter ~/.claude/mayringcoder/ vorhanden
-#   4. Standalone-Download: Repo wird automatisch nach ~/.claude/mayringcoder/ geklont
 _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-_DEFAULT_DIR="$HOME/.claude/mayringcoder"
-_DESKTOP_DIR="$HOME/Desktop/MayringCoder"
+REPO_ROOT="$(cd "$_SCRIPT_DIR/.." && pwd)"
 
-if [ -f "$_SCRIPT_DIR/../src/api/local_mcp.py" ]; then
-    # Klassisch: aus geklontem Repo
-    MAYRING_DIR="$(cd "$_SCRIPT_DIR/.." && pwd)"
-elif [ -f "$_DESKTOP_DIR/src/api/local_mcp.py" ]; then
-    # Marketplace-Install: claude-plugin/.mcp.json setzt cwd auf $HOME/Desktop/MayringCoder
-    MAYRING_DIR="$_DESKTOP_DIR"
-elif [ -f "$_DEFAULT_DIR/src/api/local_mcp.py" ]; then
-    # Repo bereits vorhanden
-    MAYRING_DIR="$_DEFAULT_DIR"
-else
-    # Standalone: nur Client-Dateien via sparse checkout holen (kein Server-Code, kein whisper/gradio).
-    # Pi-Agent (run_task_with_memory) braucht zusätzlich: model_router, ollama_client,
-    # llm/ (LLMEndpoint), analysis/ (analyzer._parse_llm_json) und config/ (model_routes.yaml).
-    echo "Klone MayringCoder (client-only, sparse) nach $_DEFAULT_DIR..."
-    git clone --filter=blob:none --no-checkout https://github.com/Nileneb/MayringCoder "$_DEFAULT_DIR"
-    git -C "$_DEFAULT_DIR" sparse-checkout init --no-cone
-    git -C "$_DEFAULT_DIR" sparse-checkout set \
-        '/.claude-plugin/' \
-        '/claude-plugin/' \
-        '/config/' \
-        '/src/__init__.py' \
-        '/src/config.py' \
-        '/src/model_router.py' \
-        '/src/ollama_client.py' \
-        '/src/agents/' \
-        '/src/analysis/' \
-        '/src/api/__init__.py' \
-        '/src/api/local_mcp.py' \
-        '/src/api/mcp_agent_tools.py' \
-        '/src/api/mcp_auth.py' \
-        '/src/api/dependencies.py' \
-        '/src/api/memory_service.py' \
-        '/src/api/jwt_auth.py' \
-        '/src/llm/' \
-        '/src/memory/' \
-        '/tools/memory_sync.py' \
-        '/tools/postcompact_hook.py' \
-        '/tools/oauth_install.py' \
-        '/requirements-client.txt'
-    git -C "$_DEFAULT_DIR" checkout
-    MAYRING_DIR="$_DEFAULT_DIR"
+if [ ! -f "$REPO_ROOT/src/api/local_mcp.py" ]; then
+    echo "Error: $REPO_ROOT does not look like a MayringCoder clone (no src/api/local_mcp.py)." >&2
+    echo "Use the marketplace install instead: /plugin marketplace add Nileneb/MayringCoder" >&2
+    exit 1
 fi
 
-PLUGIN_DIR="$MAYRING_DIR/claude-plugin"
-TOOLS_DIR="$MAYRING_DIR/tools"
-
-# ── Plugin-Dateien kopieren ──────────────────────────────────────────────────
-DEST="$HOME/.claude/plugins/mayring-coder"
-mkdir -p "$DEST"
-cp -r "$PLUGIN_DIR/." "$DEST/"
-echo "Plugin installiert: $DEST"
-
-# ── Python-Umgebung einrichten ───────────────────────────────────────────────
-# venv liegt unter ~/.claude/plugins/mayring-coder/.venv (co-located mit Plugin).
-# Überschreibbar via MAYRING_VENV_PYTHON.
-VENV_PYTHON="${MAYRING_VENV_PYTHON:-"$DEST/.venv/bin/python"}"
-VENV_DIR="$(dirname "$(dirname "$VENV_PYTHON")")"
-
-if [ ! -f "$VENV_PYTHON" ]; then
-    echo "Erstelle virtuelle Umgebung: $VENV_DIR"
+VENV_DIR="$_SCRIPT_DIR/.venv"
+if [ ! -f "$VENV_DIR/bin/python" ]; then
+    echo "Creating venv: $VENV_DIR"
     python3 -m venv "$VENV_DIR"
 fi
 
-if [ -f "$MAYRING_DIR/requirements-client.txt" ]; then
-    echo "Installiere Client-Abhängigkeiten aus requirements-client.txt..."
-    "$VENV_DIR/bin/pip" install -q -r "$MAYRING_DIR/requirements-client.txt"
-else
-    echo "Installiere Abhängigkeiten aus requirements.txt..."
-    "$VENV_DIR/bin/pip" install -q -r "$MAYRING_DIR/requirements.txt"
-fi
-echo "Abhängigkeiten installiert."
+echo "Installing client dependencies..."
+"$VENV_DIR/bin/pip" install -q -r "$REPO_ROOT/requirements-client.txt"
 
-# ── Skills in superpowers-Cache kopieren ─────────────────────────────────────
-SP_SKILLS="$HOME/.claude/plugins/cache/claude-plugins-official/superpowers"
-SP_VERSION=$(ls "$SP_SKILLS" 2>/dev/null | sort -V | tail -1)
-if [ -n "$SP_VERSION" ]; then
-    SKILL_DEST="$SP_SKILLS/$SP_VERSION/skills"
-    for skill_dir in "$PLUGIN_DIR/skills"/*/; do
-        skill_name=$(basename "$skill_dir")
-        mkdir -p "$SKILL_DEST/$skill_name"
-        cp "$skill_dir/SKILL.md" "$SKILL_DEST/$skill_name/SKILL.md"
-        echo "Skill installiert: $skill_name → $SKILL_DEST/$skill_name"
-    done
+JWT_FILE="$HOME/.config/mayring/hook.jwt"
+if [ ! -s "$JWT_FILE" ]; then
+    echo "Setting up Mayring hook JWT (OAuth PKCE)..."
+    python3 "$REPO_ROOT/tools/oauth_install.py" --jwt-file "$JWT_FILE"
 else
-    echo "Warnung: superpowers-Plugin nicht gefunden — Skills nicht installiert"
+    echo "JWT already present: $JWT_FILE"
 fi
 
-# ── Hooks in ~/.claude/settings.json eintragen ──────────────────────────────
-SETTINGS="$HOME/.claude/settings.json"
-HOOK_SCRIPT="$DEST/hooks/start_watcher.py"
-COMPACT_SCRIPT="$TOOLS_DIR/postcompact_hook.py"
-STOP_SCRIPT="$DEST/hooks/stop_hook.py"
-SYNC_SCRIPT="$TOOLS_DIR/memory_sync.py"
-
-python3 - <<PYEOF
-import json, os
-
-settings_path = os.path.expanduser("$SETTINGS")
-hook_script = "$HOOK_SCRIPT"
-compact_script = "$COMPACT_SCRIPT"
-stop_script = "$STOP_SCRIPT"
-sync_script = "$SYNC_SCRIPT"
-
-try:
-    with open(settings_path) as f:
-        cfg = json.load(f)
-except (FileNotFoundError, json.JSONDecodeError):
-    cfg = {}
-
-hooks = cfg.setdefault("hooks", {})
-
-# UserPromptSubmit — Watcher starten
-hooks.setdefault("UserPromptSubmit", [])
-if not any(any(h.get("command", "").endswith("start_watcher.py") for h in e.get("hooks", [])) for e in hooks["UserPromptSubmit"]):
-    hooks["UserPromptSubmit"].append({"matcher": "", "hooks": [{"type": "command", "command": f"python3 {hook_script}"}]})
-    print("Hook hinzugefügt: UserPromptSubmit → start_watcher.py")
-else:
-    print("Hook bereits vorhanden: UserPromptSubmit → start_watcher.py")
-
-# UserPromptSubmit — memory_sync
-if not any(any(h.get("command", "").endswith("memory_sync.py") for h in e.get("hooks", [])) for e in hooks["UserPromptSubmit"]):
-    hooks["UserPromptSubmit"].append({"matcher": "", "hooks": [{"type": "command", "command": f"python3 {sync_script}"}]})
-    print("Hook hinzugefügt: UserPromptSubmit → memory_sync.py")
-else:
-    print("Hook bereits vorhanden: UserPromptSubmit → memory_sync.py")
-
-# PostCompact — Summary ingesten
-hooks.setdefault("PostCompact", [])
-if not any(any(h.get("command", "").endswith("postcompact_hook.py") for h in e.get("hooks", [])) for e in hooks["PostCompact"]):
-    hooks["PostCompact"].append({"matcher": "", "hooks": [{"type": "command", "command": f"python3 {compact_script}"}]})
-    print("Hook hinzugefügt: PostCompact → postcompact_hook.py")
-else:
-    print("Hook bereits vorhanden: PostCompact → postcompact_hook.py")
-
-# Stop — unbeurteilte Chunks → neutral
-hooks.setdefault("Stop", [])
-if not any(any(h.get("command", "").endswith("stop_hook.py") for h in e.get("hooks", [])) for e in hooks["Stop"]):
-    hooks["Stop"].append({"matcher": "", "hooks": [{"type": "command", "command": f"python3 {stop_script}"}]})
-    print("Hook hinzugefügt: Stop → stop_hook.py")
-else:
-    print("Hook bereits vorhanden: Stop → stop_hook.py")
-
-with open(settings_path, "w") as f:
-    json.dump(cfg, f, indent=2)
-    f.write("\n")
-PYEOF
-
-# ── MCP-Server in ~/.claude/.mcp.json eintragen ──────────────────────────────
-# command: venv-Python aus Plugin-Verzeichnis
-# cwd: MayringCoder-Repo (src/api/local_mcp.py liegt dort)
-MCP_JSON="$HOME/.claude/.mcp.json"
-python3 - <<MCPEOF
-import json, os
-
-mcp_json_path = os.path.expanduser("$MCP_JSON")
-mayring_dir = "$MAYRING_DIR"
-venv_python = "$VENV_PYTHON"
-
-try:
-    with open(mcp_json_path) as f:
-        cfg = json.load(f)
-except (FileNotFoundError, json.JSONDecodeError):
-    cfg = {}
-
-mcp_servers = cfg.setdefault("mcpServers", {})
-if "memory-agents" not in mcp_servers:
-    mcp_servers["memory-agents"] = {
-        "command": venv_python,
-        "args": ["-m", "src.api.local_mcp"],
-        "cwd": mayring_dir,
-        "env": {"PYTHONPATH": mayring_dir},
-    }
-    print(f"MCP-Server hinzugefügt: memory-agents (cwd={mayring_dir})")
-else:
-    print("MCP-Server bereits vorhanden: memory-agents")
-
-with open(mcp_json_path, "w") as f:
-    json.dump(cfg, f, indent=2)
-    f.write("\n")
-MCPEOF
-
-# ── Auth-Token einrichten via OAuth PKCE ─────────────────────────────────────
-HOOK_JWT="$HOME/.config/mayring/hook.jwt"
-OAUTH_SCRIPT="$TOOLS_DIR/oauth_install.py"
-echo ""
-if [ -f "$HOOK_JWT" ] && [ -s "$HOOK_JWT" ]; then
-    echo "Token bereits vorhanden: $HOOK_JWT"
-else
-    echo "=== Mayring JWT einrichten (OAuth-Login) ==="
-    python3 "$OAUTH_SCRIPT" --jwt-file "$HOOK_JWT"
-fi
-echo ""
-echo "Watcher-Log: ~/.cache/mayringcoder/watcher.log"
+echo "Done. Restart Claude Code to load the plugin."

--- a/tools/oauth_install.py
+++ b/tools/oauth_install.py
@@ -126,8 +126,8 @@ def main() -> None:
     print(f"Login-URL (falls Browser nicht öffnet): {auth_url}", file=sys.stderr)
     try:
         webbrowser.open(auth_url)
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"webbrowser.open() fehlgeschlagen ({e}) — bitte URL manuell öffnen.", file=sys.stderr)
     print(f"Warte auf Login (max {_TIMEOUT_SECONDS}s) …")
 
     if not server_done.wait(timeout=_TIMEOUT_SECONDS):

--- a/tools/oauth_install.py
+++ b/tools/oauth_install.py
@@ -123,8 +123,11 @@ def main() -> None:
         "code_challenge_method": "S256",
     })
 
-    print("Browser wird geöffnet …")
-    webbrowser.open(auth_url)
+    print(f"Login-URL (falls Browser nicht öffnet): {auth_url}", file=sys.stderr)
+    try:
+        webbrowser.open(auth_url)
+    except Exception:
+        pass
     print(f"Warte auf Login (max {_TIMEOUT_SECONDS}s) …")
 
     if not server_done.wait(timeout=_TIMEOUT_SECONDS):


### PR DESCRIPTION
## Summary
- Marketplace install is now a single `/plugin marketplace add Nileneb/MayringCoder` — `SessionStart` hook bootstraps venv + OAuth JWT on first run, idempotently.
- `claude-plugin/.mcp.json` uses portable `${CLAUDE_PLUGIN_ROOT}/..` (no more hardcoded `~/Desktop/MayringCoder`).
- `claude-plugin/install.sh` collapses from 207 → 41 lines (local-dev helper only); settings.json + ~/.claude/.mcp.json patching is gone (plugin manifest owns hooks + MCP-server now).

## Why
On the user's PC, both standalone (`~/.claude/plugins/mayring-coder/`) and marketplace (`~/.claude/plugins/marketplaces/MayringCoder/`) installs coexisted with broken/missing venvs. Three venv expectations collided. This PR collapses everything to one source of truth (Marketplace), with the hook handling the bootstrap.

## Test plan
- [x] `pytest tests/` — 1084/1086 pass; 2 pre-existing failures (also fail on master, unrelated):
  - `tests/test_context_improvements.py::TestIndexOverviewFunctionDocs`
  - `tests/test_memory_ingest.py::TestIngestConversationSummary::test_chunks_are_produced`
- [x] Fresh venv built from `requirements-client.txt`; `from src.api.mcp_agent_tools import register_agent_tools` runs cleanly.
- [ ] Smoke test on the user's PC: after merge + `/plugin marketplace update MayringCoder`, the SessionStart hook bootstraps the venv and JWT, `/mcp` lists `memory-agents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify the Claude Code plugin marketplace installation by moving venv and JWT bootstrap into the SessionStart hook and simplifying local development setup.

New Features:
- Automatically bootstrap the plugin venv and OAuth JWT on session start when missing, using the marketplace-installed plugin layout.

Enhancements:
- Convert the SessionStart hook into an idempotent bootstrap plus memory-context injector with better repo and venv discovery.
- Simplify claude-plugin/install.sh into a local-development helper that only creates the venv and JWT for a checked-out repo.
- Update README instructions to reflect the marketplace-first install flow and provide a minimal local development setup.
- Make the OAuth browser-login helper more robust by printing the login URL and tolerating browser launch failures.