### PR TITLE
fix(wiki): tighten fence-detection + root-level filename matching

### DIFF
--- a/src/wiki_v2/igio_classifier.py
+++ b/src/wiki_v2/igio_classifier.py
@@ -121,11 +121,12 @@ def _build_user_prompt(text: str, category_labels: list[str]) -> str:
 def _strip_markdown_fence(raw: str) -> str:
     """Strip a leading ```json … ``` fence if the LLM wrapped its reply.
 
-    Tolerant by design — trims trailing whitespace and accepts arbitrary text
-    after the closing fence (some models append "Let me know if…" prose).
-    Strategy: detect leading fence, drop optional language tag, then trim from
-    the LAST ``` onwards. Strict endswith() would silently lose otherwise-
-    valid fenced JSON.
+    Tolerates leading whitespace before the opening fence, language tags,
+    trailing whitespace and arbitrary prose after the closing fence. The
+    closing fence is only recognised when it appears at the START of a line
+    (the body of the fence has been seen) — a stray ``` inside the JSON
+    payload (e.g. as part of a markdown example in a string value) will not
+    be treated as the closing fence.
     """
     if not raw.lstrip().startswith("```"):
         return raw
@@ -136,9 +137,15 @@ def _strip_markdown_fence(raw: str) -> str:
         if not first.strip().startswith("{"):
             body = rest
     body = body.rstrip()
-    last_fence = body.rfind("```")
-    if last_fence != -1:
-        body = body[:last_fence]
+    # Closing fence must be on its own line — search for "\n```" anchor.
+    # Falls back to the bare last "```" only when nothing follows it (i.e.
+    # the body literally ends with the fence), which can never be embedded
+    # JSON content.
+    line_anchored = body.rfind("\n```")
+    if line_anchored != -1:
+        body = body[:line_anchored]
+    elif body.endswith("```"):
+        body = body[:-3]
     return body.strip()
 
 

--- a/src/wiki_v2/injection.py
+++ b/src/wiki_v2/injection.py
@@ -98,28 +98,36 @@ class WikiContextInjector:
         if not filename:
             return ""
         # Anchor on a path separator so `auth.py` doesn't match `oauth.py`
-        # or `auth.py.bak`. A filename containing `/` is treated as a
-        # path fragment and used verbatim.
-        like_pattern = (
-            f"%{filename}%" if "/" in filename else f"%/{filename}"
-        )
+        # or `auth.py.bak`. Two parallel patterns so root-level files at
+        # `repo:owner/name:auth.py` are matched too:
+        #   - `%/auth.py`   → files under a directory
+        #   - `%:auth.py`   → files at the repo root
+        # A filename containing `/` is treated as a path fragment used verbatim.
+        if "/" in filename:
+            like_pattern = f"%{filename}%"
+            like_alt = like_pattern   # same pattern, repeated to keep SQL shape
+        else:
+            like_pattern = f"%/{filename}"
+            like_alt = f"%:{filename}"
         # Static SQL strings + parameterised values — opengrep raw-query
         # audit clean.
         if workspace_id:
             count_sql = (
                 "SELECT igio_axis, COUNT(*) AS n FROM chunks "
                 "WHERE igio_axis != '' AND is_active = 1 "
-                "AND source_id LIKE ? AND workspace_id = ? "
+                "AND (source_id LIKE ? OR source_id LIKE ?) "
+                "AND workspace_id = ? "
                 "GROUP BY igio_axis"
             )
-            count_params: tuple = (like_pattern, workspace_id)
+            count_params: tuple = (like_pattern, like_alt, workspace_id)
         else:
             count_sql = (
                 "SELECT igio_axis, COUNT(*) AS n FROM chunks "
-                "WHERE igio_axis != '' AND is_active = 1 AND source_id LIKE ? "
+                "WHERE igio_axis != '' AND is_active = 1 "
+                "AND (source_id LIKE ? OR source_id LIKE ?) "
                 "GROUP BY igio_axis"
             )
-            count_params = (like_pattern,)
+            count_params = (like_pattern, like_alt)
         counts = memory_conn.execute(count_sql, count_params).fetchall()
         if not counts:
             return ""
@@ -132,18 +140,19 @@ class WikiContextInjector:
                 sample_sql = (
                     "SELECT substr(text, 1, 100) AS preview, igio_confidence "
                     "FROM chunks WHERE igio_axis = ? AND is_active = 1 "
-                    "AND source_id LIKE ? AND workspace_id = ? "
+                    "AND (source_id LIKE ? OR source_id LIKE ?) "
+                    "AND workspace_id = ? "
                     "ORDER BY igio_confidence DESC LIMIT 1"
                 )
-                sample_params: tuple = (axis, like_pattern, workspace_id)
+                sample_params: tuple = (axis, like_pattern, like_alt, workspace_id)
             else:
                 sample_sql = (
                     "SELECT substr(text, 1, 100) AS preview, igio_confidence "
                     "FROM chunks WHERE igio_axis = ? AND is_active = 1 "
-                    "AND source_id LIKE ? "
+                    "AND (source_id LIKE ? OR source_id LIKE ?) "
                     "ORDER BY igio_confidence DESC LIMIT 1"
                 )
-                sample_params = (axis, like_pattern)
+                sample_params = (axis, like_pattern, like_alt)
             sample = memory_conn.execute(sample_sql, sample_params).fetchone()
             if sample:
                 preview = (sample["preview"] or "").replace("\n", " ").strip()

