### PR TITLE
fix(models): drop references to non-existent mayring-qwen3:2b / mayringqwen:latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ flowchart TD
 
     subgraph Stage2["Stage 2 — Analyze"]
         G[SQLite Diff\ncache/repo.db] --> H{Changed?}
-        H -- yes --> MR["Model Router\nsrc/model_router.py\nmayring_code → mayringqwen:latest\nfallback: llama3.1:8b"]
+        H -- yes --> MR["Model Router\nsrc/model_router.py\nmayring_code → mistral:7b-instruct\nfallback: qwen2.5-coder:7b"]
         MR --> I[LLM Analysis\nOllama stream]
         I --> J[JSON Parser]
         J -- fail --> K[Regex Fallback\nextractor.py]
@@ -112,7 +112,7 @@ sequenceDiagram
     Worker->>MR: resolve("mayring_code")
     MR->>Ollama: GET /api/tags (Verfügbarkeits-Check, 30s TTL)
     Ollama-->>MR: Modellliste
-    MR-->>Worker: "mayringqwen:latest"
+    MR-->>Worker: "mistral:7b-instruct"
 
     Worker->>Ollama: POST /api/generate (stream, mayring_categorize)
     Ollama-->>Worker: Token-Stream → Kategorie-Label
@@ -140,7 +140,7 @@ sequenceDiagram
 | `fetch_repo` | GitHub URL / Dateipfad | Rohdatei-Dicts via gitingest | — | Dateianzahl, Repo-Größe |
 | `split` | gitingest-Text | `[{path, content, size}]` | — | Datei-Splitgrenzen |
 | `categorize_files` | Datei-Dicts + codebook.yaml | `{category, priority}` pro Datei | — | Kategorieverteilung |
-| `analyze_files` | Dateiinhalt + Prompt | Findings-JSON | `mayring_code` → mayringqwen:latest | Ollama-Stream-Tokens |
+| `analyze_files` | Dateiinhalt + Prompt | Findings-JSON | `mayring_code` → mistral:7b-instruct | Ollama-Stream-Tokens |
 | `structural_chunk` | Quelltext | `[{chunk_text, chunk_index}]` | — | Chunk-Anzahl |
 | `mayring_categorize` | Chunk + Codebook | Kategorie-Label | `mayring_hybrid` → llama3.1:8b | Label pro Chunk |
 | `_embed_texts` | Texte (Liste) | float[384]-Vektoren | `embedding` → nomic-embed-text | Embedding-Dauer |

--- a/config/model_routes.yaml
+++ b/config/model_routes.yaml
@@ -13,7 +13,7 @@ mayring_social:
   timeout: 240
 
 mayring_hybrid:
-  model: "mayring-qwen3:2b"
+  model: "qwen3.5:2b"
   fallback: "mistral:7b-instruct"
   timeout: 240
 

