### PR TITLE
fix(hooks): memory_sync survives transient cloud errors silently

### DIFF
--- a/tools/memory_sync.py
+++ b/tools/memory_sync.py
@@ -12,6 +12,7 @@ import json
 import os
 import sqlite3
 import sys
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -164,6 +165,29 @@ def sync(workspace_id: str, db_path: str, chroma_path: str) -> int:
     while True:
         try:
             data = _fetch_changes(token, workspace_id, cursor, limit=_BATCH_SIZE)
+        except urllib.error.HTTPError as e:
+            # Server-side hiccups (5xx, 404 on legacy endpoints, …) must NOT
+            # block the user's prompt. The hook fires on every UserPromptSubmit
+            # and a 500 from /memory/changes used to surface as a red error
+            # line on every prompt. Log to stderr, exit 0.
+            if e.code >= 500 or e.code == 404:
+                print(
+                    f"memory_sync: skipping sync — {_API_URL}/memory/changes "
+                    f"returned HTTP {e.code} (transient or endpoint missing)",
+                    file=sys.stderr,
+                )
+                return 0
+            # 4xx (bad JWT, wrong workspace) is a real config issue — surface.
+            print(f"Fetch error: HTTP {e.code} {e.reason}", file=sys.stderr)
+            return 1
+        except urllib.error.URLError as e:
+            # Network down / DNS / connection refused — non-fatal.
+            print(
+                f"memory_sync: skipping sync — network unreachable "
+                f"({e.reason})",
+                file=sys.stderr,
+            )
+            return 0
         except Exception as e:
             print(f"Fetch error: {e}", file=sys.stderr)
             return 1


### PR DESCRIPTION
User reported persistent red error lines on every `UserPromptSubmit`:

```
Fetch error: HTTP Error 500: Internal Server Error
```

Root cause: `tools/memory_sync.py` (UserPromptSubmit hook) calls `https://mcp.linn.games/memory/changes` which currently returns HTTP 500 server-side. The hook exited 1 → Claude Code surfaced the stderr line on every prompt.

Cloud MCP tools (`mcp__claude_ai_Memory__*`) reach the same server via stdio/SSE — unaffected. Only this REST sync is broken cloud-side. The hook should not nag the user while that's fixed upstream.

**Fix:** split `except Exception` into:
- `HTTPError 5xx / 404` → log + exit 0 (transient or legacy endpoint)
- `URLError` → log + exit 0 (offline)
- `HTTPError 4xx` → exit 1 (real config issue, surface)
- everything else → exit 1

Verified live against the currently-broken /memory/changes endpoint: hook exits 0 instead of 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle cloud memory sync hook failures more gracefully so transient server or network issues do not surface as errors on every prompt.

Bug Fixes:
- Treat 5xx and 404 HTTP errors from the memory changes endpoint as non-fatal and skip sync without failing the hook.
- Treat network-level URL errors as non-fatal and skip sync while logging the issue.
- Preserve hard failures for 4xx HTTP errors and unexpected exceptions to surface real configuration problems.