### PR TITLE
feat(wiki): IGIO axis classifier — content layer over structural Wiki 2.0

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -126,6 +126,71 @@ def _cmd_generate_wiki(args: argparse.Namespace, repo_url: str, ollama_url: str,
         print(f"Wiki 2.0 update skipped: {_e}")
 
 
+def _cmd_classify_igio(args: argparse.Namespace, ollama_url: str, model: str) -> None:
+    """Backfill IGIO axes for unclassified active chunks.
+
+    Reads `chunks` rows where `igio_axis = ''` and `is_active = 1`, runs
+    `classify_chunk()` per row, persists the verdict back to the row when the
+    confidence clears `--igio-min-confidence`.
+    """
+    from src.config import CACHE_DIR
+    from src.memory.store import init_memory_db
+    from src.wiki_v2.igio_classifier import classify_chunk, now_iso
+
+    if not model:
+        print("Fehler: --classify-igio braucht ein --model.")
+        return
+
+    limit = max(1, int(getattr(args, "igio_limit", 200)))
+    threshold = float(getattr(args, "igio_min_confidence", 0.5))
+    workspace = getattr(args, "workspace_id", None)
+
+    conn = init_memory_db(CACHE_DIR / "memory.db")
+    where = ["igio_axis = ''", "is_active = 1", "text != ''"]
+    params: list = []
+    if workspace:
+        where.append("workspace_id = ?")
+        params.append(workspace)
+    sql = (
+        f"SELECT chunk_id, text, category_labels FROM chunks "
+        f"WHERE {' AND '.join(where)} "
+        f"ORDER BY created_at DESC LIMIT ?"
+    )
+    params.append(limit)
+    rows = conn.execute(sql, tuple(params)).fetchall()
+    if not rows:
+        print(f"[igio] Nichts zu klassifizieren (workspace={workspace or 'all'}).")
+        conn.close()
+        return
+
+    print(f"[igio] {len(rows)} Chunks → Klassifikator (model={model})")
+    counts: dict[str, int] = {a: 0 for a in ("issue", "goal", "intervention", "outcome", "")}
+    persisted = 0
+    for r in rows:
+        cid = r["chunk_id"] if hasattr(r, "__getitem__") else r[0]
+        text = r["text"] if hasattr(r, "__getitem__") else r[1]
+        cats_raw = r["category_labels"] if hasattr(r, "__getitem__") else r[2]
+        cats = [c for c in (cats_raw or "").split(",") if c]
+        verdict = classify_chunk(text, cats, ollama_url=ollama_url, model=model)
+        counts[verdict.axis] = counts.get(verdict.axis, 0) + 1
+        if verdict.axis and verdict.confidence >= threshold:
+            conn.execute(
+                "UPDATE chunks SET igio_axis = ?, igio_confidence = ?, "
+                "igio_classified_at = ? WHERE chunk_id = ?",
+                (verdict.axis, verdict.confidence, now_iso(), cid),
+            )
+            persisted += 1
+
+    conn.commit()
+    conn.close()
+    print(
+        f"[igio] persisted={persisted}/{len(rows)} | "
+        f"issue={counts.get('issue',0)} goal={counts.get('goal',0)} "
+        f"intervention={counts.get('intervention',0)} outcome={counts.get('outcome',0)} "
+        f"unclassified={counts.get('',0)}"
+    )
+
+
 def _cmd_wiki_history(args: argparse.Namespace) -> None:
     import sqlite3 as _sq
     from src.wiki_v2.history import WikiHistory
@@ -250,6 +315,7 @@ def main() -> None:
         args.mode in ("analyze", "overview")
         or (args.mode == "turbulence" and args.llm)
         or args.resolve_model_only
+        or getattr(args, "classify_igio", False)
     )
     model = resolve_model(ollama_url, args.model, None) if _needs_llm else (args.model or "")
 
@@ -281,6 +347,7 @@ def main() -> None:
         set_batch_delay(args.batch_delay)
 
     if not repo_url and not (args.ingest_issues or args.ingest_images or args.pi_task or args.generate_wiki
+                              or getattr(args, "classify_igio", False)
                               or getattr(args, "generate_training_data", None)):
         print("Fehler: Kein Repository angegeben. Nutze --repo oder setze GITHUB_REPO in .env")
         sys.exit(1)