--- a/src/api/mcp_agent_tools.py
+++ b/src/api/mcp_agent_tools.py
@@ -17,7 +17,7 @@ from src.api.mcp_auth import (
 
 def _model(task: str = "analysis") -> str:
     from src.model_router import ModelRouter
-    return ModelRouter(_OLLAMA_URL).resolve(task) or "mayring-qwen3:2b"
+    return ModelRouter(_OLLAMA_URL).resolve(task) or "qwen2.5-coder:7b"
 from src.api.dependencies import get_conn as _get_conn, get_chroma as _get_chroma
 from src.api.memory_service import run_ingest as _run_ingest
 

--- a/src/memory/retrieval.py
+++ b/src/memory/retrieval.py
@@ -171,7 +171,7 @@ def _llm_relevance_scores(
     query: str,
     candidates: list[Chunk],
     ollama_url: str,
-    model: str = "mayring-qwen3:2b",
+    model: str = "qwen2.5-coder:7b",
     timeout: float = 10.0,
     task_context: str | None = None,
 ) -> dict[str, float]:

--- a/src/model_router.py
+++ b/src/model_router.py
@@ -28,7 +28,7 @@ _CONFIG_PATH = _ROOT / "config" / "model_routes.yaml"
 _DEFAULTS: dict[str, dict] = {
     "mayring_code":   {"model": "mistral:7b-instruct",  "fallback": "qwen2.5-coder:7b",  "timeout": 240},
     "mayring_social": {"model": "mistral:7b-instruct",  "fallback": "qwen2.5-coder:7b",  "timeout": 240},
-    "mayring_hybrid": {"model": "mayring-qwen3:2b",     "fallback": "mistral:7b-instruct","timeout": 240},
+    "mayring_hybrid": {"model": "qwen3.5:2b",           "fallback": "mistral:7b-instruct","timeout": 240},
     "vision":         {"model": "qwen2.5vl:3b",         "fallback": "",                  "timeout": 120},
     "analysis":       {"model": "mistral:7b-instruct",  "fallback": "qwen2.5-coder:7b",  "timeout": 240},
     "complex":        {"model": "qwen3.5:35b-a3b",      "fallback": "mistral:7b-instruct","timeout": 480},
@@ -48,7 +48,7 @@ class ModelRouter:
 
     Usage:
         router = ModelRouter(ollama_url="http://localhost:11434")
-        model = router.resolve("mayring_code")      # "mayringqwen:latest" if available
+        model = router.resolve("mayring_code")      # default mistral:7b-instruct
         if router.is_available("vision"):
             caption = caption_image(path, router.resolve("vision"))
     """

--- a/src/turbulence.py
+++ b/src/turbulence.py
@@ -28,7 +28,7 @@ _OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
 
 def _default_model() -> str:
     from src.model_router import ModelRouter
-    return ModelRouter(_OLLAMA_URL).resolve("analysis") or "mayring-qwen3:2b"
+    return ModelRouter(_OLLAMA_URL).resolve("analysis") or "qwen2.5-coder:7b"
 
 THRESHOLD_SKIP = 0.20
 THRESHOLD_HIGH_ONLY = 0.50

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -37,10 +37,10 @@ class TestModelRouterDefaults:
             mock_path.exists.return_value = False
             router = ModelRouter("http://localhost:11434")
         router._routes["analysis"].model = ""
-        router._routes["analysis"].fallback = "mayring-qwen3:2b"
+        router._routes["analysis"].fallback = "qwen3.5:2b"
         # OLLAMA_MODEL env must NOT bleed through — fallback from config is used
         result = router.resolve("analysis")
-        assert result == "mayring-qwen3:2b"
+        assert result == "qwen3.5:2b"
         assert result != "my-env-model:latest"
 
     def test_resolve_unknown_task_returns_empty_not_env(self, monkeypatch):

--- a/tests/test_model_router_integration.py
+++ b/tests/test_model_router_integration.py
@@ -185,7 +185,7 @@ class TestMayringCategorizeRouter:
 
         router = MagicMock()
         router.is_available.return_value = True
-        router.resolve.return_value = "mayringqwen:latest"
+        router.resolve.return_value = "qwen2.5-coder:7b"
 
         chunk = Chunk(
             chunk_id="chk_test_001",
@@ -217,7 +217,7 @@ class TestMayringCategorizeRouter:
 
         router.is_available.assert_called_with("mayring_code")
         router.resolve.assert_called_with("mayring_code")
-        assert captured_models == ["mayringqwen:latest"]
+        assert captured_models == ["qwen2.5-coder:7b"]
 
     def test_explicit_model_not_overridden_by_router(self):
         """Explicit model wins over router."""
@@ -226,7 +226,7 @@ class TestMayringCategorizeRouter:
 
         router = MagicMock()
         router.is_available.return_value = True
-        router.resolve.return_value = "mayringqwen:latest"
+        router.resolve.return_value = "qwen2.5-coder:7b"
 
         chunk = Chunk(
             chunk_id="chk_test_002",


### PR DESCRIPTION
## Summary
Two model names referenced from runtime fallback paths do not exist in current Ollama installations:
- `mayring-qwen3:2b` (was the fine-tune target — never built on the user's box)
- `mayringqwen:latest` (legacy alias from earlier docs)

Both produce `404 model not found` when the router resolves to them. This explains the **424 `categorize_error` rows** sitting in `cache/memory.db.ingestion_log` (all 404s on `/api/generate`).

## Why
Real ollama state on master right now:
```
qwen3.5:35b-a3b, medgemma:4b, gemma4:e4b, minicpm-v:latest, qwen2.5vl:3b,
qwen3.5:2b, nomic-embed-text:latest, qwen3.5:9b, mistral:7b-instruct,
deepseek-coder:6.7b-instruct, starcoder2:7b, codellama:latest,
qwen2.5-coder:7b, llama3.1:8b, llama3.2:latest
```
No `mayring*` model present.

## Replacements
| Location | Before | After |
|---|---|---|
| config/model_routes.yaml mayring_hybrid | mayring-qwen3:2b | qwen3.5:2b |
| src/model_router.py _DEFAULTS | mayring-qwen3:2b | qwen3.5:2b |
| src/turbulence.py:_default_model | mayring-qwen3:2b | qwen2.5-coder:7b |
| src/api/mcp_agent_tools.py:_model | mayring-qwen3:2b | qwen2.5-coder:7b |
| src/memory/retrieval.py:_llm_relevance_scores | mayring-qwen3:2b | qwen2.5-coder:7b |
| README.md (3 lines) | mayringqwen:latest | mistral:7b-instruct |
| tests/test_model_router*.py | string literals | new defaults |

tools/export_to_ollama.py keeps mayring-qwen3:2b as --name default because the script *creates* that tag via custom build.

## Test plan
- [x] 20/20 in tests/test_model_router*.py pass
- [ ] After merge: rerun ingest, confirm categorize_error drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update default and fallback model names to use existing Ollama tags instead of deprecated mayring* models across routing, retrieval, and default-selection paths.

Bug Fixes:
- Prevent routing to non-existent mayring* models by switching defaults to currently available mistral and qwen variants.

Enhancements:
- Align model routing configuration, code defaults, and tests on qwen3.5:2b and qwen2.5-coder:7b for hybrid, analysis, and categorize flows.
- Clarify README diagrams and tables to document the new default and fallback models used by the router.

Tests:
- Adjust model router integration and unit tests to assert the updated default model resolutions.