### PR TITLE
fix(wiki): address Sourcery review on PR #123

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -149,18 +149,24 @@ def _cmd_classify_igio(args: argparse.Namespace, ollama_url: str, model: str) ->
     workspace = getattr(args, "workspace_id", None)
 
     conn = init_memory_db(CACHE_DIR / "memory.db")
-    where = ["igio_axis = ''", "is_active = 1", "text != ''"]
-    params: list = []
+    # Two static SQL paths — workspace_id is the only optional filter, toggled
+    # on the SQL itself rather than concatenating WHERE fragments. Avoids the
+    # opengrep "execute-raw-query" lint without changing behaviour.
     if workspace:
-        where.append("workspace_id = ?")
-        params.append(workspace)
-    sql = (
-        f"SELECT chunk_id, text, category_labels FROM chunks "
-        f"WHERE {' AND '.join(where)} "
-        f"ORDER BY created_at DESC LIMIT ?"
-    )
-    params.append(limit)
-    rows = conn.execute(sql, tuple(params)).fetchall()
+        rows = conn.execute(
+            "SELECT chunk_id, text, category_labels FROM chunks "
+            "WHERE igio_axis = '' AND is_active = 1 AND text != '' "
+            "AND workspace_id = ? "
+            "ORDER BY created_at DESC LIMIT ?",
+            (workspace, limit),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT chunk_id, text, category_labels FROM chunks "
+            "WHERE igio_axis = '' AND is_active = 1 AND text != '' "
+            "ORDER BY created_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
     if not rows:
         print(f"[igio] Nichts zu klassifizieren (workspace={workspace or 'all'}).")
         conn.close()

--- a/src/wiki_v2/igio_classifier.py
+++ b/src/wiki_v2/igio_classifier.py
@@ -119,17 +119,26 @@ def _build_user_prompt(text: str, category_labels: list[str]) -> str:
 
 
 def _strip_markdown_fence(raw: str) -> str:
-    """Strip a leading ```json … ``` fence if the LLM wrapped its reply."""
-    if not raw.startswith("```"):
+    """Strip a leading ```json … ``` fence if the LLM wrapped its reply.
+
+    Tolerant by design — trims trailing whitespace and accepts arbitrary text
+    after the closing fence (some models append "Let me know if…" prose).
+    Strategy: detect leading fence, drop optional language tag, then trim from
+    the LAST ``` onwards. Strict endswith() would silently lose otherwise-
+    valid fenced JSON.
+    """
+    if not raw.lstrip().startswith("```"):
         return raw
-    body = raw.lstrip("`").lstrip()
+    body = raw.lstrip().lstrip("`").lstrip()
     # Drop optional language tag on the first line
     if "\n" in body:
         first, rest = body.split("\n", 1)
         if not first.strip().startswith("{"):
             body = rest
-    if body.endswith("```"):
-        body = body[:-3]
+    body = body.rstrip()
+    last_fence = body.rfind("```")
+    if last_fence != -1:
+        body = body[:last_fence]
     return body.strip()
 
 

--- a/src/wiki_v2/injection.py
+++ b/src/wiki_v2/injection.py
@@ -87,22 +87,40 @@ class WikiContextInjector:
     ) -> str:
         """Render an IGIO-position section for `filename` from chunks.
 
-        Strategy: source_id heuristically contains the filename (e.g.
-        `repo:owner/name:src/foo.py`). We aggregate axis counts per file and
-        pick the top-confidence chunk per axis as a one-line sample.
+        Strategy: source_id heuristically contains the filename anchored on a
+        path separator. So `auth.py` matches `repo:owner/name:src/auth.py`
+        but does NOT match `oauth.py` or `auth.py.bak`. If `filename` already
+        contains a separator (e.g. `src/auth.py`) we use it as-is.
+
+        Trade-off: still ambiguous between repos with identical relative paths.
+        Callers wanting strict matching should pass the source_id directly.
         """
         if not filename:
             return ""