@@ -333,6 +400,7 @@ def main() -> None:
     # Pipeline commands
     if args.populate_memory:                           run_populate_memory(args, repo_url, ollama_url, model); sys.exit(0)
     if args.generate_wiki:                             _cmd_generate_wiki(args, repo_url, ollama_url, model);  sys.exit(0)
+    if getattr(args, "classify_igio", False):          _cmd_classify_igio(args, ollama_url, model);            sys.exit(0)
     if getattr(args, "wiki_history", False):           _cmd_wiki_history(args);                               sys.exit(0)
     if getattr(args, "wiki_team_activity", False):     _cmd_wiki_team_activity(args);                         sys.exit(0)
     if getattr(args, "wiki_history_cleanup", None) is not None: _cmd_wiki_history_cleanup(args);              sys.exit(0)

--- a/src/cli_args.py
+++ b/src/cli_args.py
@@ -84,6 +84,12 @@ def parse_args() -> argparse.Namespace:
     p.set_defaults(memory_categorize=True)
     p.add_argument("--generate-wiki", action="store_true",
                    help="Verknüpfungswiki aus Overview-Cache + Memory erzeugen (cache/<slug>_wiki.md)")
+    p.add_argument("--classify-igio", action="store_true",
+                   help="Backfill: IGIO-Achse (issue/goal/intervention/outcome) für unklassifizierte Chunks setzen.")
+    p.add_argument("--igio-limit", type=int, default=200, metavar="N",
+                   help="Max. Anzahl Chunks pro --classify-igio Lauf (Standard: 200).")
+    p.add_argument("--igio-min-confidence", type=float, default=0.5, metavar="X",
+                   help="Verdicts unter dieser Konfidenz werden als unklassifiziert behandelt (Standard: 0.5).")
     p.add_argument("--rebuild-transitions", action="store_true",
                    help="Scan conversation-summaries + rebuild Markov topic-transition matrix")
     p.add_argument("--wiki-type", choices=["code", "paper"], default="code",

--- a/src/memory/schema.py
+++ b/src/memory/schema.py
@@ -85,6 +85,9 @@ class Chunk:
     dedup_key: str = ""           # sha256 of normalized text (for near-dedup)
     category_source: str = ""     # "deductive"|"inductive"|"hybrid"|"fallback"|"manual"|""
     category_confidence: float = 0.0
+    igio_axis: str = ""           # "" | "issue" | "goal" | "intervention" | "outcome"
+    igio_confidence: float = 0.0
+    igio_classified_at: str = ""
     created_at: str = field(default_factory=lambda: _now_iso())
     workspace_id: str = "default"
     superseded_by: str | None = None
@@ -119,6 +122,9 @@ class Chunk:
             "dedup_key": self.dedup_key,
             "category_source": self.category_source,
             "category_confidence": self.category_confidence,
+            "igio_axis": self.igio_axis,
+            "igio_confidence": self.igio_confidence,
+            "igio_classified_at": self.igio_classified_at,
             "created_at": self.created_at,
             "superseded_by": self.superseded_by,
             "is_active": self.is_active,

--- a/src/memory/store.py
+++ b/src/memory/store.py
@@ -113,6 +113,9 @@ def _migrate_schema(conn: DBAdapter) -> None:
             ("workspace_id", "TEXT NOT NULL DEFAULT 'default'"),
             ("category_source", "TEXT NOT NULL DEFAULT ''"),
             ("category_confidence", "REAL NOT NULL DEFAULT 0.0"),
+            ("igio_axis", "TEXT NOT NULL DEFAULT ''"),
+            ("igio_confidence", "REAL NOT NULL DEFAULT 0.0"),
+            ("igio_classified_at", "TEXT NOT NULL DEFAULT ''"),
         ],
     }
     for table, columns in migrations.items():

