### PR TITLE
fix(server): force schema migration at startup + DiD in mcp_pi_tools

### DIFF
--- a/src/api/mcp_pi_tools.py
+++ b/src/api/mcp_pi_tools.py
@@ -14,15 +14,70 @@ Tool surface:
 
 from __future__ import annotations
 
+import logging
+import sqlite3
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
 from src.api.mcp_auth import _enforce_tenant, _effective_workspace_id
 
+logger = logging.getLogger(__name__)
+
+
+_PI_JOBS_PHASE2_COLUMNS = (
+    ("scope", "TEXT NOT NULL DEFAULT 'local'"),
+    ("capability_required", "TEXT NOT NULL DEFAULT ''"),
+    ("claimed_by", "TEXT NOT NULL DEFAULT ''"),
+    ("claimed_at", "TEXT NOT NULL DEFAULT ''"),
+)
+
+
+def _ensure_pi_jobs_phase2_columns(db) -> None:
+    """Lazily add Plan-C Phase-2 columns to pi_jobs.
+
+    Defence-in-depth: production hit "no such column: scope" because the
+    cloud DB pre-dates the migration, and the central `_migrate_schema`
+    only fires when `init_memory_db` runs against that DB. The startup
+    hook in server.py covers the happy path; this hook covers the case
+    where the connection was already cached before that hook landed.
+
+    Idempotent: PRAGMA skips if the column is present, ALTER TABLE
+    fails are logged but never raised — so `pi_task_*_cloud` requests
+    never 500 on a half-migrated schema.
+    """
+    try:
+        cols = {r[1] for r in db.execute("PRAGMA table_info(pi_jobs)").fetchall()}
+    except sqlite3.Error:
+        return  # table itself missing — caller will fail visibly, not silently.
+    if not cols:
+        # PRAGMA on a non-existent table returns no rows. Surface that
+        # explicitly: the deployment lost the pi_jobs table entirely and
+        # needs init_memory_db to recreate it. Don't try ALTER TABLE.
+        logger.error(
+            "mcp_pi_tools: pi_jobs table is missing — run init_memory_db()"
+        )
+        return
+    for col_name, col_def in _PI_JOBS_PHASE2_COLUMNS:
+        if col_name not in cols:
+            try:
+                db.execute(f"ALTER TABLE pi_jobs ADD COLUMN {col_name} {col_def}")
+                logger.warning("mcp_pi_tools: applied missing pi_jobs.%s", col_name)
+            except sqlite3.Error as e:
+                logger.error("mcp_pi_tools: failed to add pi_jobs.%s: %s", col_name, e)
+
 
 def register_pi_queue_tools(mcp: FastMCP) -> None:
     """Register the pi-task cloud queue tools onto the FastMCP instance."""
