### PR TITLE
feat(pi): async pi_task — persistent jobs + worker thread (Plan C Phase 1)

### DIFF
--- a/src/agents/pi_jobs.py
+++ b/src/agents/pi_jobs.py
@@ -1,0 +1,242 @@
+"""Persistent pi-task job lifecycle on top of memory.db.
+
+Lifecycle:
+    queued    — `insert_job()` writes the row, status='queued'
+    running   — worker calls `claim_next()`: atomically flips one queued row
+                to 'running' and returns it
+    completed — worker calls `complete_job(job_id, result_json)`
+    failed    — worker calls `fail_job(job_id, error)`
+
+The atomic flip in `claim_next()` is implemented as a single
+`UPDATE … WHERE status='queued' AND job_id IN (SELECT … LIMIT 1)`. SQLite
+serialises writes so two concurrent workers cannot grab the same job.
+
+This module is intentionally independent of FastMCP / LLM logic — keeps the
+data layer testable in isolation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import sqlite3
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.config import CACHE_DIR
+
+VALID_STATUSES = ("queued", "running", "completed", "failed")
+VALID_PREFER = ("auto", "local", "cloud")
+
+
+@dataclass
+class PiJob:
+    job_id: str
+    task_text: str
+    repo_slug: str = ""
+    workspace_id: str = "default"
+    status: str = "queued"
+    prefer: str = "auto"
+    ollama_url: str = ""
+    model: str = ""
+    result_json: str = ""
+    error: str = ""
+    timeout_s: float = 180.0
+    created_at: str = ""
+    started_at: str = ""
+    finished_at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        d = self.__dict__.copy()
+        # Decode result_json into a real object for callers
+        d["result"] = _safe_json_load(self.result_json) if self.result_json else None
+        return d
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _new_job_id() -> str:
+    raw = f"{time.time_ns()}:{secrets.token_hex(4)}"
+    return "pij_" + hashlib.sha256(raw.encode()).hexdigest()[:12]
+
+
+def _safe_json_load(s: str) -> Any:
+    try:
+        return json.loads(s)
+    except (TypeError, ValueError):
+        return s
+
+
+def _conn(db_path: Path | None = None) -> sqlite3.Connection:
+    """Lightweight per-call connection — pi_jobs operations are short.
+
+    Each call uses its own connection with row_factory=Row + WAL so reads
+    and writes from the worker thread don't fight a long-lived sqlite
+    handle that another module may have opened.
+    """
+    p = db_path or (CACHE_DIR / "memory.db")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(p), check_same_thread=False, timeout=10.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA busy_timeout = 10000")
+    return conn
+
+
+def insert_job(
+    task_text: str,
+    *,
+    repo_slug: str = "",
+    workspace_id: str = "default",
+    prefer: str = "auto",
+    ollama_url: str = "",
+    model: str = "",
+    timeout_s: float = 180.0,
+    db_path: Path | None = None,
+) -> PiJob:
+    """Insert a new job in `queued` state. Returns the persisted job."""
+    if prefer not in VALID_PREFER:
+        raise ValueError(f"prefer must be one of {VALID_PREFER}, got {prefer!r}")
+    job = PiJob(
+        job_id=_new_job_id(),
+        task_text=task_text,
+        repo_slug=repo_slug,
+        workspace_id=workspace_id,
+        prefer=prefer,
+        ollama_url=ollama_url,
+        model=model,
+        timeout_s=float(timeout_s),
+        created_at=_now_iso(),
+    )
+    conn = _conn(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO pi_jobs (job_id, task_text, repo_slug, workspace_id, "
+            "status, prefer, ollama_url, model, timeout_s, created_at) "
+            "VALUES (?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?)",
+            (
+                job.job_id, job.task_text, job.repo_slug, job.workspace_id,
+                job.prefer, job.ollama_url, job.model, job.timeout_s, job.created_at,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return job
+
+
+def claim_next(*, db_path: Path | None = None) -> PiJob | None:
+    """Atomically take the oldest queued job, flip to 'running'."""
+    conn = _conn(db_path)
+    try:
+        # Single UPDATE … WHERE … = atomic flip; RETURNING is sqlite >= 3.35
+        row = conn.execute(
+            "UPDATE pi_jobs SET status='running', started_at=? "
+            "WHERE job_id = (SELECT job_id FROM pi_jobs WHERE status='queued' "
+            "                ORDER BY created_at LIMIT 1) "
+            "RETURNING *",
+            (_now_iso(),),
+        ).fetchone()
+        conn.commit()
+    finally:
+        conn.close()
+    return _row_to_job(row) if row else None
+
+
+def complete_job(job_id: str, result: Any, *, db_path: Path | None = None) -> None:
+    """Mark a job completed with the JSON-encodable `result` payload."""
+    payload = json.dumps(result) if not isinstance(result, str) else result
+    conn = _conn(db_path)
+    try:
+        conn.execute(
+            "UPDATE pi_jobs SET status='completed', result_json=?, finished_at=? "
+            "WHERE job_id=? AND status='running'",
+            (payload, _now_iso(), job_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def fail_job(job_id: str, error: str, *, db_path: Path | None = None) -> None:
+    """Mark a job failed with a short error string."""
+    conn = _conn(db_path)
+    try:
+        conn.execute(
+            "UPDATE pi_jobs SET status='failed', error=?, finished_at=? "
+            "WHERE job_id=? AND status IN ('queued', 'running')",
+            (str(error)[:1000], _now_iso(), job_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_job(job_id: str, *, db_path: Path | None = None) -> PiJob | None:
+    conn = _conn(db_path)
+    try:
+        row = conn.execute(
+            "SELECT * FROM pi_jobs WHERE job_id=?", (job_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    return _row_to_job(row) if row else None
+
+
+def list_recent(
+    *, only_active: bool = False, limit: int = 10, db_path: Path | None = None,
+) -> list[PiJob]:
+    conn = _conn(db_path)
+    try:
+        if only_active:
+            rows = conn.execute(
+                "SELECT * FROM pi_jobs WHERE status IN ('queued', 'running') "
+                "ORDER BY created_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM pi_jobs ORDER BY created_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+    finally:
+        conn.close()
+    return [_row_to_job(r) for r in rows]
+
+
+def _row_to_job(row: sqlite3.Row) -> PiJob:
+    return PiJob(
+        job_id=row["job_id"],
+        task_text=row["task_text"],
+        repo_slug=row["repo_slug"] or "",
+        workspace_id=row["workspace_id"] or "default",
+        status=row["status"],
+        prefer=row["prefer"] or "auto",
+        ollama_url=row["ollama_url"] or "",
+        model=row["model"] or "",
+        result_json=row["result_json"] or "",
+        error=row["error"] or "",
+        timeout_s=float(row["timeout_s"] or 180.0),
+        created_at=row["created_at"],
+        started_at=row["started_at"] or "",
+        finished_at=row["finished_at"] or "",
+    )
+
+
+__all__ = (
+    "PiJob",
+    "VALID_PREFER",
+    "VALID_STATUSES",
+    "insert_job",
+    "claim_next",
+    "complete_job",
+    "fail_job",
+    "get_job",
+    "list_recent",
+)

--- a/src/agents/pi_worker.py
+++ b/src/agents/pi_worker.py
@@ -1,0 +1,130 @@
+"""Background worker thread that drains pi_jobs.
+
+Runs as a daemon thread spawned at import time by `local_mcp.py`. Polls the
+`pi_jobs` table for `status='queued'` rows, atomically claims them, and runs
+`run_task_with_memory()` directly (no subprocess). Results are persisted via
+`complete_job()` / `fail_job()`.
+
+A single workflow.start() guard prevents double-starting the loop when the
+module is imported multiple times (e.g. tests vs runtime).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from src.agents import pi_jobs
+from src.agents.pi_jobs import PiJob
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_POLL_INTERVAL = 1.0
+_DEFAULT_MAX_WORKERS = 2
+
+_lock = threading.Lock()
+_started: bool = False
+_stop_event: threading.Event | None = None
+_executor: ThreadPoolExecutor | None = None
+_loop_thread: threading.Thread | None = None
+
+
+def _resolve_executor() -> ThreadPoolExecutor:
+    """Lazy-create a ThreadPoolExecutor; capacity comes from PI_ASYNC_WORKERS env."""
+    global _executor
+    if _executor is None:
+        size = max(1, int(os.getenv("PI_ASYNC_WORKERS", str(_DEFAULT_MAX_WORKERS))))
+        _executor = ThreadPoolExecutor(max_workers=size, thread_name_prefix="pi-worker")
+        logger.info("pi_worker: ThreadPoolExecutor started (workers=%d)", size)
+    return _executor
+
+
+def _execute(job: PiJob) -> None:
+    """Run a single job. Persists outcome via complete_job/fail_job."""
+    try:
+        from src.agents.pi import run_task_with_memory
+        ollama = job.ollama_url or os.getenv("OLLAMA_URL", "http://localhost:11434")
+        result = run_task_with_memory(
+            task=job.task_text,
+            ollama_url=ollama,
+            model=job.model or os.getenv("OLLAMA_MODEL", "qwen2.5-coder:7b"),
+            repo_slug=job.repo_slug or None,
+            timeout=job.timeout_s,
+        )
+        pi_jobs.complete_job(job.job_id, {"text": result})
+        logger.info("pi_worker: completed %s", job.job_id)
+    except Exception as e:
+        logger.exception("pi_worker: failed %s", job.job_id)
+        pi_jobs.fail_job(job.job_id, repr(e))
+
+
+def _loop(stop: threading.Event, poll_interval: float) -> None:
+    """Polling loop body. Runs in a dedicated thread."""
+    executor = _resolve_executor()
+    while not stop.is_set():
+        try:
+            job = pi_jobs.claim_next()
+        except Exception:
+            logger.exception("pi_worker: claim_next failed")
+            stop.wait(poll_interval)
+            continue
+        if job is None:
+            stop.wait(poll_interval)
+            continue
+        executor.submit(_execute, job)
+
+
+def start(*, poll_interval: float = _DEFAULT_POLL_INTERVAL) -> bool:
+    """Start the worker loop once per process. Returns True on first start.
+
+    Subsequent calls return False without side effects — the loop is a
+    process-scoped singleton.
+    """
+    global _started, _stop_event, _loop_thread
+    with _lock:
+        if _started:
+            return False
+        if os.getenv("PI_ASYNC_DISABLED", "").lower() in ("1", "true", "yes"):
+            logger.info("pi_worker: disabled via PI_ASYNC_DISABLED")
+            _started = True
+            return False
+        _stop_event = threading.Event()
+        _loop_thread = threading.Thread(
+            target=_loop,
+            args=(_stop_event, poll_interval),
+            name="pi-worker-loop",
+            daemon=True,
+        )
+        _loop_thread.start()
+        _started = True
+        logger.info("pi_worker: loop thread started (poll=%.1fs)", poll_interval)
+        return True
+
+
+def stop(timeout: float = 2.0) -> None:
+    """Stop the loop and shut the executor down. Used from tests."""
+    global _started, _stop_event, _executor, _loop_thread
+    with _lock:
+        if not _started:
+            return
+        if _stop_event is not None:
+            _stop_event.set()
+        if _loop_thread is not None:
+            _loop_thread.join(timeout=timeout)
+        if _executor is not None:
+            _executor.shutdown(wait=False, cancel_futures=True)
+        _stop_event = None
+        _executor = None
+        _loop_thread = None
+        _started = False
+
+
+def _is_running() -> bool:
+    """For tests: peek at internal state."""
+    return _started
+
+
+__all__ = ("start", "stop", "_is_running")