--- a/src/wiki_v2/igio_classifier.py
+++ b/src/wiki_v2/igio_classifier.py
@@ -1,0 +1,187 @@
+"""IGIO axis classifier.
+
+Maps each chunk to one of four content axes derived from clinical/Mayring
+research practice:
+
+    - issue        — what problem or question is being addressed
+    - goal         — what is the desired state or aim
+    - intervention — what action, change, or implementation is being made
+    - outcome      — what result, effect, or evidence has been observed
+
+This is *orthogonal* to the existing Mayring `category_labels` (api/data_access/
+domain/...): a chunk in `data_access` can be an `intervention` (change to a
+repository) or an `outcome` (test result). The two dimensions are stored
+independently on the same `chunks` row.
+
+The classifier is LLM-only on purpose — accuracy of the IGIO axis is more
+load-bearing than its compute cost (a misclassified `outcome` pollutes the
+context-injection that the model sees on later sessions). Heuristic shortcuts
+exist in `_FAST_HINTS` only to skip the LLM round-trip for unambiguous cases
+that show up at high volume (e.g. test-result chunks).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable
+
+from src.ollama_client import generate
+
+logger = logging.getLogger(__name__)
+
+
+VALID_AXES: tuple[str, ...] = ("issue", "goal", "intervention", "outcome")
+
+
+@dataclass(frozen=True)
+class IgioVerdict:
+    axis: str          # one of VALID_AXES, or "" for "could not classify"
+    confidence: float  # 0.0 .. 1.0
+    rationale: str
+
+
+_FAST_HINTS: tuple[tuple[re.Pattern, str, float], ...] = (
+    # Test results / pytest outputs → outcome
+    (re.compile(r"\b(\d+\s+passed|\d+\s+failed|tests? grün|tests? red)\b", re.I),
+     "outcome", 0.92),
+    # Stack traces / explicit bug reports → issue
+    (re.compile(r"\bTraceback \(most recent call last\)", re.I),
+     "issue", 0.95),
+    (re.compile(r"\b(?:bug|broken|regression|TODO|FIXME)\b|\bfix(?:e[ds])?:", re.I),
+     "issue", 0.78),
+    # Plan/intervention markers
+    (re.compile(r"^##?\s*Plan\b|\bImplemented\b|\brefactor(?:ed|ing)\b", re.I | re.M),
+     "intervention", 0.75),
+)
+
+
+def _fast_classify(text: str) -> IgioVerdict | None:
+    for pattern, axis, conf in _FAST_HINTS:
+        if pattern.search(text):
+            return IgioVerdict(axis=axis, confidence=conf,
+                               rationale=f"keyword:{pattern.pattern[:32]}")
+    return None
+
+
+_PROMPT_SYSTEM = """You classify text snippets into exactly one of four content
+axes. Respond with strict JSON only — no prose, no markdown.
+
+Axes:
+  issue        — surfaces a problem, bug, missing piece, or open question
+  goal         — names a desired state, target, or success criterion
+  intervention — describes a change, implementation, refactor, or action taken
+  outcome      — reports a result, effect, test outcome, or measurable evidence
+
+If the snippet does not fit any axis, return axis="" with low confidence.
+
+Output schema:
+  {"axis": "<one of: issue|goal|intervention|outcome|>", "confidence": <0.0-1.0>, "rationale": "<one short sentence>"}
+"""
+
+
+def _build_user_prompt(text: str, category_labels: list[str]) -> str:
+    cats = ", ".join(category_labels) if category_labels else "(none)"
+    snippet = text if len(text) <= 1500 else text[:1500] + "…"
+    return (
+        f"Mayring categories already assigned: {cats}\n\n"
+        f"Snippet:\n```\n{snippet}\n```\n\n"
+        "Respond with JSON only."
+    )
+
+
+_JSON_BLOCK_RE = re.compile(r"\{[^{}]*\}", re.S)
+
+
+def _parse_verdict(raw: str) -> IgioVerdict | None:
+    raw = raw.strip()
+    if not raw:
+        return None
+    candidates = [raw]
+    m = _JSON_BLOCK_RE.search(raw)
+    if m and m.group(0) != raw:
+        candidates.append(m.group(0))
+    for cand in candidates:
+        try:
+            obj = json.loads(cand)
+        except json.JSONDecodeError:
+            continue
+        axis = str(obj.get("axis", "")).strip().lower()
+        if axis and axis not in VALID_AXES:
+            continue
+        try:
+            conf = float(obj.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            conf = 0.0
+        rationale = str(obj.get("rationale", ""))[:200]
+        return IgioVerdict(axis=axis, confidence=max(0.0, min(1.0, conf)),
+                           rationale=rationale)
+    return None
+
+
+def classify_chunk(
+    text: str,
+    category_labels: list[str] | None = None,
+    *,
+    ollama_url: str,
+    model: str,
+    timeout: float = 30.0,
+) -> IgioVerdict:
+    """Classify a single chunk into an IGIO axis.
+
+    Returns a verdict with axis="" and confidence=0.0 when the LLM call fails
+    or returns malformed output (the caller should leave the chunk unclassified
+    rather than persist a bad label).
+    """
+    if not text.strip():
+        return IgioVerdict(axis="", confidence=0.0, rationale="empty text")
+
+    fast = _fast_classify(text)
+    if fast is not None:
+        return fast
+
+    prompt = _build_user_prompt(text, category_labels or [])
+    try:
+        raw = generate(
+            ollama_url, model, prompt,
+            system=_PROMPT_SYSTEM,
+            stream=False,
+            timeout=timeout,
+            max_retries=1,
+        )
+    except Exception as e:
+        logger.warning("igio classify: LLM call failed (%s)", e)
+        return IgioVerdict(axis="", confidence=0.0, rationale=f"llm_error: {e}")
+
+    verdict = _parse_verdict(raw)
+    if verdict is None:
+        logger.warning("igio classify: could not parse LLM output: %r", raw[:120])
+        return IgioVerdict(axis="", confidence=0.0, rationale="parse_error")
+    return verdict
+
+
+def classify_batch(
+    chunks: Iterable[tuple[str, str, list[str]]],
+    *,
+    ollama_url: str,
+    model: str,
+    timeout: float = 30.0,
+) -> list[tuple[str, IgioVerdict]]:
+    """Classify a batch of (chunk_id, text, category_labels) tuples.
+
+    Returns a list of (chunk_id, verdict) — order preserved. The function does
+    not persist; callers wire the verdicts into `chunks.igio_*` themselves so
+    the persistence path stays testable in isolation.
+    """
+    out: list[tuple[str, IgioVerdict]] = []
+    for chunk_id, text, cats in chunks:
+        v = classify_chunk(text, cats, ollama_url=ollama_url, model=model, timeout=timeout)
+        out.append((chunk_id, v))
+    return out
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/tests/test_igio_classifier.py
+++ b/tests/test_igio_classifier.py
@@ -1,0 +1,191 @@
+"""Tests for IGIO axis classifier (no Ollama dependency).
+
+Covers:
+- Fast keyword shortcuts (no LLM call)
+- LLM JSON parsing happy path
+- LLM error / malformed output → empty verdict
+- Schema migration is idempotent on existing memory.db rows
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.wiki_v2.igio_classifier import (
+    VALID_AXES,
+    IgioVerdict,
+    _fast_classify,
+    _parse_verdict,
+    classify_chunk,
+)
+
+
+# ----- Fast hints -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,axis",
+    [
+        ("============ 142 passed in 3.41s ============", "outcome"),
+        ("Tests grün auf master", "outcome"),
+        ('Traceback (most recent call last):\n  File "x.py"', "issue"),
+        ("BUG: token expires before refresh runs", "issue"),
+        ("## Plan\n\n- Step 1: ...", "intervention"),
+    ],
+)
+def test_fast_classify_known_phrases(text: str, axis: str) -> None:
+    v = _fast_classify(text)
+    assert v is not None, f"expected fast hit for {text!r}"
+    assert v.axis == axis
+    assert v.confidence >= 0.7
+
+
+def test_fast_classify_misses_neutral_text() -> None:
+    assert _fast_classify("The user clicked the button to log in.") is None
+
+
+# ----- JSON parser ----------------------------------------------------------
+
+
+def test_parse_verdict_strict_json() -> None:
+    raw = json.dumps({"axis": "outcome", "confidence": 0.83, "rationale": "tests passed"})
+    v = _parse_verdict(raw)
+    assert v == IgioVerdict(axis="outcome", confidence=0.83, rationale="tests passed")
+
+
+def test_parse_verdict_extracts_embedded_json() -> None:
+    raw = (
+        'Sure, here you go:\n'
+        '{"axis": "intervention", "confidence": 0.7, "rationale": "refactor"}'
+        '\nBest regards.'
+    )
+    v = _parse_verdict(raw)
+    assert v is not None and v.axis == "intervention"
+    assert v.confidence == pytest.approx(0.7)
+
+
+def test_parse_verdict_rejects_invalid_axis() -> None:
+    raw = json.dumps({"axis": "improvement", "confidence": 0.9, "rationale": "x"})
+    assert _parse_verdict(raw) is None
+
+
+def test_parse_verdict_clamps_confidence() -> None:
+    raw = json.dumps({"axis": "issue", "confidence": 1.5, "rationale": "x"})
+    v = _parse_verdict(raw)
+    assert v is not None and v.confidence == 1.0
+
+
+def test_parse_verdict_handles_empty_axis() -> None:
+    raw = json.dumps({"axis": "", "confidence": 0.1, "rationale": "uncertain"})
+    v = _parse_verdict(raw)
+    assert v is not None and v.axis == ""
+
+
+def test_parse_verdict_garbage_returns_none() -> None:
+    assert _parse_verdict("not json at all") is None
+
+
+# ----- Full classify_chunk path with mocked LLM -----------------------------
+
+
+def test_classify_chunk_uses_fast_hint_without_llm() -> None:
+    with patch("src.wiki_v2.igio_classifier.generate") as gen:
+        v = classify_chunk(
+            "BUG: login flow drops session after refresh",
+            [], ollama_url="http://x", model="m",
+        )
+    assert v.axis == "issue"
+    gen.assert_not_called()
+
+
+def test_classify_chunk_uses_llm_when_no_fast_hint() -> None:
+    with patch("src.wiki_v2.igio_classifier.generate") as gen:
+        gen.return_value = json.dumps({"axis": "goal", "confidence": 0.78, "rationale": "ok"})
+        v = classify_chunk(
+            "We aim to keep p95 latency under 200ms for the search endpoint.",
+            ["api", "performance"], ollama_url="http://x", model="m",
+        )
+    assert v.axis == "goal"
+    assert v.confidence == pytest.approx(0.78)
+    gen.assert_called_once()
+
+
+def test_classify_chunk_swallows_llm_error() -> None:
+    with patch("src.wiki_v2.igio_classifier.generate", side_effect=RuntimeError("net down")):
+        v = classify_chunk("Some neutral text.", [], ollama_url="http://x", model="m")
+    assert v.axis == ""
+    assert v.confidence == 0.0
+
+
+def test_classify_chunk_handles_malformed_llm_output() -> None:
+    with patch("src.wiki_v2.igio_classifier.generate", return_value="???"):
+        v = classify_chunk("Some neutral text.", [], ollama_url="http://x", model="m")
+    assert v.axis == ""
+    assert v.rationale == "parse_error"
+
+
+def test_classify_chunk_truncates_long_text() -> None:
+    long = "x" * 5000
+    captured: dict = {}
+
+    def _gen(_url: str, _model: str, prompt: str, **_kwargs: object) -> str:
+        captured["prompt"] = prompt
+        return json.dumps({"axis": "outcome", "confidence": 0.6, "rationale": "ok"})
+
+    with patch("src.wiki_v2.igio_classifier.generate", side_effect=_gen):
+        v = classify_chunk(long, [], ollama_url="http://x", model="m")
+    assert v.axis == "outcome"
+    # Snippet was truncated with the elision marker
+    assert "…" in captured["prompt"]
+    assert len(captured["prompt"]) < 2500
+
+
+def test_valid_axes_constant() -> None:
+    assert set(VALID_AXES) == {"issue", "goal", "intervention", "outcome"}
+
+
+# ----- Schema migration is idempotent --------------------------------------
+
+
+def test_migration_adds_igio_columns_idempotently(tmp_path: Path) -> None:
+    from src.memory.store import init_memory_db
+
+    db = tmp_path / "memory.db"
+    init_memory_db(db).close()
+    init_memory_db(db).close()  # second run must be a no-op
+
+    cols = {r[1] for r in sqlite3.connect(db).execute(
+        "PRAGMA table_info(chunks)"
+    ).fetchall()}
+    assert {"igio_axis", "igio_confidence", "igio_classified_at"} <= cols
+
+
+def test_migration_preserves_existing_data(tmp_path: Path) -> None:
+    """Running the migration on an existing memory.db must not drop rows."""
+    from src.memory.store import init_memory_db
+
+    real_db = Path(__file__).resolve().parent.parent / "cache" / "memory.db"
+    if not real_db.exists():
+        pytest.skip("no real memory.db present in this checkout")
+
+    test_db = tmp_path / "memory.db"
+    shutil.copy(real_db, test_db)
+
+    before = sqlite3.connect(test_db).execute(
+        "SELECT COUNT(*) FROM chunks"
+    ).fetchone()[0]
+
+    init_memory_db(test_db).close()
+
+    conn = sqlite3.connect(test_db)
+    after = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(chunks)").fetchall()}
+    assert before == after
+    assert {"igio_axis", "igio_confidence", "igio_classified_at"} <= cols


