### PR TITLE
feat(wiki): IGIO Phase 2+3 + axis-alias fix from real backfill data

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -132,6 +132,9 @@ def _cmd_classify_igio(args: argparse.Namespace, ollama_url: str, model: str) ->
     Reads `chunks` rows where `igio_axis = ''` and `is_active = 1`, runs
     `classify_chunk()` per row, persists the verdict back to the row when the
     confidence clears `--igio-min-confidence`.
+
+    DBAdapter wraps sqlite3 with `row_factory = sqlite3.Row`, so rows are
+    Mapping-like and we always use key access.
     """
     from src.config import CACHE_DIR
     from src.memory.store import init_memory_db
@@ -167,17 +170,16 @@ def _cmd_classify_igio(args: argparse.Namespace, ollama_url: str, model: str) ->
     counts: dict[str, int] = {a: 0 for a in ("issue", "goal", "intervention", "outcome", "")}
     persisted = 0
     for r in rows:
-        cid = r["chunk_id"] if hasattr(r, "__getitem__") else r[0]
-        text = r["text"] if hasattr(r, "__getitem__") else r[1]
-        cats_raw = r["category_labels"] if hasattr(r, "__getitem__") else r[2]
-        cats = [c for c in (cats_raw or "").split(",") if c]
-        verdict = classify_chunk(text, cats, ollama_url=ollama_url, model=model)
+        cats = [c for c in (r["category_labels"] or "").split(",") if c]
+        verdict = classify_chunk(
+            r["text"], cats, ollama_url=ollama_url, model=model,
+        )
         counts[verdict.axis] = counts.get(verdict.axis, 0) + 1
         if verdict.axis and verdict.confidence >= threshold:
             conn.execute(
                 "UPDATE chunks SET igio_axis = ?, igio_confidence = ?, "
                 "igio_classified_at = ? WHERE chunk_id = ?",
-                (verdict.axis, verdict.confidence, now_iso(), cid),
+                (verdict.axis, verdict.confidence, now_iso(), r["chunk_id"]),
             )
             persisted += 1
 
@@ -188,6 +190,36 @@ def _cmd_classify_igio(args: argparse.Namespace, ollama_url: str, model: str) ->
         f"issue={counts.get('issue',0)} goal={counts.get('goal',0)} "
         f"intervention={counts.get('intervention',0)} outcome={counts.get('outcome',0)} "
         f"unclassified={counts.get('',0)}"
+    )
+
+
+def _cmd_generate_recap(args: argparse.Namespace) -> None:
+    """Render a markdown recap for a single issue id."""
+    from src.config import CACHE_DIR, WIKI_DIR
+    from src.memory.store import init_memory_db
+    from src.wiki_v2.recap_indexer import build_recap
+    from src.wiki_v2.recap_renderer import render_recap
+
+    issue_id = str(getattr(args, "generate_recap", "") or "").strip().lstrip("#")
+    if not issue_id:
+        print("Fehler: --generate-recap erwartet eine Issue-ID.")
+        return
+    workspace = getattr(args, "workspace_id", None) or "default"
+
+    conn = init_memory_db(CACHE_DIR / "memory.db")
+    recap = build_recap(issue_id, conn=conn, workspace_id=workspace)
+    conn.close()
+
+    md = render_recap(recap)
+    out_arg = getattr(args, "recap_out", None)
+    out_path = Path(out_arg) if out_arg else (WIKI_DIR / workspace / f"recap-{issue_id}.md")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(md, encoding="utf-8")
+    print(
+        f"[recap] issue=#{issue_id} workspace={workspace} → {out_path} "
+        f"(issue:{len(recap.issue_chunks)} interv:{len(recap.intervention_chunks)} "
+        f"out:{len(recap.outcome_chunks)} plans:{len(recap.plans)} "
+        f"commits:{len(recap.commits)})"
     )
 
 
@@ -348,6 +380,7 @@ def main() -> None:
 
     if not repo_url and not (args.ingest_issues or args.ingest_images or args.pi_task or args.generate_wiki
                               or getattr(args, "classify_igio", False)
+                              or getattr(args, "generate_recap", None)
                               or getattr(args, "generate_training_data", None)):
         print("Fehler: Kein Repository angegeben. Nutze --repo oder setze GITHUB_REPO in .env")
         sys.exit(1)
@@ -401,6 +434,7 @@ def main() -> None:
     if args.populate_memory:                           run_populate_memory(args, repo_url, ollama_url, model); sys.exit(0)
     if args.generate_wiki:                             _cmd_generate_wiki(args, repo_url, ollama_url, model);  sys.exit(0)
     if getattr(args, "classify_igio", False):          _cmd_classify_igio(args, ollama_url, model);            sys.exit(0)
+    if getattr(args, "generate_recap", None):          _cmd_generate_recap(args);                              sys.exit(0)
     if getattr(args, "wiki_history", False):           _cmd_wiki_history(args);                               sys.exit(0)
     if getattr(args, "wiki_team_activity", False):     _cmd_wiki_team_activity(args);                         sys.exit(0)
     if getattr(args, "wiki_history_cleanup", None) is not None: _cmd_wiki_history_cleanup(args);              sys.exit(0)

--- a/src/cli_args.py
+++ b/src/cli_args.py
@@ -90,6 +90,10 @@ def parse_args() -> argparse.Namespace:
                    help="Max. Anzahl Chunks pro --classify-igio Lauf (Standard: 200).")
     p.add_argument("--igio-min-confidence", type=float, default=0.5, metavar="X",
                    help="Verdicts unter dieser Konfidenz werden als unklassifiziert behandelt (Standard: 0.5).")
+    p.add_argument("--generate-recap", metavar="ISSUE",
+                   help="Recap-MD für ein Issue rendern (issue id, ohne #).")
+    p.add_argument("--recap-out", metavar="PATH", default=None,
+                   help="Output-Pfad für --generate-recap (Default: wiki/<workspace>/recap-<issue>.md).")
     p.add_argument("--rebuild-transitions", action="store_true",
                    help="Scan conversation-summaries + rebuild Markov topic-transition matrix")
     p.add_argument("--wiki-type", choices=["code", "paper"], default="code",

--- a/src/wiki_v2/igio_classifier.py
+++ b/src/wiki_v2/igio_classifier.py
@@ -93,33 +93,55 @@ def _build_user_prompt(text: str, category_labels: list[str]) -> str:
     )
 
 
-_JSON_BLOCK_RE = re.compile(r"\{[^{}]*\}", re.S)
+def _strip_markdown_fence(raw: str) -> str:
+    """Strip a leading ```json … ``` fence if the LLM wrapped its reply."""
+    if not raw.startswith("```"):
+        return raw
+    body = raw.lstrip("`").lstrip()
+    # Drop optional language tag on the first line
+    if "\n" in body:
+        first, rest = body.split("\n", 1)
+        if not first.strip().startswith("{"):
+            body = rest
+    if body.endswith("```"):
+        body = body[:-3]
+    return body.strip()
 
 
 def _parse_verdict(raw: str) -> IgioVerdict | None:
-    raw = raw.strip()
+    """Parse the LLM reply into an IgioVerdict, or None on failure.
+
+    Tolerates: leading/trailing prose, ```json fences, and JSON objects with
+    nested arrays or braces inside `rationale`. Strategy: slice from the first
+    `{` to the matching last `}` (greedy), then a single json.loads.
+    """
+    raw = _strip_markdown_fence(raw.strip())
     if not raw:
         return None
-    candidates = [raw]
-    m = _JSON_BLOCK_RE.search(raw)
-    if m and m.group(0) != raw:
-        candidates.append(m.group(0))
-    for cand in candidates:
-        try:
-            obj = json.loads(cand)
-        except json.JSONDecodeError:
-            continue
-        axis = str(obj.get("axis", "")).strip().lower()
-        if axis and axis not in VALID_AXES:
-            continue
-        try:
-            conf = float(obj.get("confidence", 0.0))
-        except (TypeError, ValueError):
-            conf = 0.0
-        rationale = str(obj.get("rationale", ""))[:200]
-        return IgioVerdict(axis=axis, confidence=max(0.0, min(1.0, conf)),
-                           rationale=rationale)
-    return None
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    try:
+        obj = json.loads(raw[start:end + 1])
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    axis = str(obj.get("axis", "")).strip().lower()
+    if axis and axis not in VALID_AXES:
+        return None
+    try:
+        conf = float(obj.get("confidence", 0.0))
+    except (TypeError, ValueError):
+        conf = 0.0
+    rationale_raw = obj.get("rationale", "")
+    rationale = (str(rationale_raw) if rationale_raw is not None else "")[:200]
+    return IgioVerdict(
+        axis=axis,
+        confidence=max(0.0, min(1.0, conf)),
+        rationale=rationale,
+    )
 
 
 def classify_chunk(

--- a/src/wiki_v2/igio_classifier.py
+++ b/src/wiki_v2/igio_classifier.py
@@ -67,20 +67,45 @@ def _fast_classify(text: str) -> IgioVerdict | None:
     return None
 
 
-_PROMPT_SYSTEM = """You classify text snippets into exactly one of four content
-axes. Respond with strict JSON only — no prose, no markdown.
+_PROMPT_SYSTEM = """You classify a text snippet into EXACTLY ONE of four
+content axes. Respond with strict JSON only — no prose, no markdown fences.
 
-Axes:
+The four axes (these are the ONLY valid `axis` values):
   issue        — surfaces a problem, bug, missing piece, or open question
   goal         — names a desired state, target, or success criterion
   intervention — describes a change, implementation, refactor, or action taken
   outcome      — reports a result, effect, test outcome, or measurable evidence
 
+DO NOT use other words like "tests", "testing", "test", "fix", "bug", or
+"implementation". A test function reporting pass/fail is `outcome`. A bug
+report or open question is `issue`. A code change or refactor is
+`intervention`. A goal statement is `goal`.
+
 If the snippet does not fit any axis, return axis="" with low confidence.
 
-Output schema:
-  {"axis": "<one of: issue|goal|intervention|outcome|>", "confidence": <0.0-1.0>, "rationale": "<one short sentence>"}
+Output schema (no other keys, no nested objects):
+  {"axis": "<issue|goal|intervention|outcome|>", "confidence": <0.0-1.0>, "rationale": "<one short sentence>"}
 """
+
+# Common LLM-produced near-misses → canonical axis. The LLM keeps suggesting
+# "tests"/"testing" for test functions even when the prompt forbids it; rather
+# than discarding 20% of throughput we accept the synonym at a slight
+# confidence penalty.
+_AXIS_ALIASES: dict[str, str] = {
+    "test": "outcome",
+    "tests": "outcome",
+    "testing": "outcome",
+    "result": "outcome",
+    "results": "outcome",
+    "fix": "intervention",
+    "fixes": "intervention",
+    "refactor": "intervention",
+    "implementation": "intervention",
+    "bug": "issue",
+    "problem": "issue",
+    "question": "issue",
+}
+_ALIAS_PENALTY = 0.1
 
 
 def _build_user_prompt(text: str, category_labels: list[str]) -> str:
@@ -129,12 +154,19 @@ def _parse_verdict(raw: str) -> IgioVerdict | None:
     if not isinstance(obj, dict):
         return None
     axis = str(obj.get("axis", "")).strip().lower()
+    aliased = False
     if axis and axis not in VALID_AXES:
-        return None
+        mapped = _AXIS_ALIASES.get(axis)
+        if mapped is None:
+            return None
+        axis = mapped
+        aliased = True
     try:
         conf = float(obj.get("confidence", 0.0))
     except (TypeError, ValueError):
         conf = 0.0
+    if aliased:
+        conf = max(0.0, conf - _ALIAS_PENALTY)
     rationale_raw = obj.get("rationale", "")
     rationale = (str(rationale_raw) if rationale_raw is not None else "")[:200]
     return IgioVerdict(

--- a/src/wiki_v2/injection.py
+++ b/src/wiki_v2/injection.py
@@ -2,22 +2,35 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from src.memory.db_adapter import DBAdapter
     from src.wiki_v2.graph import WikiGraph
 
 
 class WikiContextInjector:
-    """Builds a wiki context block for analysis prompts from WikiGraph data."""
+    """Builds a wiki context block for analysis prompts from WikiGraph data.
+
+    With an optional `memory_conn` (DBAdapter) the injector also adds an
+    IGIO section listing the chunk-level axis distribution and the highest-
+    confidence sample per axis. The structural sections are unchanged so
+    existing callers/tests continue to work.
+    """
 
     def build_context(
         self,
         filename: str,
         graph: "WikiGraph",
         max_chars: int = 2000,
+        *,
+        memory_conn: "DBAdapter | None" = None,
     ) -> str:
-        """Return a formatted context string (≤ max_chars) for use in analysis prompts.
+        """Return a formatted context string (≤ max_chars).
 
-        Includes: cluster membership, direct dependencies, hot-zone neighbours.
-        Returns "" when no relevant graph data exists.
+        Sections (in order):
+          1. Cluster membership
+          2. Direct dependencies (imports)
+          3. Hot-zone neighbours
+          4. IGIO position — only when memory_conn is provided and the file
+             has classified chunks
         """
         clusters = graph.get_clusters()
         cluster = next((c for c in clusters if filename in c.members), None)
@@ -53,6 +66,64 @@ class WikiContextInjector:
         if hot:
             sections.append(f"### Hot-Zone Nachbarn\n{', '.join(hot)}")
 
+        if memory_conn is not None:
+            igio_section = self._build_igio_section(
+                filename, memory_conn,
+                workspace_id=getattr(graph, "workspace_id", None),
+            )
+            if igio_section:
+                sections.append(igio_section)
+
         if not sections:
             return ""
         return ("\n\n".join(sections))[:max_chars]
+
+    @staticmethod
+    def _build_igio_section(
+        filename: str,
+        memory_conn: "DBAdapter",
+        *,
+        workspace_id: str | None = None,
+    ) -> str:
+        """Render an IGIO-position section for `filename` from chunks.
+
+        Strategy: source_id heuristically contains the filename (e.g.
+        `repo:owner/name:src/foo.py`). We aggregate axis counts per file and
+        pick the top-confidence chunk per axis as a one-line sample.
+        """
+        if not filename:
+            return ""
+        where = ["igio_axis != ''", "is_active = 1", "source_id LIKE ?"]
+        params: list = [f"%{filename}%"]
+        if workspace_id:
+            where.append("workspace_id = ?")
+            params.append(workspace_id)
+        sql = (
+            "SELECT igio_axis, COUNT(*) AS n FROM chunks "
+            f"WHERE {' AND '.join(where)} GROUP BY igio_axis"
+        )
+        counts = memory_conn.execute(sql, tuple(params)).fetchall()
+        if not counts:
+            return ""
+
+        lines = ["### IGIO-Position"]
+        for r in counts:
+            axis = r["igio_axis"]
+            n = r["n"]
+            sample_sql = (
+                "SELECT substr(text, 1, 100) AS preview, igio_confidence "
+                f"FROM chunks WHERE {' AND '.join(where)} AND igio_axis = ? "
+                "ORDER BY igio_confidence DESC LIMIT 1"
+            )
+            sample_params = (*params, axis)
+            sample = memory_conn.execute(sample_sql, sample_params).fetchone()
+            if sample:
+                preview = (sample["preview"] or "").replace("\n", " ").strip()
+                lines.append(
+                    f"- {axis} ({n}): {preview[:80]}…"
+                    if len(preview) > 80
+                    else f"- {axis} ({n}): {preview}"
+                )
+            else:
+                lines.append(f"- {axis} ({n})")
+        return "\n".join(lines)

--- a/src/wiki_v2/recap_indexer.py
+++ b/src/wiki_v2/recap_indexer.py
@@ -1,0 +1,277 @@
+"""Recap indexer — issue-centric view that joins IGIO chunks, plans, and git.
+
+A recap binds together what was raised (Issue), what was planned/changed
+(Intervention), and what came out (Outcome) for a single GitHub issue. The
+index is a pure data-gatherer; rendering lives in `recap_renderer.py`.
+
+Inputs (already-on-disk data, no LLM calls):
+    - chunks rows where igio_axis matches and source_id/text references the issue
+    - plan markdowns under `~/.claude/plans/` that mention the issue
+    - git log commits since the plan's mtime
+
+Output: a `Recap` dataclass — caller renders it.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from src.memory.db_adapter import DBAdapter
+
+PLANS_DIR_DEFAULT = Path.home() / ".claude" / "plans"
+
+
+@dataclass
+class RecapChunk:
+    chunk_id: str
+    source_id: str
+    text_preview: str
+    category_labels: list[str]
+    igio_axis: str
+    igio_confidence: float
+
+
+@dataclass
+class RecapPlan:
+    path: Path
+    title: str
+    mtime_iso: str
+
+
+@dataclass
+class RecapCommit:
+    sha: str
+    subject: str
+    iso_date: str
+
+
+@dataclass
+class Recap:
+    issue_id: str
+    workspace_id: str
+    issue_chunks: list[RecapChunk] = field(default_factory=list)
+    goal_chunks: list[RecapChunk] = field(default_factory=list)
+    intervention_chunks: list[RecapChunk] = field(default_factory=list)
+    outcome_chunks: list[RecapChunk] = field(default_factory=list)
+    plans: list[RecapPlan] = field(default_factory=list)
+    commits: list[RecapCommit] = field(default_factory=list)
+
+
+_PREVIEW_LEN = 200
+
+
+def _to_chunk(row) -> RecapChunk:
+    return RecapChunk(
+        chunk_id=row["chunk_id"],
+        source_id=row["source_id"],
+        text_preview=(row["text"] or "")[:_PREVIEW_LEN],
+        category_labels=[c for c in (row["category_labels"] or "").split(",") if c],
+        igio_axis=row["igio_axis"] or "",
+        igio_confidence=float(row["igio_confidence"] or 0.0),
+    )
+
+
+def _chunks_for_axis(
+    conn: DBAdapter,
+    axis: str,
+    *,
+    issue_id: str,
+    workspace_id: str | None,
+    limit: int = 25,
+) -> list[RecapChunk]:
+    """Return chunks classified to `axis` that touch the issue.
+
+    Issue-touch heuristic: source_id contains "issue-{id}" or "issues/{id}",
+    or the chunk text mentions "#{id}" / "issue {id}".
+    """
+    issue_key = str(issue_id).strip().lstrip("#")
+    if not issue_key:
+        return []
+
+    where = ["igio_axis = ?", "is_active = 1"]
+    params: list = [axis]
+    if workspace_id:
+        where.append("workspace_id = ?")
+        params.append(workspace_id)
+    where.append(
+        "(source_id LIKE ? OR source_id LIKE ? OR text LIKE ? OR text LIKE ?)"
+    )
+    params.extend([
+        f"%issue-{issue_key}%",
+        f"%issues/{issue_key}%",
+        f"%#{issue_key}%",
+        f"%issue {issue_key}%",
+    ])
+    sql = (
+        "SELECT chunk_id, source_id, text, category_labels, igio_axis, igio_confidence "
+        f"FROM chunks WHERE {' AND '.join(where)} "
+        "ORDER BY igio_confidence DESC, created_at DESC LIMIT ?"
+    )
+    params.append(limit)
+    rows = conn.execute(sql, tuple(params)).fetchall()
+    return [_to_chunk(r) for r in rows]
+
+
+_ISSUE_RE_TEMPLATE = r"(?:#|issue[\s_-]+)({})\b"
+
+
+def _plans_mentioning_issue(
+    plans_dir: Path,
+    issue_id: str,
+) -> list[RecapPlan]:
+    """Find plan markdowns whose body mentions the issue."""
+    if not plans_dir.exists():
+        return []
+    issue_key = str(issue_id).strip().lstrip("#")
+    if not issue_key:
+        return []
+    pattern = re.compile(_ISSUE_RE_TEMPLATE.format(re.escape(issue_key)), re.I)
+    out: list[RecapPlan] = []
+    for path in sorted(plans_dir.glob("*.md")):
+        try:
+            body = path.read_text(errors="ignore")
+        except OSError:
+            continue
+        if not pattern.search(body):
+            continue
+        title = next(
+            (
+                line.lstrip("# ").strip()
+                for line in body.splitlines()
+                if line.startswith("# ")
+            ),
+            path.stem,
+        )
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat()
+        out.append(RecapPlan(path=path, title=title, mtime_iso=mtime))
+    return out
+
+
+def _commits_since(
+    repo_root: Path,
+    since_iso: str | None,
+    *,
+    grep: str | None = None,
+    limit: int = 30,
+) -> list[RecapCommit]:
+    """Run `git log` against repo_root and return parsed commits."""
+    if not (repo_root / ".git").exists():
+        return []
+    args = [
+        "git", "log",
+        f"--max-count={limit}",
+        "--pretty=format:%H%x09%aI%x09%s",
+    ]
+    if since_iso:
+        args.append(f"--since={since_iso}")
+    if grep:
+        args.extend(["--grep", grep, "-i"])
+    try:
+        proc = subprocess.run(  # nosec B603
+            args,
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0:
+        return []
+    out: list[RecapCommit] = []
+    for line in proc.stdout.splitlines():
+        parts = line.split("\t", 2)
+        if len(parts) != 3:
+            continue
+        sha, iso, subject = parts
+        out.append(RecapCommit(sha=sha[:12], iso_date=iso, subject=subject.strip()))
+    return out
+
+
+def build_recap(
+    issue_id: str,
+    *,
+    conn: DBAdapter,
+    workspace_id: str | None = None,
+    repo_root: Path | None = None,
+    plans_dir: Path | None = None,
+    chunk_limit: int = 25,
+    commit_limit: int = 30,
+) -> Recap:
+    """Assemble a Recap for a single issue id from already-classified data."""
+    issue_id = str(issue_id).strip().lstrip("#")
+    plans_dir = plans_dir or PLANS_DIR_DEFAULT
+    repo_root = repo_root or _detect_repo_root()
+
+    recap = Recap(issue_id=issue_id, workspace_id=workspace_id or "")
+
+    recap.issue_chunks = _chunks_for_axis(
+        conn, "issue", issue_id=issue_id, workspace_id=workspace_id, limit=chunk_limit,
+    )
+    recap.goal_chunks = _chunks_for_axis(
+        conn, "goal", issue_id=issue_id, workspace_id=workspace_id, limit=chunk_limit,
+    )
+    recap.intervention_chunks = _chunks_for_axis(
+        conn, "intervention", issue_id=issue_id, workspace_id=workspace_id,
+        limit=chunk_limit,
+    )
+    recap.outcome_chunks = _chunks_for_axis(
+        conn, "outcome", issue_id=issue_id, workspace_id=workspace_id, limit=chunk_limit,
+    )
+
+    recap.plans = _plans_mentioning_issue(plans_dir, issue_id)
+
+    earliest_plan = min((p.mtime_iso for p in recap.plans), default=None)
+    recap.commits = _commits_since(
+        repo_root,
+        since_iso=earliest_plan,
+        grep=f"#{issue_id}",
+        limit=commit_limit,
+    )
+    return recap
+
+
+def _detect_repo_root() -> Path:
+    """Best-effort: walk up from $CWD until we hit a `.git` dir."""
+    p = Path(os.getcwd()).resolve()
+    for parent in (p, *p.parents):
+        if (parent / ".git").exists():
+            return parent
+    return p
+
+
+def discover_issue_ids(conn: DBAdapter, workspace_id: str | None = None) -> list[str]:
+    """Return issue ids that appear in github_issue source_ids.
+
+    Lets callers ask "which issues do I have data for" without scanning text.
+    """
+    where = ["source_type = 'github_issue'"]
+    params: list = []
+    if workspace_id:
+        where.append("workspace_id = ?")
+        params.append(workspace_id)
+    rows = conn.execute(
+        f"SELECT DISTINCT source_id FROM sources WHERE {' AND '.join(where)}",
+        tuple(params),
+    ).fetchall()
+    out: set[str] = set()
+    pattern = re.compile(r"issue[s]?[/_-](\d+)", re.I)
+    for r in rows:
+        sid = r["source_id"] if hasattr(r, "keys") else r[0]
+        m = pattern.search(sid or "")
+        if m:
+            out.add(m.group(1))
+    return sorted(out, key=lambda x: int(x) if x.isdigit() else 0)
+
+
+__all__: Iterable[str] = (
+    "Recap", "RecapChunk", "RecapPlan", "RecapCommit",
+    "build_recap", "discover_issue_ids",
+)

--- a/src/wiki_v2/recap_renderer.py
+++ b/src/wiki_v2/recap_renderer.py
@@ -1,0 +1,69 @@
+"""Recap renderer — Recap dataclass → markdown.
+
+Output convention: `wiki/<workspace>/recap-<issue_id>.md`. Goal/Outcome blocks
+get an explicit "(manuell ergänzen)" placeholder when no chunks exist on
+those axes — that's the User's prompt to fill them in.
+"""
+
+from __future__ import annotations
+
+from src.wiki_v2.recap_indexer import Recap, RecapChunk
+
+
+def _format_chunk(c: RecapChunk) -> str:
+    cats = ", ".join(c.category_labels) if c.category_labels else "—"
+    preview = c.text_preview.replace("\n", " ").strip()
+    return (
+        f"- `{c.chunk_id[:16]}` [{cats}] (conf {c.igio_confidence:.2f})\n"
+        f"  > {preview[:140]}"
+    )
+
+
+def _section(title: str, chunks: list[RecapChunk], placeholder: str = "") -> str:
+    if not chunks:
+        body = f"_{placeholder}_" if placeholder else "_(noch keine Daten)_"
+        return f"## {title}\n\n{body}\n"
+    body = "\n".join(_format_chunk(c) for c in chunks)
+    return f"## {title}\n\n{body}\n"
+
+
+def render_recap(recap: Recap) -> str:
+    """Render a Recap to markdown."""
+    parts: list[str] = []
+    title = f"# Recap — Issue #{recap.issue_id}"
+    if recap.workspace_id:
+        title += f" (workspace `{recap.workspace_id}`)"
+    parts.append(title + "\n")
+
+    parts.append(_section("Issue", recap.issue_chunks,
+                          placeholder="Keine Chunks mit igio_axis='issue' für dieses Issue gefunden."))
+
+    parts.append(_section("Goal", recap.goal_chunks,
+                          placeholder="(manuell ergänzen)"))
+
+    if recap.plans:
+        plans_md = "\n".join(
+            f"- [{p.title}]({p.path}) — {p.mtime_iso}" for p in recap.plans
+        )
+        parts.append(f"## Intervention — Plans\n\n{plans_md}\n")
+    else:
+        parts.append("## Intervention — Plans\n\n_(kein Plan verlinkt)_\n")
+
+    parts.append(_section("Intervention — Chunks", recap.intervention_chunks,
+                          placeholder="(noch keine intervention-Chunks)"))
+
+    if recap.commits:
+        commits_md = "\n".join(
+            f"- `{c.sha}` {c.iso_date} — {c.subject}" for c in recap.commits
+        )
+        parts.append(f"## Outcome — Commits\n\n{commits_md}\n")
+    else:
+        parts.append("## Outcome — Commits\n\n_(keine zugeordneten Commits)_\n")
+
+    parts.append(_section("Outcome — Chunks", recap.outcome_chunks,
+                          placeholder="(manuell ergänzen — z.B. Test-Ergebnisse, Review-Findings)"))
+
+    return "\n".join(parts)
+
+
+__all__ = ("render_recap",)

--- a/tests/test_igio_classifier.py
+++ b/tests/test_igio_classifier.py
@@ -125,6 +125,33 @@ def test_parse_verdict_strips_markdown_fence() -> None:
     assert v is not None and v.axis == "goal"
 
 
+@pytest.mark.parametrize(
+    "alias,canonical",
+    [
+        ("tests", "outcome"),
+        ("testing", "outcome"),
+        ("test", "outcome"),
+        ("fix", "intervention"),
+        ("refactor", "intervention"),
+        ("bug", "issue"),
+    ],
+)
+def test_parse_verdict_remaps_common_aliases(alias: str, canonical: str) -> None:
+    """qwen models keep emitting 'tests' for test fns even when the prompt
+    forbids it. Re-map well-known near-misses to the canonical axis."""
+    raw = json.dumps({"axis": alias, "confidence": 1.0, "rationale": "x"})
+    v = _parse_verdict(raw)
+    assert v is not None
+    assert v.axis == canonical
+    assert v.confidence < 1.0  # penalised for non-canonical token
+
+
+def test_parse_verdict_unknown_axis_still_rejected() -> None:
+    """Aliases are an allow-list, not a free-for-all."""
+    raw = json.dumps({"axis": "improvement", "confidence": 0.9, "rationale": "x"})
+    assert _parse_verdict(raw) is None
+
+
 def test_parse_verdict_handles_empty_axis() -> None:
     raw = json.dumps({"axis": "", "confidence": 0.1, "rationale": "uncertain"})
     v = _parse_verdict(raw)

--- a/tests/test_igio_classifier.py
+++ b/tests/test_igio_classifier.py
@@ -82,6 +82,49 @@ def test_parse_verdict_clamps_confidence() -> None:
     assert v is not None and v.confidence == 1.0
 
 
+def test_parse_verdict_missing_confidence_defaults_zero() -> None:
+    raw = json.dumps({"axis": "issue", "rationale": "x"})
+    v = _parse_verdict(raw)
+    assert v is not None and v.confidence == 0.0
+
+
+def test_parse_verdict_non_numeric_confidence_defaults_zero() -> None:
+    raw = json.dumps({"axis": "issue", "confidence": "high", "rationale": "x"})
+    v = _parse_verdict(raw)
+    assert v is not None and v.confidence == 0.0
+
+
+def test_parse_verdict_missing_rationale_yields_empty_string() -> None:
+    raw = json.dumps({"axis": "outcome", "confidence": 0.6})
+    v = _parse_verdict(raw)
+    assert v is not None and v.rationale == ""
+
+
+def test_parse_verdict_truncates_long_rationale() -> None:
+    long = "y" * 500
+    raw = json.dumps({"axis": "outcome", "confidence": 0.6, "rationale": long})
+    v = _parse_verdict(raw)
+    assert v is not None and len(v.rationale) == 200
+
+
+def test_parse_verdict_handles_nested_objects_in_rationale() -> None:
+    """Slice-based extraction must survive nested JSON inside the value."""
+    raw = (
+        '{"axis": "intervention", "confidence": 0.7, '
+        '"rationale": "patched {auth, session} flow", "extra": [1, 2, 3]}'
+    )
+    v = _parse_verdict(raw)
+    assert v is not None
+    assert v.axis == "intervention"
+    assert "auth" in v.rationale
+
+
+def test_parse_verdict_strips_markdown_fence() -> None:
+    raw = '```json\n{"axis": "goal", "confidence": 0.9, "rationale": "x"}\n```'
+    v = _parse_verdict(raw)
+    assert v is not None and v.axis == "goal"
+
+
 def test_parse_verdict_handles_empty_axis() -> None:
     raw = json.dumps({"axis": "", "confidence": 0.1, "rationale": "uncertain"})
     v = _parse_verdict(raw)
@@ -167,8 +210,65 @@ def test_migration_adds_igio_columns_idempotently(tmp_path: Path) -> None:
     assert {"igio_axis", "igio_confidence", "igio_classified_at"} <= cols
 
 
-def test_migration_preserves_existing_data(tmp_path: Path) -> None:
-    """Running the migration on an existing memory.db must not drop rows."""
+def test_migration_preserves_existing_rows_hermetic(tmp_path: Path) -> None:
+    """Hermetic: build a pre-IGIO chunks table, migrate, assert rows survive."""
+    from src.memory.store import init_memory_db
+
+    db = tmp_path / "memory.db"
+    conn = sqlite3.connect(db)
+    conn.executescript("""
+        CREATE TABLE sources (
+            source_id     TEXT PRIMARY KEY,
+            source_type   TEXT NOT NULL DEFAULT 'repo_file',
+            repo          TEXT NOT NULL DEFAULT '',
+            path          TEXT NOT NULL DEFAULT '',
+            branch        TEXT NOT NULL DEFAULT 'main',
+            "commit"      TEXT NOT NULL DEFAULT '',
+            content_hash  TEXT NOT NULL DEFAULT '',
+            captured_at   TEXT NOT NULL
+        );
+        CREATE TABLE chunks (
+            chunk_id          TEXT PRIMARY KEY,
+            source_id         TEXT NOT NULL,
+            chunk_level       TEXT NOT NULL DEFAULT 'file',
+            ordinal           INTEGER NOT NULL DEFAULT 0,
+            start_offset      INTEGER NOT NULL DEFAULT 0,
+            end_offset        INTEGER NOT NULL DEFAULT 0,
+            text              TEXT NOT NULL DEFAULT '',
+            text_hash         TEXT NOT NULL DEFAULT '',
+            summary           TEXT NOT NULL DEFAULT '',
+            category_labels   TEXT NOT NULL DEFAULT '',
+            category_version  TEXT NOT NULL DEFAULT 'mayring-inductive-v1',
+            embedding_model   TEXT NOT NULL DEFAULT 'nomic-embed-text',
+            embedding_id      TEXT NOT NULL DEFAULT '',
+            quality_score     REAL NOT NULL DEFAULT 0.0,
+            dedup_key         TEXT NOT NULL DEFAULT '',
+            created_at        TEXT NOT NULL,
+            is_active         INTEGER NOT NULL DEFAULT 1
+        );
+    """)
+    conn.executemany(
+        "INSERT INTO sources (source_id, captured_at) VALUES (?, ?)",
+        [(f"src_{i}", "2026-01-01") for i in range(3)],
+    )
+    conn.executemany(
+        "INSERT INTO chunks (chunk_id, source_id, text, created_at) VALUES (?, ?, ?, ?)",
+        [(f"chk_{i}", f"src_{i}", f"text {i}", "2026-01-01") for i in range(3)],
+    )
+    conn.commit()
+    conn.close()
+
+    init_memory_db(db).close()
+
+    conn = sqlite3.connect(db)
+    after = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(chunks)").fetchall()}
+    assert after == 3
+    assert {"igio_axis", "igio_confidence", "igio_classified_at"} <= cols
+
+
+def test_migration_preserves_existing_data_realdb(tmp_path: Path) -> None:
+    """Optional integration check against the real cache/memory.db."""
     from src.memory.store import init_memory_db
 
     real_db = Path(__file__).resolve().parent.parent / "cache" / "memory.db"

--- a/tests/test_recap_indexer.py
+++ b/tests/test_recap_indexer.py
@@ -1,0 +1,142 @@
+"""Hermetic tests for recap_indexer + recap_renderer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.memory.store import init_memory_db
+from src.wiki_v2.recap_indexer import (
+    Recap,
+    _plans_mentioning_issue,
+    build_recap,
+    discover_issue_ids,
+)
+from src.wiki_v2.recap_renderer import render_recap
+
+
+@pytest.fixture
+def populated_db(tmp_path: Path):
+    db = tmp_path / "memory.db"
+    conn = init_memory_db(db)
+    conn.execute(
+        "INSERT INTO sources (source_id, source_type, captured_at) VALUES (?, ?, ?)",
+        ("repo:test:src/auth.py", "repo_file", "2026-01-01"),
+    )
+    conn.execute(
+        "INSERT INTO sources (source_id, source_type, captured_at) VALUES (?, ?, ?)",
+        ("github:nileneb/MayringCoder/issues/42", "github_issue", "2026-01-01"),
+    )
+    rows = [
+        ("chk_iss_1", "github:nileneb/MayringCoder/issues/42",
+         "Login flow drops session on refresh — see #42",
+         "auth", "issue", 0.91),
+        ("chk_int_1", "repo:test:src/auth.py",
+         "Refactored session refresh to extend cookie lifetime — closes issue 42",
+         "auth", "intervention", 0.88),
+        ("chk_out_1", "repo:test:src/auth.py",
+         "Tests grün after fix for #42 — 142 passed",
+         "tests,auth", "outcome", 0.95),
+        ("chk_unrelated", "repo:test:src/auth.py",
+         "Some neutral change unrelated to any issue",
+         "infra", "intervention", 0.7),
+    ]
+    for cid, sid, text, cats, axis, conf in rows:
+        conn.execute(
+            "INSERT INTO chunks (chunk_id, source_id, text, category_labels, "
+            "igio_axis, igio_confidence, igio_classified_at, created_at, is_active) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)",
+            (cid, sid, text, cats, axis, conf, "2026-01-02", "2026-01-02"),
+        )
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+def test_build_recap_groups_chunks_by_axis(populated_db, tmp_path: Path):
+    plans_dir = tmp_path / "plans"
+    plans_dir.mkdir()
+    (plans_dir / "session-fix.md").write_text(
+        "# Session-Fix\n\nFixing issue #42 — refresh flow.\n"
+    )
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    recap = build_recap(
+        "42", conn=populated_db, plans_dir=plans_dir, repo_root=repo_root,
+    )
+    assert len(recap.issue_chunks) == 1
+    assert recap.issue_chunks[0].chunk_id == "chk_iss_1"
+    assert len(recap.intervention_chunks) == 1
+    assert recap.intervention_chunks[0].chunk_id == "chk_int_1"
+    assert len(recap.outcome_chunks) == 1
+    assert recap.outcome_chunks[0].chunk_id == "chk_out_1"
+    assert recap.goal_chunks == []
+    assert len(recap.plans) == 1
+    assert recap.plans[0].title == "Session-Fix"
+
+
+def test_build_recap_strips_hash_prefix(populated_db, tmp_path: Path):
+    plans_dir = tmp_path / "plans"
+    plans_dir.mkdir()
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    a = build_recap("#42", conn=populated_db, plans_dir=plans_dir, repo_root=repo_root)
+    b = build_recap("42", conn=populated_db, plans_dir=plans_dir, repo_root=repo_root)
+    assert a.issue_id == b.issue_id == "42"
+
+
+def test_build_recap_unknown_issue_returns_empty(populated_db, tmp_path: Path):
+    plans_dir = tmp_path / "plans"
+    plans_dir.mkdir()
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    recap = build_recap(
+        "999", conn=populated_db, plans_dir=plans_dir, repo_root=repo_root,
+    )
+    assert recap.issue_chunks == []
+    assert recap.intervention_chunks == []
+    assert recap.outcome_chunks == []
+    assert recap.plans == []
+
+
+def test_plans_mentioning_issue_skips_unrelated(tmp_path: Path):
+    plans_dir = tmp_path / "plans"
+    plans_dir.mkdir()
+    (plans_dir / "match.md").write_text("# A\n\nfix for #42\n")
+    (plans_dir / "miss.md").write_text("# B\n\nunrelated work\n")
+    out = _plans_mentioning_issue(plans_dir, "42")
+    assert len(out) == 1
+    assert out[0].path.name == "match.md"
+
+
+def test_discover_issue_ids(populated_db):
+    ids = discover_issue_ids(populated_db)
+    assert "42" in ids
+
+
+def test_render_recap_shape(populated_db, tmp_path: Path):
+    plans_dir = tmp_path / "plans"
+    plans_dir.mkdir()
+    (plans_dir / "p.md").write_text("# Plan A\n\nissue #42\n")
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    recap = build_recap(
+        "42", conn=populated_db, plans_dir=plans_dir, repo_root=repo_root,
+    )
+    md = render_recap(recap)
+    assert md.startswith("# Recap — Issue #42")
+    assert "## Issue" in md
+    assert "## Goal" in md
+    assert "## Intervention — Plans" in md
+    assert "## Intervention — Chunks" in md
+    assert "## Outcome" in md
+    assert "chk_iss_1" in md
+    assert "(manuell ergänzen)" in md
+
+
+def test_render_recap_empty():
+    md = render_recap(Recap(issue_id="999", workspace_id="ws"))
+    assert "Recap — Issue #999" in md
+    assert "noch keine Daten" in md or "manuell ergänzen" in md


### PR DESCRIPTION
## Summary
Re-lands the Phase 2+3 work that was lost when PR #120 squash-merged before the follow-up commit landed. Plus two improvements driven by running the backfill against the **real** `cache/memory.db` (200 chunks):

| Backfill result on master | Reality |
|---|---|
| Persisted | 161/200 (80%) |
| issue / goal / intervention / outcome | 5 / 0 / 23 / 133 |
| **Lost to strict-axis rejection** | **39/200 (19.5%)** |
| Lost-reason | qwen2.5-coder:7b kept emitting `axis="tests"` / `"testing"` / `"test"` for test functions |

## Phase 2 — Recap Indexer (`src/wiki_v2/recap_*.py`)
- `build_recap(issue_id, conn, ...)` joins:
  - chunks per IGIO axis touching the issue (`source_id LIKE %issue-{id}%` / text LIKE)
  - plan markdowns under `~/.claude/plans/` mentioning `#<id>`
  - git log commits since the earliest plan mtime, `--grep #<id>`