--- a/src/api/local_mcp.py
+++ b/src/api/local_mcp.py
@@ -41,9 +41,19 @@ os.environ.setdefault("MAYRING_LOCAL_CHROMA", str(_local_cache / "chroma"))
 os.environ.setdefault("PI_AGENT_URL", "direct")
 
 from src.api.mcp_agent_tools import register_agent_tools  # noqa: E402
+from src.memory.store import init_memory_db  # noqa: E402
+from src.agents import pi_worker  # noqa: E402
+
+# Ensure schema (incl. pi_jobs table) exists before the worker starts polling.
+_local_db = Path(os.environ["MAYRING_LOCAL_DB"])
+init_memory_db(_local_db).close()
 
 mcp = FastMCP("memory-agents")
 register_agent_tools(mcp)
+
+# Start the background worker loop. Idempotent — start() is a no-op if the
+# loop is already running. Disable via PI_ASYNC_DISABLED=1 (used in tests).
+pi_worker.start()
 
 
 if __name__ == "__main__":

--- a/src/api/mcp_agent_tools.py
+++ b/src/api/mcp_agent_tools.py
@@ -102,6 +102,113 @@ def register_agent_tools(mcp: FastMCP) -> None:
             return {"error": str(exc)}
 
     @mcp.tool()
+    def pi_task_start(
+        task: str,
+        repo_slug: str | None = None,
+        prefer: str = "auto",
+        ollama_url: str | None = None,
+        model: str | None = None,
+        timeout: float = 180.0,
+        workspace_id: str | None = None,
+    ) -> dict:
+        """Submit a pi-task asynchronously. Returns immediately with a job_id.
+
+        The local worker thread (started at MCP-server boot) picks the job up,
+        runs `run_task_with_memory()` on the configured Ollama backend, and
+        persists the result. Poll `pi_task_status(job_id)` to retrieve it.
+
+        Args:
+            task: Free-form task description.
+            repo_slug: Repository slug for memory scope filtering.
+            prefer: "auto" | "local" | "cloud" — routing hint (Phase 2 honours it;
+                Phase 1 always runs locally).
+            ollama_url: Override the default OLLAMA_URL for this single job.
+            model: Override the resolved model for this single job.
+            timeout: Per-LLM-request timeout (seconds).
+            workspace_id: Tenant namespace (default: from JWT).
+
+        Returns:
+            {"job_id": "pij_...", "status": "queued", "workspace_id": "..."}
+        """
+        from src.agents import pi_jobs
+        ws = _enforce_tenant(workspace_id) or _effective_workspace_id()
+        if prefer not in pi_jobs.VALID_PREFER:
+            return {
+                "error": f"prefer must be one of {pi_jobs.VALID_PREFER}",
+                "workspace_id": ws,
+            }
+        try:
+            job = pi_jobs.insert_job(
+                task_text=task,
+                repo_slug=repo_slug or "",
+                workspace_id=ws,
+                prefer=prefer,
+                ollama_url=ollama_url or "",
+                model=model or _model("complex"),
+                timeout_s=timeout,
+            )
+        except Exception as exc:
+            return {"error": str(exc), "workspace_id": ws}
+        return {"job_id": job.job_id, "status": "queued", "workspace_id": ws}
+
+    @mcp.tool()
+    def pi_task_status(job_id: str, workspace_id: str | None = None) -> dict:
+        """Return the current state of a pi-task job.
+
+        Result envelope:
+            {"job_id", "status", "result", "error",
+             "started_at", "finished_at", "workspace_id"}
+
+        `result` is the JSON-decoded payload when status == "completed",
+        otherwise None.
+        """
+        from src.agents import pi_jobs
+        ws = _enforce_tenant(workspace_id) or _effective_workspace_id()
+        job = pi_jobs.get_job(job_id)
+        if job is None:
+            return {"error": "not found", "job_id": job_id, "workspace_id": ws}
+        d = job.to_dict()
+        return {
+            "job_id": d["job_id"],
+            "status": d["status"],
+            "result": d["result"],
+            "error": d["error"],
+            "started_at": d["started_at"],
+            "finished_at": d["finished_at"],
+            "workspace_id": ws,
+        }
+
+    @mcp.tool()
+    def pi_task_list(
+        only_active: bool = False,
+        limit: int = 10,
+        workspace_id: str | None = None,
+    ) -> dict:
+        """List recent pi-task jobs (default: 10 newest, all statuses).
+
+        Set `only_active=True` to see only queued+running jobs.
+        """
+        from src.agents import pi_jobs
+        ws = _enforce_tenant(workspace_id) or _effective_workspace_id()
+        jobs = pi_jobs.list_recent(only_active=only_active, limit=max(1, min(50, limit)))
+        return {
+            "jobs": [
+                {
+                    "job_id": j.job_id,
+                    "status": j.status,
+                    "task_preview": j.task_text[:120],
+                    "created_at": j.created_at,
+                    "started_at": j.started_at,
+                    "finished_at": j.finished_at,
+                    "model": j.model,
+                    "prefer": j.prefer,
+                }
+                for j in jobs
+            ],
+            "workspace_id": ws,
+        }
+
+    @mcp.tool()
     def ingest(
         source: str,
         source_type: str = "auto",

--- a/src/memory/store.py
+++ b/src/memory/store.py
@@ -223,6 +223,26 @@ def _init_schema(conn: DBAdapter) -> None:
             last_fired   TEXT NOT NULL DEFAULT ''
         );
 