### PR DESCRIPTION
## Summary

Adds an orthogonal **IGIO classification** (Issue / Goal / Intervention / Outcome) to every chunk, sitting alongside the existing Mayring `category_labels` axis. A chunk in `data_access` can simultaneously be an `outcome` (test result) or `intervention` (refactor) — both axes coexist on the same row.

This is **Plan B Phase 1** of the wiki refactor. Phase 2 (Recap-Indexer) and Phase 3 (Layer-integration into `WikiContextInjector`) follow in separate PRs.

## What was actually true on disk before this PR

Real numbers from `cache/memory.db` and `cache/wiki_v2.db` on master:

| Pipeline | Real state |
|---|---|
| Memory: sources / chunks / feedback / ingestion-events | 992 / 3501 / 2683 / 4181 |
| Mayring `category_labels` filled | 756 / 3501 (~22%) |
| `categorize_error` ingestion-log entries | 424 (404 on /api/generate — separate model bug) |
| Wiki 2.0 nodes / edges / clusters / snapshots | 3 / 0 / 0 / 0 |
| Workspaces with chunks | bene-workspace (939), system (53) |

Wiki 2.0 was effectively empty. IGIO does not depend on Wiki 2.0 having data — it labels chunks directly, so it works on the corpus that actually exists.

## Schema migration (idempotent)