- `render_recap()` produces markdown with explicit `(manuell ergänzen)` placeholders for goal/outcome.
- New CLI: `--generate-recap <id> [--recap-out PATH]`

## Phase 3 — Injection IGIO section (`src/wiki_v2/injection.py`)
- `WikiContextInjector.build_context()` takes optional `memory_conn=DBAdapter`.
- When supplied, appends `### IGIO-Position` with axis counts + top-confidence sample.
- All 9 existing injection tests untouched.

## PR #120 review fixes (originally Sourcery-flagged)
- `_parse_verdict`: regex/multi-candidate scan → first-`{` to last-`}` slice + single `json.loads`. Tolerates nested arrays/braces in `rationale`. Drops markdown fences.
- `_cmd_classify_igio`: rows are `sqlite3.Row` — direct key access, drop the misleading `hasattr(__getitem__)` branch.
- Hermetic migration test (no longer depends on `cache/memory.db` being present).

## Backfill-driven fix: graceful axis aliasing
After running on 200 real chunks, **19.5% throughput was being dropped** because the model kept emitting near-miss axis values that strict validation rejected. The fix:

```python
_AXIS_ALIASES = {
    "test": "outcome", "tests": "outcome", "testing": "outcome",
    "result": "outcome", "results": "outcome",
    "fix": "intervention", "fixes": "intervention",
    "refactor": "intervention", "implementation": "intervention",
    "bug": "issue", "problem": "issue", "question": "issue",
}
_ALIAS_PENALTY = 0.1
```

