### PR TITLE
fix(plugin): wrapper finds repo-root in cache OR marketplace OR dev-clone

### DIFF
--- a/claude-plugin/bin/run_local_mcp.sh
+++ b/claude-plugin/bin/run_local_mcp.sh
@@ -25,7 +25,34 @@ if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
     CLAUDE_PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 fi
 
-REPO_ROOT="$(cd "$CLAUDE_PLUGIN_ROOT/.." && pwd)"
+# When Claude Code installs a plugin, the cache directory holds ONLY
+# claude-plugin/* — the repo-level src/, requirements-client.txt, tools/
+# live in the marketplace clone (or a dev clone). Try the well-known
+# layouts in order and pick the first one that has src/api/local_mcp.py.
+_find_repo_root() {
+    local candidate
+    for candidate in \
+        "${MAYRING_REPO:-}" \
+        "$CLAUDE_PLUGIN_ROOT/.." \
+        "$HOME/.claude/plugins/marketplaces/MayringCoder" \
+        "$HOME/Desktop/MayringCoder" \
+        "$HOME/.claude/mayringcoder"
+    do
+        if [ -n "$candidate" ] && [ -f "$candidate/src/api/local_mcp.py" ]; then
+            (cd "$candidate" && pwd)
+            return 0
+        fi
+    done
+    return 1
+}
+
+REPO_ROOT="$(_find_repo_root)" || {
+    echo "run_local_mcp: no repo with src/api/local_mcp.py found." >&2
+    echo "  Tried: \$MAYRING_REPO, \$CLAUDE_PLUGIN_ROOT/.., ~/.claude/plugins/marketplaces/MayringCoder, ~/Desktop/MayringCoder, ~/.claude/mayringcoder" >&2
+    echo "  Fix: clone the repo and set MAYRING_REPO=/path/to/MayringCoder, OR re-run /plugin marketplace add Nileneb/MayringCoder" >&2
+    exit 1
+}
+
 VENV_DIR="$CLAUDE_PLUGIN_ROOT/.venv"
 VENV_PYTHON="$VENV_DIR/bin/python"
 REQ_FILE="$REPO_ROOT/requirements-client.txt"


### PR DESCRIPTION
## Summary
PR #128 assumed `\${CLAUDE_PLUGIN_ROOT}/..` always contains `requirements-client.txt` and `src/`. True when Claude Code runs the MCP server from the marketplace-clone layout, but it actually runs from the **cache directory** (`~/.claude/plugins/cache/MayringCoder/mayring-coder/1.0.0/`) where `..` is empty.

Result: wrapper exited 1 with "requirements-client.txt missing" on every fresh `/plugin install`, even after merging #128.

## Fix
Wrapper walks an ordered list of candidate repo roots and picks the first one that has `src/api/local_mcp.py`:

1. `$MAYRING_REPO` — explicit override
2. `$CLAUDE_PLUGIN_ROOT/..` — legacy marketplace layout (still wins when present)
3. `~/.claude/plugins/marketplaces/MayringCoder` — canonical marketplace clone
4. `~/Desktop/MayringCoder` — User-Konvention dev-clone
5. `~/.claude/mayringcoder` — `install.sh` standalone-Konvention

If none match, exit 1 with an actionable error pointing the user at `MAYRING_REPO=` or `/plugin marketplace add`.

## Test plan
- [x] Smoke test from cache layout: wrapper resolves to marketplace clone, builds venv, MCP-server boots, worker thread starts, resolver returns `localhost` (default) + correct per-job override
- [x] No test regressions: 33/33 in `tests/test_pi_jobs.py` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix plugin startup failures when installed from the Claude cache by resolving the repository root from multiple known locations and providing a clearer error when none are found.