### PR TITLE
fix(plugin): default MAYRING_API_URL to cloud, not localhost:8090

### DIFF
--- a/src/api/local_mcp.py
+++ b/src/api/local_mcp.py
@@ -39,6 +39,11 @@ os.environ.setdefault("OLLAMA_URL", "http://localhost:11434")
 os.environ.setdefault("MAYRING_LOCAL_DB", str(_local_cache / "memory.db"))
 os.environ.setdefault("MAYRING_LOCAL_CHROMA", str(_local_cache / "chroma"))
 os.environ.setdefault("PI_AGENT_URL", "direct")
+# The plugin runs on a user device — there is no FastAPI on localhost:8090
+# unless the user explicitly started `python -m src.main`. The agent tools
+# (ingest, duel, benchmark_tasks) need a real REST endpoint, so default to
+# the cloud API. Override locally with MAYRING_API_URL=http://localhost:8090.
+os.environ.setdefault("MAYRING_API_URL", "https://mcp.linn.games")
 
 from src.api.mcp_agent_tools import register_agent_tools  # noqa: E402
 from src.memory.store import init_memory_db  # noqa: E402


### PR DESCRIPTION
User reported `Connection refused` from `mcp__plugin_mayring-coder_memory-agents__ingest`.

**Root cause:** the agent tools default `MAYRING_API_URL` to `http://localhost:8090` (the all-in-one server's REST port). That process only runs when the user explicitly starts `python -m src.main` on their device. The plugin runs against the marketplace clone, not a dev server, so localhost:8090 is unreachable.

**Fix:** `src/api/local_mcp.py` now sets `MAYRING_API_URL` default to `https://mcp.linn.games` via `os.environ.setdefault`. Local devs who run the all-in-one server can still override with the env var.

Verified: importing `src.api.local_mcp` populates the env when not pre-set. Tests: 33/33 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent connection failures in the Mayring MCP plugin by pointing its default API URL at the reachable cloud service rather than localhost.