+
+    # One-shot migration at registration time, against the same connection
+    # the tools below will use. Cheap: ALTER TABLE on already-present
+    # columns is a no-op via the PRAGMA pre-check.
+    try:
+        from src.api.dependencies import get_conn as _get_conn
+        _ensure_pi_jobs_phase2_columns(_get_conn())
+    except Exception:
+        logger.exception("mcp_pi_tools: registration-time migration skipped")
 
     @mcp.tool()
     def pi_task_submit_cloud(

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -58,6 +58,44 @@ app.include_router(reports.router)
 app.include_router(_sync_router)
 
 
+@app.on_event("startup")
+def _run_pending_schema_migrations() -> None:
+    """Force the idempotent schema migration on the cloud DB at boot.
+
+    The lazy `get_conn()` path *should* trigger this via init_memory_db,
+    but a series of production 500s ("no such column: visibility",
+    "no such column: scope") proved that the live DB pre-dates several
+    schema additions and the lazy path was not reaching them — likely
+    because the connection was set up before the relevant migration was
+    added to the codebase, and never re-initialised.
+    Calling init_memory_db here on every container start is cheap (a
+    no-op when fully migrated) and removes the foot-gun for good.
+
+    Path resolution mirrors `get_conn()` exactly: when MAYRING_LOCAL_DB
+    is set (production), migrate that file; otherwise fall back to the
+    default MEMORY_DB_PATH. Otherwise the startup migration would touch
+    a different file than the request handlers and miss the live DB.
+    """
+    import logging
+    import os
+    from pathlib import Path
+    from src.memory.store import init_memory_db
+    logger = logging.getLogger(__name__)
+    db_path = os.environ.get("MAYRING_LOCAL_DB", "")
+    target = Path(db_path) if db_path else None
+    try:
+        init_memory_db(target).close()
+        logger.info(
+            "server.startup: schema migrations applied at %s",
+            target or "<default MEMORY_DB_PATH>",
+        )
+    except Exception:
+        # Don't block server boot — get_conn() will retry on first request,
+        # and the new defence-in-depth in sync.py / mcp_pi_tools handles the
+        # remaining gap if this step somehow failed.
+        logger.exception("server.startup: schema migration failed (non-fatal)")
+
+
 @app.get("/health")
 def health() -> dict:
     return {"status": "ok", "version": "1.0.0"}

--- a/tests/test_pi_jobs.py
+++ b/tests/test_pi_jobs.py
@@ -349,6 +349,72 @@ def test_cloud_tools_register_without_error() -> None:
     register_pi_queue_tools(mcp)  # must not raise
 
 
+# ----- Defence-in-depth: pi_jobs phase-2 column lazy migration -----------
+
+
+def test_ensure_pi_jobs_phase2_columns_adds_missing(tmp_path: Path) -> None:
+    """Legacy DB without scope/capability_required/claimed_by/claimed_at —
+    helper applies the missing columns idempotently."""
+    import sqlite3
+    from src.api.mcp_pi_tools import _ensure_pi_jobs_phase2_columns
+
+    db = tmp_path / "legacy.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE pi_jobs (job_id TEXT PRIMARY KEY, task_text TEXT, "
+        "status TEXT DEFAULT 'queued', created_at TEXT NOT NULL)"
+    )
+    cols_before = {r[1] for r in conn.execute("PRAGMA table_info(pi_jobs)").fetchall()}
+    assert "scope" not in cols_before
+
+    _ensure_pi_jobs_phase2_columns(conn)
+    cols_after = {r[1] for r in conn.execute("PRAGMA table_info(pi_jobs)").fetchall()}
+    assert {"scope", "capability_required", "claimed_by", "claimed_at"} <= cols_after
+
+    # Idempotent — second call is a no-op.
+    _ensure_pi_jobs_phase2_columns(conn)
+
+
+def test_ensure_pi_jobs_phase2_columns_handles_missing_table(
+    tmp_path: Path, caplog,
+) -> None:
+    """If pi_jobs table is gone entirely, the helper logs and returns —
+    must NOT crash, must NOT silently mask the deployment problem."""
+    import logging
+    import sqlite3
+    from src.api.mcp_pi_tools import _ensure_pi_jobs_phase2_columns
+
+    conn = sqlite3.connect(tmp_path / "no-table.db")
+    with caplog.at_level(logging.ERROR, logger="src.api.mcp_pi_tools"):
+        _ensure_pi_jobs_phase2_columns(conn)
+    assert any("pi_jobs table is missing" in r.message for r in caplog.records)
+
+
+def test_server_startup_runs_schema_migration(monkeypatch, tmp_path: Path) -> None:
+    """The FastAPI startup hook in server.py calls init_memory_db so
+    legacy DBs get migrated on every boot."""
+    monkeypatch.setenv("MAYRING_LOCAL_DB", str(tmp_path / "fresh.db"))
+
+    # Reset cached singleton so the test gets a clean import path.
+    import src.api.dependencies as deps
+    deps._conn = None
+
+    from fastapi.testclient import TestClient
+    from src.api.server import app
+
+    with TestClient(app) as client:
+        # Hitting any endpoint forces lifespan startup.
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    # The schema migration must have created the pi_jobs table with phase-2 cols.
+    import sqlite3
+    cols = {r[1] for r in sqlite3.connect(tmp_path / "fresh.db").execute(
+        "PRAGMA table_info(pi_jobs)"
+    ).fetchall()}
+    assert {"scope", "capability_required", "claimed_by", "claimed_at"} <= cols
+
+
 # ----- Tenant scoping (cross-workspace isolation) -------------------------
 
 


### PR DESCRIPTION
Production has been 500-ing with `no such column: visibility` (sync) and `no such column: scope` (mcp_pi_tools). The live DB pre-dates several schema additions and `get_conn()`'s lazy migration path was not reaching them.

Two layers of defence:

**1. `server.py` startup hook** — `init_memory_db()` on every container boot, path mirrors `get_conn()` exactly (`MAYRING_LOCAL_DB` or `MEMORY_DB_PATH`). Idempotent. Failures logged, do not block boot.

**2. `mcp_pi_tools._ensure_pi_jobs_phase2_columns`** — defence-in-depth at register-time, identical in spirit to the `_ensure_visibility_column` from PR #133. Walks PRAGMA, ALTERs in `scope` / `capability_required` / `claimed_by` / `claimed_at` if missing. Missing table logs a clear "run init_memory_db" hint — does not silently mask the deployment problem (per `CLAUDE.md` no-mute rule).

Tests: 36/36 pass (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)