-        where = ["igio_axis != ''", "is_active = 1", "source_id LIKE ?"]
-        params: list = [f"%{filename}%"]
-        if workspace_id:
-            where.append("workspace_id = ?")
-            params.append(workspace_id)
-        sql = (
-            "SELECT igio_axis, COUNT(*) AS n FROM chunks "
-            f"WHERE {' AND '.join(where)} GROUP BY igio_axis"
+        # Anchor on a path separator so `auth.py` doesn't match `oauth.py`
+        # or `auth.py.bak`. A filename containing `/` is treated as a
+        # path fragment and used verbatim.
+        like_pattern = (
+            f"%{filename}%" if "/" in filename else f"%/{filename}"
         )
-        counts = memory_conn.execute(sql, tuple(params)).fetchall()
+        # Static SQL strings + parameterised values — opengrep raw-query
+        # audit clean.
+        if workspace_id:
+            count_sql = (
+                "SELECT igio_axis, COUNT(*) AS n FROM chunks "
+                "WHERE igio_axis != '' AND is_active = 1 "
+                "AND source_id LIKE ? AND workspace_id = ? "
+                "GROUP BY igio_axis"
+            )
+            count_params: tuple = (like_pattern, workspace_id)
+        else:
+            count_sql = (
+                "SELECT igio_axis, COUNT(*) AS n FROM chunks "
+                "WHERE igio_axis != '' AND is_active = 1 AND source_id LIKE ? "
+                "GROUP BY igio_axis"
+            )
+            count_params = (like_pattern,)
+        counts = memory_conn.execute(count_sql, count_params).fetchall()
         if not counts:
             return ""
 
@@ -110,12 +128,22 @@ class WikiContextInjector:
         for r in counts:
             axis = r["igio_axis"]
             n = r["n"]
-            sample_sql = (
-                "SELECT substr(text, 1, 100) AS preview, igio_confidence "
-                f"FROM chunks WHERE {' AND '.join(where)} AND igio_axis = ? "
-                "ORDER BY igio_confidence DESC LIMIT 1"
-            )
-            sample_params = (*params, axis)
+            if workspace_id:
+                sample_sql = (
+                    "SELECT substr(text, 1, 100) AS preview, igio_confidence "
+                    "FROM chunks WHERE igio_axis = ? AND is_active = 1 "
+                    "AND source_id LIKE ? AND workspace_id = ? "
+                    "ORDER BY igio_confidence DESC LIMIT 1"
+                )
+                sample_params: tuple = (axis, like_pattern, workspace_id)
+            else:
+                sample_sql = (
+                    "SELECT substr(text, 1, 100) AS preview, igio_confidence "
+                    "FROM chunks WHERE igio_axis = ? AND is_active = 1 "
+                    "AND source_id LIKE ? "
+                    "ORDER BY igio_confidence DESC LIMIT 1"
+                )
+                sample_params = (axis, like_pattern)
             sample = memory_conn.execute(sample_sql, sample_params).fetchone()
             if sample:
                 preview = (sample["preview"] or "").replace("\n", " ").strip()

--- a/src/wiki_v2/recap_indexer.py
+++ b/src/wiki_v2/recap_indexer.py
@@ -94,27 +94,35 @@ def _chunks_for_axis(
     if not issue_key:
         return []
 
-    where = ["igio_axis = ?", "is_active = 1"]
-    params: list = [axis]
-    if workspace_id:
-        where.append("workspace_id = ?")
-        params.append(workspace_id)
-    where.append(
-        "(source_id LIKE ? OR source_id LIKE ? OR text LIKE ? OR text LIKE ?)"
-    )
-    params.extend([
+    # Issue-touch heuristic packed as four parameterised LIKE clauses — every
+    # value is bound, no concatenation. Two static SQL strings cover the
+    # optional workspace filter without joining WHERE fragments.
+    issue_patterns = (
         f"%issue-{issue_key}%",
         f"%issues/{issue_key}%",
         f"%#{issue_key}%",
         f"%issue {issue_key}%",
-    ])
-    sql = (
-        "SELECT chunk_id, source_id, text, category_labels, igio_axis, igio_confidence "
-        f"FROM chunks WHERE {' AND '.join(where)} "
-        "ORDER BY igio_confidence DESC, created_at DESC LIMIT ?"
     )
-    params.append(limit)
-    rows = conn.execute(sql, tuple(params)).fetchall()
+    if workspace_id:
+        rows = conn.execute(
+            "SELECT chunk_id, source_id, text, category_labels, igio_axis, "
+            "igio_confidence FROM chunks "
+            "WHERE igio_axis = ? AND is_active = 1 AND workspace_id = ? "
+            "AND (source_id LIKE ? OR source_id LIKE ? "
+            "     OR text LIKE ? OR text LIKE ?) "
+            "ORDER BY igio_confidence DESC, created_at DESC LIMIT ?",
+            (axis, workspace_id, *issue_patterns, limit),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT chunk_id, source_id, text, category_labels, igio_axis, "
+            "igio_confidence FROM chunks "
+            "WHERE igio_axis = ? AND is_active = 1 "
+            "AND (source_id LIKE ? OR source_id LIKE ? "
+            "     OR text LIKE ? OR text LIKE ?) "
+            "ORDER BY igio_confidence DESC, created_at DESC LIMIT ?",
+            (axis, *issue_patterns, limit),
+        ).fetchall()
     return [_to_chunk(r) for r in rows]
 
 
@@ -252,15 +260,21 @@ def discover_issue_ids(conn: DBAdapter, workspace_id: str | None = None) -> list
 
     Lets callers ask "which issues do I have data for" without scanning text.
     """
-    where = ["source_type = 'github_issue'"]
-    params: list = []
+    # Two fixed SQL strings — workspace_id is the only optional filter and
+    # rides on a placeholder. No string concatenation of caller input into
+    # the query body; satisfies the opengrep raw-query audit.
     if workspace_id:
-        where.append("workspace_id = ?")
-        params.append(workspace_id)
-    rows = conn.execute(
-        f"SELECT DISTINCT source_id FROM sources WHERE {' AND '.join(where)}",
-        tuple(params),
-    ).fetchall()
+        rows = conn.execute(
+            "SELECT DISTINCT source_id FROM sources "
+            "WHERE source_type = 'github_issue' AND workspace_id = ?",
+            (workspace_id,),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT DISTINCT source_id FROM sources "
+            "WHERE source_type = 'github_issue'",
+            (),
+        ).fetchall()
     out: set[str] = set()
     pattern = re.compile(r"issue[s]?[/_-](\d+)", re.I)
     for r in rows:

--- a/tests/test_igio_classifier.py
+++ b/tests/test_igio_classifier.py
@@ -146,6 +146,41 @@ def test_parse_verdict_remaps_common_aliases(alias: str, canonical: str) -> None
     assert v.confidence < 1.0  # penalised for non-canonical token
 
 
+def test_parse_verdict_alias_low_confidence_clamps_to_zero() -> None:
+    """Alias confidence below the penalty must clamp to 0.0, not go negative."""
+    raw = json.dumps({"axis": "tests", "confidence": 0.05, "rationale": "x"})
+    v = _parse_verdict(raw)
+    assert v is not None
+    assert v.axis == "outcome"
+    assert v.confidence == 0.0
+
+
+def test_parse_verdict_alias_missing_confidence_stays_zero() -> None:
+    """Missing confidence + alias penalty must not produce a negative value."""
+    raw = json.dumps({"axis": "tests", "rationale": "x"})
+    v = _parse_verdict(raw)
+    assert v is not None
+    assert v.axis == "outcome"
+    assert v.confidence == 0.0
+
+
+def test_parse_verdict_strips_fence_with_trailing_whitespace() -> None:
+    """Closing fence followed by whitespace must still parse cleanly."""
+    raw = '```json\n{"axis": "outcome", "confidence": 0.7, "rationale": "x"}\n```   \n'
+    v = _parse_verdict(raw)
+    assert v is not None and v.axis == "outcome"
+
+
+def test_parse_verdict_strips_fence_with_trailing_text() -> None:
+    """Trailing prose after the closing fence is also tolerated."""
+    raw = (
+        '```json\n{"axis": "issue", "confidence": 0.8, "rationale": "x"}\n'
+        '```\n\nLet me know if you need more.'
+    )
+    v = _parse_verdict(raw)
+    assert v is not None and v.axis == "issue"
+
+
 def test_parse_verdict_unknown_axis_still_rejected() -> None:
     """Aliases are an allow-list, not a free-for-all."""
     raw = json.dumps({"axis": "improvement", "confidence": 0.9, "rationale": "x"})


### PR DESCRIPTION
## Summary
PR #123 squash-merged before the follow-up review-fix commit landed. This PR applies those fixes on top of fresh master.

## Review points addressed

### 1. `_strip_markdown_fence` was too strict
Previously required `body.endswith('```')` — silently failed on replies like:
````
\`\`\`json
{"axis": "outcome", ...}
\`\`\`

Let me know if you need more.
````
Now trims trailing whitespace and accepts arbitrary text after the closing fence by searching for the **last** ``` rather than asserting the suffix. Two new tests: trailing whitespace + trailing prose.

### 2. Alias-penalty edge cases (Comment #1)
Two new tests pin the clamping behaviour after `_ALIAS_PENALTY` (0.1):
- `axis="tests", confidence=0.05` → `outcome / 0.0` (clamps, no negative)
- `axis="tests"` (no confidence key) → `outcome / 0.0` (default 0.0 stays at 0.0)

Locks the semantics so future tuning of `_ALIAS_PENALTY` can't silently produce negative confidences.

### 3. Dynamic WHERE-clause builders (Comment #2 + extension)
Opengrep flagged `recap_indexer.discover_issue_ids`. Two more identical patterns existed in `cli._cmd_classify_igio` and `recap_indexer._chunks_for_axis` — all three refactored. Pattern was:
```python
where = ["base = ?"]
params = [...]
if optional_filter:
    where.append("workspace_id = ?")
    params.append(...)
sql = f"... WHERE {' AND '.join(where)} ..."
```
Now: two static SQL paths (workspace_id present / absent). All values are parameter-bound; no concatenation of caller input into the query body.

### 4. `_build_igio_section` source_id heuristic (overall comment)
`%<filename>%` was too loose — `auth.py` matched `oauth.py` and `auth.py.bak`. Now anchors on a path separator: `%/<filename>` for bare names, `%<path>%` when the caller already includes a separator. Cross-repo ambiguity (same relative path in two repos) is documented for callers who want stricter matching.

## Test plan
- [x] `pytest tests/test_igio_classifier.py tests/test_recap_indexer.py tests/test_wiki_v2_injection.py` → 54/54 pass
- [x] `grep "f\\\".*WHERE.*join(where)" src/` → empty
- [ ] After merge: opengrep raw-query alert count drops to zero on the wiki module

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten wiki IGIO handling and address SQL and parsing review feedback.

Bug Fixes:
- Relax fenced-markdown stripping to handle trailing whitespace and prose while still extracting valid JSON from LLM replies.
- Clamp alias-adjusted verdict confidences at zero to prevent negative values when confidence is low or omitted.

Enhancements:
- Refine IGIO source_id matching to anchor filenames on path separators and reduce false matches across similar file names.
- Replace dynamic WHERE-clause construction with two static, parameterised SQL paths across wiki indexing and CLI commands to satisfy raw-query audits and keep input fully bound.

Tests:
- Add regression tests for alias confidence clamping, fenced reply parsing edge cases, and IGIO classifier behaviour to lock in the adjusted semantics.