+        CREATE TABLE IF NOT EXISTS pi_jobs (
+            job_id          TEXT PRIMARY KEY,
+            task_text       TEXT NOT NULL,
+            repo_slug       TEXT NOT NULL DEFAULT '',
+            workspace_id    TEXT NOT NULL DEFAULT 'default',
+            status          TEXT NOT NULL DEFAULT 'queued',
+            prefer          TEXT NOT NULL DEFAULT 'auto',
+            ollama_url      TEXT NOT NULL DEFAULT '',
+            model           TEXT NOT NULL DEFAULT '',
+            result_json     TEXT NOT NULL DEFAULT '',
+            error           TEXT NOT NULL DEFAULT '',
+            timeout_s       REAL NOT NULL DEFAULT 180.0,
+            created_at      TEXT NOT NULL,
+            started_at      TEXT NOT NULL DEFAULT '',
+            finished_at     TEXT NOT NULL DEFAULT ''
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_pi_jobs_status ON pi_jobs(status);
+        CREATE INDEX IF NOT EXISTS idx_pi_jobs_created ON pi_jobs(created_at);
+
         CREATE TABLE IF NOT EXISTS context_feedback_log (
             id               INTEGER PRIMARY KEY AUTOINCREMENT,
             trigger_ids      TEXT NOT NULL,

--- a/tests/test_pi_jobs.py
+++ b/tests/test_pi_jobs.py
@@ -1,0 +1,196 @@
+"""Hermetic tests for pi_jobs lifecycle + worker-loop.
+
+The worker is exercised end-to-end with a mocked `run_task_with_memory` so
+the test runs without Ollama. Schema migration is verified in isolation.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.agents import pi_jobs, pi_worker
+from src.memory.store import init_memory_db
+
+
+@pytest.fixture
+def db(tmp_path: Path):
+    p = tmp_path / "memory.db"
+    init_memory_db(p).close()
+    yield p
+
+
+def _wait_for_status(db_path: Path, job_id: str, target: str, timeout: float = 5.0):
+    start = time.time()
+    while time.time() - start < timeout:
+        row = sqlite3.connect(db_path).execute(
+            "SELECT status FROM pi_jobs WHERE job_id=?", (job_id,)
+        ).fetchone()
+        if row and row[0] == target:
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"job {job_id} stuck at {row[0] if row else 'missing'}")
+
+
+# ----- Schema migration --------------------------------------------------
+
+
+def test_pi_jobs_table_created(db: Path) -> None:
+    cols = {r[1] for r in sqlite3.connect(db).execute(
+        "PRAGMA table_info(pi_jobs)"
+    ).fetchall()}
+    assert {
+        "job_id", "task_text", "repo_slug", "workspace_id", "status",
+        "prefer", "ollama_url", "model", "result_json", "error",
+        "timeout_s", "created_at", "started_at", "finished_at",
+    } <= cols
+
+
+def test_init_memory_db_idempotent(db: Path) -> None:
+    init_memory_db(db).close()  # second call must not crash on existing index
+
+
+# ----- Lifecycle ---------------------------------------------------------
+
+
+def test_insert_job_starts_queued(db: Path) -> None:
+    job = pi_jobs.insert_job("hi", db_path=db)
+    fetched = pi_jobs.get_job(job.job_id, db_path=db)
+    assert fetched is not None
+    assert fetched.status == "queued"
+    assert fetched.task_text == "hi"
+
+
+def test_insert_job_rejects_invalid_prefer(db: Path) -> None:
+    with pytest.raises(ValueError):
+        pi_jobs.insert_job("x", prefer="never", db_path=db)
+
+
+def test_claim_next_returns_oldest_first(db: Path) -> None:
+    a = pi_jobs.insert_job("first", db_path=db)
+    time.sleep(0.01)
+    b = pi_jobs.insert_job("second", db_path=db)
+    claimed = pi_jobs.claim_next(db_path=db)
+    assert claimed is not None
+    assert claimed.job_id == a.job_id
+    assert claimed.status == "running"
+    # The other job is still queued
+    assert pi_jobs.get_job(b.job_id, db_path=db).status == "queued"
+
+
+def test_claim_next_returns_none_when_empty(db: Path) -> None:
+    assert pi_jobs.claim_next(db_path=db) is None
+
+
+def test_claim_next_atomic_under_concurrency(db: Path) -> None:
+    """Two concurrent claim_next() must not both grab the same row."""
+    pi_jobs.insert_job("only-one", db_path=db)
+
+    import threading
+    results: list = []
+    barrier = threading.Barrier(2)
+
+    def worker() -> None:
+        barrier.wait()
+        results.append(pi_jobs.claim_next(db_path=db))
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    [t.start() for t in threads]
+    [t.join() for t in threads]
+
+    claimed = [r for r in results if r is not None]
+    assert len(claimed) == 1, f"both threads claimed: {results}"
+
+
+def test_complete_job_sets_result(db: Path) -> None:
+    job = pi_jobs.insert_job("hi", db_path=db)
+    pi_jobs.claim_next(db_path=db)
+    pi_jobs.complete_job(job.job_id, {"text": "done"}, db_path=db)
+    fetched = pi_jobs.get_job(job.job_id, db_path=db)
+    assert fetched.status == "completed"
+    assert fetched.to_dict()["result"] == {"text": "done"}
+    assert fetched.finished_at != ""
+
+
+def test_fail_job_records_error(db: Path) -> None:
+    job = pi_jobs.insert_job("hi", db_path=db)
+    pi_jobs.claim_next(db_path=db)
+    pi_jobs.fail_job(job.job_id, "ollama down", db_path=db)
+    fetched = pi_jobs.get_job(job.job_id, db_path=db)
+    assert fetched.status == "failed"
+    assert "ollama down" in fetched.error
+
+
+def test_list_recent_filters_active(db: Path) -> None:
+    a = pi_jobs.insert_job("a", db_path=db)
+    b = pi_jobs.insert_job("b", db_path=db)
+    pi_jobs.claim_next(db_path=db)
+    pi_jobs.complete_job(a.job_id, {"text": "x"}, db_path=db)
+    active = pi_jobs.list_recent(only_active=True, db_path=db)
+    assert {j.job_id for j in active} == {b.job_id}
+    all_jobs = pi_jobs.list_recent(only_active=False, db_path=db)
+    assert {j.job_id for j in all_jobs} == {a.job_id, b.job_id}
+
+
+# ----- Worker loop end-to-end --------------------------------------------
+
+
+def test_worker_drains_queued_job(db: Path, monkeypatch) -> None:
+    """A queued job is claimed by the worker, executed (mocked LLM), and
+    persisted as 'completed'."""
+    monkeypatch.setattr(
+        "src.agents.pi_jobs.CACHE_DIR",
+        db.parent,
+        raising=True,
+    )
+
+    pi_worker.stop()  # ensure clean state if a previous test left state
+    with patch("src.agents.pi.run_task_with_memory", return_value="hello world"):
+        pi_worker.start(poll_interval=0.05)
+        try:
+            job = pi_jobs.insert_job("hi", db_path=db)
+            _wait_for_status(db, job.job_id, "completed", timeout=5.0)
+        finally:
+            pi_worker.stop()
+
+    fetched = pi_jobs.get_job(job.job_id, db_path=db)
+    assert fetched.status == "completed"
+    assert fetched.to_dict()["result"] == {"text": "hello world"}
+
+
+def test_worker_marks_failure_on_exception(db: Path, monkeypatch) -> None:
+    monkeypatch.setattr("src.agents.pi_jobs.CACHE_DIR", db.parent, raising=True)
+    pi_worker.stop()
+    with patch(
+        "src.agents.pi.run_task_with_memory",
+        side_effect=RuntimeError("ollama down"),
+    ):
+        pi_worker.start(poll_interval=0.05)
+        try:
+            job = pi_jobs.insert_job("boom", db_path=db)
+            _wait_for_status(db, job.job_id, "failed", timeout=5.0)
+        finally:
+            pi_worker.stop()
+
+    fetched = pi_jobs.get_job(job.job_id, db_path=db)
+    assert fetched.status == "failed"
+    assert "ollama down" in fetched.error
+
+
+def test_worker_start_is_idempotent() -> None:
+    pi_worker.stop()
+    assert pi_worker.start() is True
+    assert pi_worker.start() is False
+    pi_worker.stop()
+
+
+def test_worker_disabled_via_env(monkeypatch) -> None:
+    monkeypatch.setenv("PI_ASYNC_DISABLED", "1")
+    pi_worker.stop()
+    assert pi_worker.start() is False
+    assert pi_worker._is_running() is True  # marked started, but no thread
+    pi_worker.stop()


### PR DESCRIPTION
## Summary
**Plan C Phase 1** — pi_task no longer blocks the Claude session for up to 3 minutes. The MCP server now spawns a daemon worker thread at boot; `pi_task_start()` returns immediately with a `job_id`, the worker drains the new `pi_jobs` table every second, runs `run_task_with_memory()` directly (no subprocess), and persists the result. Existing sync `pi_task()` stays as a BC wrapper.

## Schema (additive, idempotent)
```sql
CREATE TABLE IF NOT EXISTS pi_jobs (
    job_id        TEXT PRIMARY KEY,
    task_text     TEXT NOT NULL,
    repo_slug     TEXT DEFAULT '',
    workspace_id  TEXT DEFAULT 'default',
    status        TEXT DEFAULT 'queued',     -- queued|running|completed|failed
    prefer        TEXT DEFAULT 'auto',        -- auto|local|cloud (Phase 2 honours)
    ollama_url    TEXT DEFAULT '',
    model         TEXT DEFAULT '',
    result_json   TEXT DEFAULT '',
    error         TEXT DEFAULT '',
    timeout_s     REAL DEFAULT 180.0,
    created_at    TEXT NOT NULL,
    started_at    TEXT DEFAULT '',
    finished_at   TEXT DEFAULT ''
);
```

## New modules
- `src/agents/pi_jobs.py` — `insert_job` / `claim_next` (atomic flip via single `UPDATE … RETURNING`) / `complete_job` / `fail_job` / `get_job` / `list_recent`. Each call uses a short-lived sqlite connection.
- `src/agents/pi_worker.py` — process-singleton ThreadPoolExecutor + polling-loop daemon. Idempotent `start()`. Disabled via `PI_ASYNC_DISABLED=1` (used in tests).

## New MCP tools (in `mcp_agent_tools.py`)
- `pi_task_start(task, repo_slug, prefer, ollama_url, model, timeout, workspace_id)` → `{job_id, status, workspace_id}`
- `pi_task_status(job_id)` → `{status, result, error, started_at, finished_at, workspace_id}`
- `pi_task_list(only_active, limit)` → `{jobs: [...], workspace_id}`

Original `pi_task` (sync) remains for callers that want blocking behaviour.

## Test plan
- [x] `pytest tests/test_pi_jobs.py` → 14/14 pass
  - schema migration creates expected columns
  - `init_memory_db` is idempotent
  - lifecycle: insert (queued) → claim (running) → complete | fail
  - `claim_next` is atomic under concurrent threads (only one wins)
  - `list_recent(only_active=True)` filters correctly
  - end-to-end: worker drains a queued job, persists `{"text": "..."}` result
  - failure path: exception in `run_task_with_memory` flips status to `failed` with error string
  - `start()` is idempotent (returns False on second call)
  - `PI_ASYNC_DISABLED=1` short-circuits the loop
- [ ] After merge: install plugin from marketplace, verify `mcp__plugin_mayring-coder_memory-agents__pi_task_start` is in the tool picker
- [ ] Live test: `pi_task_start("…")` returns immediately; `pi_task_status(job_id)` shows status transition

## Phase 2 (parallel branch)
`feat/plan-c-phase2-cloud-queue` is being prepared with the cloud-side counterpart — same schema lives on `mcp.linn.games`, plus `pi_task_submit_cloud` / `_claim_cloud` / `_complete_cloud` so a PC without GPU can submit and a Laptop worker can claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an asynchronous, persistent job system for pi tasks backed by a new pi_jobs table and a background worker thread, while keeping the existing synchronous pi_task interface intact.

New Features:
- Add MCP tools to start pi tasks asynchronously, query individual job status, and list recent jobs.
- Introduce a persistent pi_jobs table and associated data-access layer for managing queued, running, completed, and failed pi jobs.
- Add a background worker thread with a thread pool to poll for queued pi jobs, execute them, and persist their results.

Enhancements:
- Initialize the local memory database schema, including pi_jobs, before starting the MCP server worker loop.
- Allow the pi worker to be configured and disabled via environment variables, ensuring idempotent startup behavior.

Tests:
- Add hermetic tests covering pi_jobs schema migration, lifecycle behavior, concurrency guarantees, and the pi_worker polling loop including success, failure, idempotent start, and env-based disabling.