--- a/tests/test_igio_classifier.py
+++ b/tests/test_igio_classifier.py
@@ -164,6 +164,17 @@ def test_parse_verdict_alias_missing_confidence_stays_zero() -> None:
     assert v.confidence == 0.0
 
 
+def test_parse_verdict_alias_confidence_equal_to_penalty_clamps_to_zero() -> None:
+    """Boundary case: confidence exactly equal to _ALIAS_PENALTY (0.1)
+    must produce 0.0 — not a near-zero positive — so the clamp semantics
+    are unambiguous if the penalty constant is ever tuned."""
+    raw = json.dumps({"axis": "tests", "confidence": 0.1, "rationale": "x"})
+    v = _parse_verdict(raw)
+    assert v is not None
+    assert v.axis == "outcome"
+    assert v.confidence == 0.0
+
+
 def test_parse_verdict_strips_fence_with_trailing_whitespace() -> None:
     """Closing fence followed by whitespace must still parse cleanly."""
     raw = '```json\n{"axis": "outcome", "confidence": 0.7, "rationale": "x"}\n```   \n'
@@ -179,6 +190,28 @@ def test_parse_verdict_strips_fence_with_trailing_text() -> None:
     )
     v = _parse_verdict(raw)
     assert v is not None and v.axis == "issue"
+
+
+def test_parse_verdict_strips_fence_with_leading_whitespace() -> None:
+    """Leading spaces/newlines before the opening fence must still parse."""
+    raw = '   \n```json\n{"axis": "goal", "confidence": 0.6, "rationale": "x"}\n```'
+    v = _parse_verdict(raw)
+    assert v is not None and v.axis == "goal"
+
+
+def test_parse_verdict_keeps_backticks_inside_rationale() -> None:
+    """A stray triple-backtick inside the rationale (e.g. a markdown example)
+    must NOT be treated as the closing fence — the closer is line-anchored."""
+    raw = (
+        '```json\n'
+        '{"axis": "intervention", "confidence": 0.7, '
+        '"rationale": "Example shown as ``` snippet ``` inside text"}\n'
+        '```'
+    )
+    v = _parse_verdict(raw)
+    assert v is not None
+    assert v.axis == "intervention"
+    assert "snippet" in v.rationale
 
 
 def test_parse_verdict_unknown_axis_still_rejected() -> None:


### PR DESCRIPTION
## Summary
Follow-up review items from PR #124 — Sourcery flagged three points after PR #124 was already merged. This PR applies them on fresh master.

## Review points addressed

### 1. `_strip_markdown_fence` could trim payload backticks (bug_risk)
Previous `body.rfind("```")` would strip from any triple-backtick anywhere in the body — including a stray ``` that legitimately appears inside the JSON payload (e.g. as part of a markdown example in the `rationale` value). The closing fence is now **line-anchored**:
- primary: `\n```` (a fence at the start of a line)
- fallback: `body.endswith("```")` (when the JSON literally ends with the fence and nothing follows)

Anywhere-else-in-the-body backticks survive intact. New test `test_parse_verdict_keeps_backticks_inside_rationale` pins this.

### 2. Boundary alias-clamp test (Comment #2)
Previous tests covered `confidence < penalty` and missing-confidence. New test covers the exact-boundary case `confidence == _ALIAS_PENALTY (0.1)`: must clamp to `0.0`, not a near-zero positive. Locks the semantics if the constant is ever tuned.

### 3. Leading-whitespace test (Comment #3)
`_strip_markdown_fence` uses `raw.lstrip().startswith("```")`. Explicit test with leading spaces/newlines before the opening fence guards against regressions.

### 4. Root-level filename matching (overall comment)
`_build_igio_section` previously only matched `%/auth.py` for bare names — missed `repo:owner/name:auth.py` (file at repo root, where the colon is the only separator). Now uses two OR'd LIKE patterns:
- `%/{name}` → files under a directory
- `%:{name}` → files at the repo root

A filename containing `/` is still treated as a path fragment used verbatim.

### Not addressed: workspace/no-workspace SQL helper
The "consider a small helper" suggestion is intentionally deferred — extracting the duplication would re-introduce SQL-string composition that the previous Sourcery review (the one merged in PR #124) explicitly asked to remove. The static-SQL-paths approach is more verbose but keeps the parameterisation clean and the opengrep audit silent.

## Test plan
- [x] `pytest tests/test_igio_classifier.py tests/test_recap_indexer.py tests/test_wiki_v2_injection.py` → 57/57 pass
- [x] New tests cover: backticks-in-rationale, confidence==penalty boundary, leading whitespace before fence
- [x] Existing 9 wiki injection tests untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten wiki verdict parsing and IGIO section source matching to handle edge cases more robustly.

Bug Fixes:
- Ensure markdown fence stripping in verdict parsing does not remove legitimate triple backticks inside JSON string values.
- Fix IGIO section source matching so bare filenames also match root-level files of the form repo:owner/name:filename, not only path-based matches.

Enhancements:
- Clarify and broaden markdown fence handling to tolerate leading whitespace, language tags, and trailing prose while keeping fenced JSON extraction reliable.

Tests:
- Add boundary test for alias confidence equal to the penalty value to guarantee clamping to zero.
- Add tests covering leading whitespace before the markdown fence and preservation of triple backticks inside the rationale when parsing verdicts.