`src/memory/store.py::_migrate_schema` adds:
- `chunks.igio_axis             TEXT NOT NULL DEFAULT ''`
- `chunks.igio_confidence       REAL NOT NULL DEFAULT 0.0`
- `chunks.igio_classified_at    TEXT NOT NULL DEFAULT ''`

Verified on a copy of the live `cache/memory.db`: 3499 → 3499 rows preserved, three new columns present.

## Classifier — `src/wiki_v2/igio_classifier.py`

- LLM-only via Ollama `generate()`, strict JSON schema (`{axis, confidence, rationale}`).
- Embedded-JSON parser tolerates LLMs that wrap output in prose.
- Fast keyword shortcuts skip the round-trip for unambiguous high-volume cases (`Traceback` → issue, `\d+ passed` → outcome, `## Plan` → intervention).
- Failure-soft: network / parse errors return `axis=""`, callers leave the row unclassified rather than persist a bad label.

Live smoke test on 5 actual chunks via `qwen2.5-coder:7b`:
```
chk_10f09874837d | axis=      outcome conf=0.80 | def test_on_post_ingest_no_chroma_creates_node_only(tmp_path...
chk_62071a3e094b | axis=      outcome conf=1.00 | def test_on_post_analyze_stores_turbulence_tier(tmp_path):  ...
chk_d07f908e9ec1 | axis=      outcome conf=0.80 | def test_on_post_ingest_adds_node(tmp_path):     ...
chk_7a7825fe71e2 | axis= intervention conf=0.90 | def test_on_post_analyze_upserts_node(tmp_path):     ...
chk_ecc6af6c7993 | axis=      outcome conf=0.90 | def test_on_post_finding_no_crash_on_empty_text(tmp_path):  ...
```