- Aliases are an **allow-list** — unrelated values like `"improvement"` still get rejected.
- Prompt also tightened with explicit forbidden tokens + per-axis one-liners.

## Test plan
- [x] 41 pass: 34 igio (incl. 7 alias regression + alias-allow-list rejection) + 7 recap
- [x] 1 skipped: real-DB integration check, gated on `cache/memory.db` presence
- [ ] After merge: rerun `--classify-igio --igio-limit 200 --workspace-id bene-workspace --model qwen2.5-coder:7b` — expected persisted-rate climbs from 80% to ≥95%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add issue recap generation capabilities, enrich wiki context with IGIO information, and harden IGIO classification parsing and migrations based on real data feedback.

New Features:
- Introduce an issue-centric recap indexer and renderer that join IGIO-classified chunks, plans, and git commits into markdown recaps.
- Expose a CLI command and arguments to generate recap markdown files for a given issue and optional output path.
- Extend wiki context injection to optionally include an IGIO-position section summarizing axis distribution and representative chunks per file.

Bug Fixes:
- Improve IGIO verdict parsing to handle markdown fences, nested JSON content, missing fields, and non-numeric confidences, while remapping selected axis aliases instead of rejecting them.
- Make the IGIO migration tests hermetic and add an optional integration test that only runs when a real cache database is present.

Enhancements:
- Tighten the IGIO classifier system prompt to clarify valid axes and discourage common mislabels, while documenting DB row access patterns in the classifier CLI.
- Refine the CLI IGIO classification path to rely on mapping-style row access and simplify update logic for classified chunks.

Tests:
- Add comprehensive tests for IGIO verdict parsing edge cases and alias handling.
- Add hermetic tests for the recap indexer and renderer, including issue discovery, plan matching, and recap markdown shape.
- Split migration-preservation tests into hermetic and real-database variants to better isolate behaviors.