### PR TITLE
fix(sync): real fix for /memory/changes 500 + revert client-side mute

### DIFF
--- a/src/api/routes/sync.py
+++ b/src/api/routes/sync.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query
+import logging
+import sqlite3
+
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from src.api.auth import get_workspace
 from src.api.dependencies import get_chroma as _get_chroma, get_conn as _get_conn
 
 router = APIRouter(prefix="/memory", tags=["sync"])
+logger = logging.getLogger(__name__)
 
 
 class ChunkSyncItem(BaseModel):
@@ -26,6 +30,29 @@ class MemorySyncResponse(BaseModel):
     chunks: list[ChunkSyncItem]
 
 
+def _ensure_visibility_column(db) -> None:
+    """If the cloud DB was created before the visibility migration landed,
+    `s.visibility` is NaN and the SELECT below fails with `no such column`.
+    The migration is in src.memory.store but only fires when init_memory_db
+    is called. Production was deployed before that migration was added, so
+    the column may be missing on the live DB. Add it lazily here so a
+    legacy DB still answers /memory/changes — idempotent: ALTER TABLE
+    re-applied raises OperationalError which we swallow."""
+    try:
+        cols = {r[1] for r in db.execute("PRAGMA table_info(sources)").fetchall()}
+    except sqlite3.Error:
+        return
+    if "visibility" not in cols:
+        try:
+            db.execute(
+                "ALTER TABLE sources ADD COLUMN visibility "
+                "TEXT NOT NULL DEFAULT 'private'"
+            )
+            logger.warning("sync: applied missing visibility column on sources")
+        except sqlite3.Error as e:
+            logger.error("sync: failed to add visibility column: %s", e)
+
+
 @router.get("/changes", response_model=MemorySyncResponse)
 def get_changes(
     since: str = Query(..., description="ISO 8601 cursor — only chunks created after this"),
@@ -33,20 +60,29 @@ def get_changes(
     workspace_id: str = Depends(get_workspace),
 ) -> MemorySyncResponse:
     db = _get_conn()
-    rows = db.execute(
-        """
-        SELECT c.chunk_id, c.source_id, c.text, c.workspace_id,
-               c.created_at, c.is_active, c.text_hash, c.dedup_key
-        FROM chunks c
-        JOIN sources s ON c.source_id = s.source_id
-        WHERE c.created_at > ?
-          AND (s.visibility = 'public'
-               OR (s.visibility = 'private' AND c.workspace_id = ?))
-        ORDER BY c.created_at ASC
-        LIMIT ?
-        """,
-        (since, workspace_id, limit),
-    ).fetchall()
+    _ensure_visibility_column(db)
+
+    try:
+        rows = db.execute(
+            """
+            SELECT c.chunk_id, c.source_id, c.text, c.workspace_id,
+                   c.created_at, c.is_active, c.text_hash, c.dedup_key
+            FROM chunks c
+            JOIN sources s ON c.source_id = s.source_id
+            WHERE c.created_at > ?
+              AND (s.visibility = 'public'
+                   OR (s.visibility = 'private' AND c.workspace_id = ?))
+            ORDER BY c.created_at ASC
+            LIMIT ?
+            """,
+            (since, workspace_id, limit),
+        ).fetchall()
+    except sqlite3.Error as e:
+        # Don't 500 — that hits the client's UserPromptSubmit hook on every
+        # keystroke. Surface the real DB error to the response so the client
+        # log shows what's actually broken.
+        logger.exception("sync: SQL query failed")
+        raise HTTPException(status_code=503, detail=f"DB query failed: {e}") from e
 
     if not rows:
         return MemorySyncResponse(cursor=since, chunks=[])
@@ -56,11 +92,16 @@ def get_changes(
     try:
         col = _get_chroma()
         result = col.get(ids=chunk_ids, include=["embeddings"])
-        for cid, emb in zip(result["ids"], result["embeddings"]):
+        ids = result.get("ids") or []
+        embs = result.get("embeddings") or []
+        for cid, emb in zip(ids, embs):
             if emb is not None:
+                # Coerce numpy.ndarray (chromadb >=0.5) to plain list.
                 embedding_map[cid] = list(emb)
     except Exception:
-        pass
+        # Non-fatal: chunks still flow back without embeddings, the client
+        # can re-embed locally. Logged with stack so the cause is visible.
+        logger.exception("sync: chroma fetch failed — continuing without embeddings")
 
     items = [
         ChunkSyncItem(

--- a/tools/memory_sync.py
+++ b/tools/memory_sync.py
@@ -12,7 +12,6 @@ import json
 import os
 import sqlite3
 import sys
-import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -165,29 +164,6 @@ def sync(workspace_id: str, db_path: str, chroma_path: str) -> int:
     while True:
         try:
             data = _fetch_changes(token, workspace_id, cursor, limit=_BATCH_SIZE)
-        except urllib.error.HTTPError as e:
-            # Server-side hiccups (5xx, 404 on legacy endpoints, …) must NOT
-            # block the user's prompt. The hook fires on every UserPromptSubmit
-            # and a 500 from /memory/changes used to surface as a red error
-            # line on every prompt. Log to stderr, exit 0.
-            if e.code >= 500 or e.code == 404:
-                print(
-                    f"memory_sync: skipping sync — {_API_URL}/memory/changes "
-                    f"returned HTTP {e.code} (transient or endpoint missing)",
-                    file=sys.stderr,
-                )
-                return 0
-            # 4xx (bad JWT, wrong workspace) is a real config issue — surface.
-            print(f"Fetch error: HTTP {e.code} {e.reason}", file=sys.stderr)
-            return 1
-        except urllib.error.URLError as e:
-            # Network down / DNS / connection refused — non-fatal.
-            print(
-                f"memory_sync: skipping sync — network unreachable "
-                f"({e.reason})",
-                file=sys.stderr,
-            )
-            return 0
         except Exception as e:
             print(f"Fetch error: {e}", file=sys.stderr)
             return 1


### PR DESCRIPTION
User correctly flagged that PR #132 was a symptom-mute, not a fix. Reverts the mute and addresses the actual server-side root cause.

**Server (src/api/routes/sync.py)** — diagnosis: cloud DB was created before `sources.visibility` migration was added; `init_memory_db` was never called against the production connection. `_ensure_visibility_column(db)` now lazily applies the missing column (idempotent). SQL wrapped in try/except → 503 with real error in detail. Chroma fetch logs full stack via `logger.exception`, plus numpy→list defensive coercion.

**Client (tools/memory_sync.py)** — reverts PR #132's `5xx → exit 0` mute. Errors surface again. Per CLAUDE.md: silencing errors without an explicit user request is forbidden — failures are fixed at the root cause, not muted.

Tests: 1165/1165 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)