### PR TITLE
fix(nginx): route /stats/* + /pi_task_* to REST API, not MCP upstream

### DIFF
--- a/docker/nginx/mcp.conf
+++ b/docker/nginx/mcp.conf
@@ -57,7 +57,11 @@ server {
     }
 
     # REST-API endpoints → mayring-api:8090
-    location ~* ^/(conversation|memory|ingest|analyze|search|overview|turbulence|benchmark|jobs|populate|papers|issues|wiki|ambient|predictive|reports|health|pi-task|duel|feedback)(/|$) {
+    # Underscore variants of pi-task cover the Plan-C async tools
+    # (pi_task_start, pi_task_status, pi_task_list, pi_task_*_cloud).
+    # `stats` was missing — Laravel MayringMcpClient.getStats() calls
+    # /stats/summary and was hitting the MCP upstream returning 404.
+    location ~* ^/(conversation|memory|ingest|analyze|search|overview|turbulence|benchmark|jobs|populate|papers|issues|wiki|ambient|predictive|reports|health|stats|pi-task|pi_task|duel|feedback)(/|_|$) {
         set $mayring_api_upstream http://mayring-api:8090;
         proxy_pass $mayring_api_upstream;
         proxy_http_version 1.1;


### PR DESCRIPTION
User reported `MayringMcpClient: getStats fehlgeschlagen (500)`.

**Root cause:** the nginx `location` whitelist on `mcp.linn.games` is a literal regex listing the REST-API paths. `stats` is missing, so `/stats/summary` falls through to the default location → `mayring-mcp:8092` upstream → 404 (or 500 when MCP errors). Verified `/stats/summary` works against the local dev DB — endpoint code is fine, only the routing was wrong.

Same blind spot hit the **Plan-C async tools**: the whitelist matched `pi-task` (hyphen) only, so `pi_task_start`, `pi_task_status`, `pi_task_*_cloud` (underscore) were silently routed to the MCP upstream too.

**Fix:** add `stats`, accept `_` as a path-segment separator, add `pi_task` as a sibling of `pi-task`. Sanity-checked 8 path patterns.

Cloud picks up the change on the next nginx reload (auto on master push via deploy workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route additional Mayring REST API endpoints through nginx to the mayring-api upstream instead of the MCP upstream.

Bug Fixes:
- Ensure /stats/* endpoints are correctly routed to the REST API, fixing MayringMcpClient.getStats failures.
- Ensure Plan-C async pi_task* endpoints (underscore variants) are routed to the REST API instead of the MCP upstream.