## CLI

```
python checker.py --classify-igio --igio-limit 200 --igio-min-confidence 0.5 --model qwen2.5-coder:7b
```

Backfills chunks where `igio_axis = '' AND is_active = 1 AND text != ''`, persists verdicts that clear the confidence threshold, prints a per-axis summary.

## Test plan

- [x] 19 new unit tests pass (`tests/test_igio_classifier.py`); 1 skipped (real-DB migration test, guarded by file presence)
- [x] Idempotent migration verified on a real-data copy of `cache/memory.db`
- [x] End-to-end live classification of 5 actual chunks against local Ollama
- [ ] Merge after PR #119 (plugin bootstrap) lands, then run `--classify-igio --igio-limit 200` on master to backfill the existing 3499 unclassified chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an IGIO (issue/goal/intervention/outcome) content axis for memory chunks and provide tooling to backfill classifications using an LLM-based classifier.

New Features:
- Add IGIO axis metadata fields to chunk schema to store axis, confidence, and classification timestamp alongside existing Mayring categories.
- Implement an LLM-backed IGIO classifier with fast keyword shortcuts and JSON parsing to robustly label chunks by content role.
- Expose a CLI command to backfill IGIO classifications for unclassified active chunks with configurable limits and confidence threshold.

Enhancements:
- Extend schema migration to idempotently add IGIO columns without impacting existing data.
- Add a batch classification helper for IGIO to support future pipeline integrations.

Tests:
- Add comprehensive unit tests covering fast-path hints, LLM JSON parsing behavior, error handling, text truncation, and schema migration idempotence/preservation for the IGIO classifier.