### PR TITLE
feat(v2): JWT memberships + 4 visibility-bug-fixes

### DIFF
--- a/src/api/jwt_auth.py
+++ b/src/api/jwt_auth.py
@@ -19,6 +19,18 @@ import os
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
+from typing import NamedTuple
+
+
+class Membership(NamedTuple):
+    """Single workspace-membership entry from the JWT `memberships[]` claim.
+
+    Issued by app.linn.games JwtIssuer. type is 'personal' or 'organization';
+    role is 'owner' | 'editor' | 'viewer'. See docs/v2-workspaces-spec.md.
+    """
+    id: str
+    type: str
+    role: str
 
 
 @dataclass(frozen=True)
@@ -33,7 +45,14 @@ class TokenInfo:
     llm_requires_key: bool = False    # True → Worker muss Key via Callback holen
     sub: str | None = None            # User-ID, wird für Key-Cache genutzt
     iat: int | None = None            # Issued-at, Teil des Key-Cache-Keys
-    org_id: str | None = None         # Org membership, for shared-memory visibility
+    # WHY(v2-workspaces): replaced single `org_id` with `memberships[]` so a
+    # user can be in multiple orgs at once. Backward-compat: an old JWT without
+    # memberships still works — `org_ids` then returns ().
+    memberships: tuple[Membership, ...] = ()
+    # WHY(backward-compat): legacy JWTs still ship a single `org_id` claim.
+    # We preserve it on TokenInfo so existing callsites that read .org_id keep
+    # working until they migrate to .org_ids.
+    org_id: str | None = None
 
     @property
     def is_admin(self) -> bool:
@@ -42,6 +61,19 @@ class TokenInfo:
     @property
     def uses_custom_provider(self) -> bool:
         return self.llm_provider != "platform"
+
+    @property
+    def org_ids(self) -> tuple[str, ...]:
+        """All organization-workspace ids the caller is a member of.
+
+        Derived from the V2 `memberships[]` claim. For legacy JWTs that only
+        carry a single `org_id`, falls back to that value as a 1-tuple so
+        callers don't need a second branch. Returns () when neither is set.
+        """
+        ids = tuple(m.id for m in self.memberships if m.type == "organization")
+        if ids:
+            return ids
+        return (self.org_id,) if self.org_id else ()
 
 
 @lru_cache(maxsize=1)
@@ -134,6 +166,25 @@ def validate_jwt_token(token: str) -> TokenInfo | None:
     iat_raw = payload.get("iat")
     org_id_raw = payload.get("org_id")
 
+    # V2 memberships claim — issued by app.linn.games JwtIssuer alongside
+    # workspace_id. Missing/malformed → empty tuple (legacy-JWT path).
+    memberships_raw = payload.get("memberships")
+    memberships: tuple[Membership, ...] = ()
+    if isinstance(memberships_raw, list):
+        parsed: list[Membership] = []
+        for m in memberships_raw:
+            if not isinstance(m, dict):
+                continue
+            mid = m.get("id")
+            if not mid:
+                continue
+            parsed.append(Membership(
+                id=str(mid),
+                type=str(m.get("type") or "personal"),
+                role=str(m.get("role") or "viewer"),
+            ))
+        memberships = tuple(parsed)
+
     return TokenInfo(
         workspace_id=workspace_id,
         scopes=scopes,
@@ -143,6 +194,7 @@ def validate_jwt_token(token: str) -> TokenInfo | None:
         llm_requires_key=bool(raw_requires_key),
         sub=sub_str,
         iat=int(iat_raw) if isinstance(iat_raw, (int, float)) else None,
+        memberships=memberships,
         org_id=str(org_id_raw) if org_id_raw else None,
     )
 

--- a/src/api/mcp_auth.py
+++ b/src/api/mcp_auth.py
@@ -46,8 +46,22 @@ def _effective_user_id() -> str | None:
 
 
 def _effective_org_id() -> str | None:
+    """Legacy single-org accessor. Prefer _effective_org_ids() in new code."""
     info = _TOKEN_CTX.get(None)
-    return info.org_id if info is not None else None
+    if info is None:
+        return None
+    if info.org_id:
+        return info.org_id
+    # Fall back to first membership-derived org so legacy callsites still
+    # surface at least one org bucket post-V2-JWT-rollout.
+    org_ids = info.org_ids
+    return org_ids[0] if org_ids else None
+
+
+def _effective_org_ids() -> tuple[str, ...]:
+    """V2: all organization-workspace ids the caller is a member of."""
+    info = _TOKEN_CTX.get(None)
+    return info.org_ids if info is not None else ()
 
 
 def _enforce_tenant(requested: str | None) -> str | None:

--- a/src/api/mcp_memory_tools.py
+++ b/src/api/mcp_memory_tools.py
@@ -12,6 +12,7 @@ from src.api.mcp_auth import (
     _effective_workspace_id,
     _effective_user_id,
     _effective_org_id,
+    _effective_org_ids,
     _current_raw_jwt,
 )
 from src.api.dependencies import get_conn as _get_conn, get_chroma as _get_chroma
@@ -72,10 +73,10 @@ def register_memory_tools(mcp: FastMCP) -> None:
                 "include_text": include_text,
                 "source_affinity": source_affinity,
                 "workspace_id": ws,
-                # user_id + org_id let visibility='user' / 'org' chunks
-                # surface across workspaces of the same human user / org.
+                # user_id + org_ids let visibility='user' / 'org' chunks
+                # surface across workspaces of the same human user / orgs.
                 "user_id": _effective_user_id(),
-                "org_id": _effective_org_id(),
+                "org_ids": _effective_org_ids(),
                 "task_context": task_context,
             }
             result = _run_search(query, _get_conn(), _get_chroma(),

--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -10,8 +10,9 @@ _log = logging.getLogger(__name__)
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from src.api.auth import get_workspace
+from src.api.auth import get_token_info, get_workspace
 from src.api.dependencies import get_chroma as _get_chroma, get_conn as _get_conn
+from src.api.jwt_auth import TokenInfo
 from src.api.memory_service import run_ingest as _run_ingest, run_search as _run_search
 from src.api.routes.models import (
     ConversationMicroBatchRequest,
@@ -91,10 +92,20 @@ async def pi_task(
 async def memory_search(
     request: MemorySearchRequest,
     workspace_id: str = Depends(get_workspace),
+    info: TokenInfo = Depends(get_token_info),
 ) -> dict:
     """Search workspace memory."""
     try:
-        opts: dict[str, Any] = {"top_k": request.top_k, "workspace_id": workspace_id}
+        # WHY(L7, v2-workspaces): without user_id + org_ids the retrieval
+        # scope_filter sees only public+private — chunks shared via
+        # visibility='user' or 'org' silently never surface for REST callers
+        # (Laravel, hooks). MCP path already does this; REST was the gap.
+        opts: dict[str, Any] = {
+            "top_k": request.top_k,
+            "workspace_id": workspace_id,
+            "user_id": info.sub,
+            "org_ids": info.org_ids,
+        }
         if request.repo:
             opts["repo"] = request.repo
         if request.source_type:
@@ -214,11 +225,54 @@ async def memory_log_event(
 async def memory_put(
     request: MemoryPutRequest,
     workspace_id: str = Depends(get_workspace),
+    info: TokenInfo = Depends(get_token_info),
 ) -> dict:
-    """Ingest content into workspace memory."""
+    """Ingest content into workspace memory.
+
+    WHY(L3, v2-workspaces): when caller asks for visibility='org' the source
+    needs an org_id stamp — otherwise the chunk is invisible to org members
+    (scope_filter requires s.org_id = caller_org). We resolve org_id from
+    the JWT memberships: if the caller passed one, verify they're a member
+    (else 403); if they didn't, default to their first org-membership.
+    """
     try:
-        source_dict = {"source_id": request.source_id, "source_type": request.source_type,
-                       "repo": request.repo, "path": request.path}
+        source_dict: dict[str, Any] = {
+            "source_id": request.source_id,
+            "source_type": request.source_type,
+            "repo": request.repo,
+            "path": request.path,
+        }
+        if request.visibility:
+            source_dict["visibility"] = request.visibility
+        if request.visibility == "org":
+            org_member_ids = set(info.org_ids)
+            if request.org_id:
+                if request.org_id not in org_member_ids:
+                    raise HTTPException(
+                        status_code=403,
+                        detail=f"caller is not a member of org_id={request.org_id!r}",
+                    )
+                source_dict["org_id"] = request.org_id
+            else:
+                if not org_member_ids:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="visibility='org' requires org membership or explicit org_id",
+                    )
+                # First org-membership as default — log so silent picks
+                # are visible in production grepping.
+                first_org = next(iter(info.org_ids))
+                _log.warning(
+                    "memory.put visibility=org without org_id — "
+                    "defaulting to first membership %r (caller=%s)",
+                    first_org, info.sub,
+                )
+                source_dict["org_id"] = first_org
+        elif request.org_id:
+            # Honor explicit org_id even outside visibility=org (e.g. when
+            # caller wants to stamp the source for later promotion).
+            source_dict["org_id"] = request.org_id
+
         result = _run_ingest(source_dict, request.content, _get_conn(), _get_chroma(),
                              _OLLAMA_URL, _model("text"), {"categorize": request.categorize},
                              workspace_id)
@@ -229,6 +283,8 @@ async def memory_put(
                 daemon=True,
             ).start()
         return {"workspace_id": workspace_id, **result}
+    except HTTPException:
+        raise
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
 
@@ -561,16 +617,41 @@ async def patch_source_visibility(
     source_id: str,
     request: PatchVisibilityRequest,
     workspace_id: str = Depends(get_workspace),
+    info: TokenInfo = Depends(get_token_info),
 ) -> dict:
-    """Update visibility (and optionally org_id) for a source."""
-    if request.visibility not in ("private", "org", "public"):
-        raise HTTPException(status_code=400, detail="visibility must be private|org|public")
+    """Update visibility (and optionally org_id) for a source.
+
+    WHY(L8, v2-workspaces): without ownership-check this endpoint allowed
+    cross-tenant vandalism — any authed caller could flip visibility on
+    another user's sources. V2 enforces: owner (same workspace OR same sub)
+    or admin (scope * / admin). 'user' added to the visibility whitelist.
+    """
+    if request.visibility not in ("private", "org", "public", "user"):
+        raise HTTPException(
+            status_code=400,
+            detail="visibility must be private|org|public|user",
+        )
     conn = _get_conn()
     row = conn.execute(
-        "SELECT source_id FROM sources WHERE source_id = ?", (source_id,)
+        "SELECT workspace_id, user_id FROM sources WHERE source_id = ?",
+        (source_id,),
     ).fetchone()
     if row is None:
         raise HTTPException(status_code=404, detail="source not found")
+    src_ws = row["workspace_id"] if hasattr(row, "keys") else row[0]
+    src_user = row["user_id"] if hasattr(row, "keys") else row[1]
+
+    is_admin = "*" in info.scopes or "admin" in info.scopes
+    is_owner = (
+        src_ws == workspace_id
+        or (src_user is not None and info.sub is not None and src_user == info.sub)
+    )
+    if not (is_admin or is_owner):
+        raise HTTPException(
+            status_code=403,
+            detail="not authorized to change visibility of this source",
+        )
+
     conn.execute(
         "UPDATE sources SET visibility = ?, org_id = ? WHERE source_id = ?",
         (request.visibility, request.org_id, source_id),

--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -284,6 +284,9 @@ async def memory_put(
             ).start()
         return {"workspace_id": workspace_id, **result}
     except HTTPException:
+        # Re-raise as-is so the 403 (membership/auth) and 404 codes
+        # survive — without this guard the broader Exception handler
+        # below would mask them as 500. Not a no-op.
         raise
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))

--- a/src/api/routes/models.py
+++ b/src/api/routes/models.py
@@ -83,6 +83,10 @@ class MemoryPutRequest(BaseModel):
     path: str = ""
     content: str
     categorize: bool = False
+    # V2 visibility — optional; defaults to 'private' downstream.
+    # 'org' requires membership in org_id (or first org_id if not given).
+    visibility: str | None = None
+    org_id: str | None = None
 
 
 class LogEvent(BaseModel):

--- a/src/api/routes/sync.py
+++ b/src/api/routes/sync.py
@@ -6,8 +6,9 @@ import sqlite3
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
-from src.api.auth import get_workspace
+from src.api.auth import get_token_info, get_workspace
 from src.api.dependencies import get_chroma as _get_chroma, get_conn as _get_conn
+from src.api.jwt_auth import TokenInfo
 
 router = APIRouter(prefix="/memory", tags=["sync"])
 logger = logging.getLogger(__name__)
@@ -58,25 +59,46 @@ def get_changes(
     since: str = Query(..., description="ISO 8601 cursor — only chunks created after this"),
     limit: int = Query(500, le=2000),
     workspace_id: str = Depends(get_workspace),
+    info: TokenInfo = Depends(get_token_info),
 ) -> MemorySyncResponse:
+    """Stream chunks created after `since`, scoped by V2 visibility rules.
+
+    WHY(L6, v2-workspaces): the previous query dropped 'org' and 'user'
+    visibility silently — Laravel + Hook clients re-syncing missed every
+    chunk shared cross-workspace via membership or same-user. The filter
+    must mirror retrieval._scope_filter: public + own private + own user
+    + chunks of orgs the caller is a member of.
+    """
     db = _get_conn()
     _ensure_visibility_column(db)
 
+    org_ids = tuple(info.org_ids) if info.org_ids else ()
+    org_clause = ""
+    org_params: list = []
+    if org_ids:
+        placeholders = ",".join("?" * len(org_ids))
+        org_clause = f" OR (s.visibility = 'org' AND s.org_id IN ({placeholders}))"
+        org_params = list(org_ids)
+
+    sql = f"""
+        SELECT c.chunk_id, c.source_id, c.text, c.workspace_id,
+               c.created_at, c.is_active, c.text_hash, c.dedup_key
+        FROM chunks c
+        JOIN sources s ON c.source_id = s.source_id
+        WHERE c.created_at > ?
+          AND (
+              s.visibility = 'public'
+              OR (s.visibility = 'private' AND c.workspace_id = ?)
+              OR (s.visibility = 'user' AND s.user_id = ?)
+              {org_clause}
+          )
+        ORDER BY c.created_at ASC
+        LIMIT ?
+    """
+    params = [since, workspace_id, info.sub, *org_params, limit]
+
     try:
-        rows = db.execute(
-            """
-            SELECT c.chunk_id, c.source_id, c.text, c.workspace_id,
-                   c.created_at, c.is_active, c.text_hash, c.dedup_key
-            FROM chunks c
-            JOIN sources s ON c.source_id = s.source_id
-            WHERE c.created_at > ?
-              AND (s.visibility = 'public'
-                   OR (s.visibility = 'private' AND c.workspace_id = ?))
-            ORDER BY c.created_at ASC
-            LIMIT ?
-            """,
-            (since, workspace_id, limit),
-        ).fetchall()
+        rows = db.execute(sql, tuple(params)).fetchall()
     except sqlite3.Error as e:
         # Don't 500 — that hits the client's UserPromptSubmit hook on every
         # keystroke. Surface the real DB error to the response so the client

--- a/src/api/routes/sync.py
+++ b/src/api/routes/sync.py
@@ -77,6 +77,10 @@ def get_changes(
     org_params: list = []
     if org_ids:
         placeholders = ",".join("?" * len(org_ids))
+        # Safe against SQLi: `placeholders` is only `?,?,...` — pure
+        # parameter placeholder string, never user data. The actual values
+        # bind via `params` (db.execute(sql, tuple(params))). Sourcery's
+        # generic f-string-with-SQL pattern flags this as false positive.
         org_clause = f" OR (s.visibility = 'org' AND s.org_id IN ({placeholders}))"
         org_params = list(org_ids)
 

--- a/src/memory/retrieval.py
+++ b/src/memory/retrieval.py
@@ -70,17 +70,22 @@ def _scope_filter(
     source_type: str | None = None,
     workspace_id: str | None = None,
     org_id: str | None = None,
+    org_ids: tuple[str, ...] | list[str] | None = None,
     user_id: str | None = None,
 ) -> list[str]:
     """Return chunk_ids of active chunks matching hard scope filters.
 
     Visibility model — a chunk is visible to the caller when ANY of:
-      - visibility='public'                              (everyone)
-      - visibility='org'     AND s.org_id   = caller_org   (same organization)
-      - visibility='user'    AND s.user_id  = caller_sub   (same human user,
-                                                            any workspace —
-                                                            claude.ai vs CLI)
-      - visibility='private' AND c.workspace_id = caller_ws (legacy default)
+      - visibility='public'                                  (everyone)
+      - visibility='org'     AND s.org_id   IN caller_orgs   (any of caller's orgs)
+      - visibility='user'    AND s.user_id  = caller_sub     (same human user,
+                                                              any workspace —
+                                                              claude.ai vs CLI)
+      - visibility='private' AND c.workspace_id = caller_ws  (legacy default)
+
+    org_ids supersedes the legacy single org_id param (V2 multi-org JWT).
+    Both are accepted: callers passing org_id (singular) are folded into the
+    list so every existing call-site keeps working.
     """
     query = """
         SELECT c.chunk_id, c.category_labels
@@ -90,15 +95,29 @@ def _scope_filter(
     """
     params: list = []
 
+    # Normalise org input: org_ids (V2) wins; otherwise fold legacy org_id.
+    effective_org_ids: tuple[str, ...]
+    if org_ids:
+        effective_org_ids = tuple(o for o in org_ids if o)
+    elif org_id:
+        effective_org_ids = (org_id,)
+    else:
+        effective_org_ids = ()
+
     if workspace_id:
+        if effective_org_ids:
+            placeholders = ",".join("?" * len(effective_org_ids))
+            org_clause = f" OR (s.visibility = 'org' AND s.org_id IN ({placeholders}))"
+        else:
+            org_clause = ""
         query += (
             " AND (s.visibility = 'public'"
-            " OR (s.visibility = 'org' AND s.org_id = ?)"
             " OR (s.visibility = 'user' AND s.user_id = ?)"
+            f"{org_clause}"
             " OR (s.visibility = 'private' AND c.workspace_id = ?))"
         )
-        params.append(org_id)
         params.append(user_id)
+        params.extend(effective_org_ids)
         params.append(workspace_id)
     if repo:
         query += " AND s.repo = ?"
@@ -478,6 +497,12 @@ def search(
     include_text: bool = bool(opts.get("include_text", True))
     workspace_id: str | None = opts.get("workspace_id")
     org_id: str | None = opts.get("org_id")
+    org_ids_opt = opts.get("org_ids")
+    org_ids: tuple[str, ...] | None
+    if org_ids_opt:
+        org_ids = tuple(org_ids_opt)
+    else:
+        org_ids = None
     user_id: str | None = opts.get("user_id")
 
     # Query-Cache check — hit: clone records, repopulate text on demand.
@@ -505,7 +530,8 @@ def search(
     # Stage 1: scope filter
     candidate_ids = _scope_filter(
         conn, repo=repo, categories=categories, source_type=source_type,
-        workspace_id=workspace_id, org_id=org_id, user_id=user_id,
+        workspace_id=workspace_id, org_id=org_id, org_ids=org_ids,
+        user_id=user_id,
     )
     if not candidate_ids:
         # Tell callers WHY the result is empty: scope filter excluded

--- a/tests/test_memory_sync_endpoint.py
+++ b/tests/test_memory_sync_endpoint.py
@@ -6,19 +6,29 @@ import pytest
 from fastapi.testclient import TestClient
 
 from src.api.server import app
-from src.api.auth import get_workspace
+from src.api.auth import get_token_info, get_workspace
+from src.api.jwt_auth import TokenInfo
 import src.api.dependencies as _deps
 
 
 @pytest.fixture(autouse=True)
 def _override_workspace():
-    prev = app.dependency_overrides.get(get_workspace)
+    prev_ws = app.dependency_overrides.get(get_workspace)
+    prev_ti = app.dependency_overrides.get(get_token_info)
+    # V2: /memory/changes now reads memberships+sub from TokenInfo to scope
+    # the visibility filter. Provide a minimal stub for legacy tests.
+    test_info = TokenInfo(workspace_id="ws-test", sub="0", scopes=("mcp:memory",))
     app.dependency_overrides[get_workspace] = lambda: "ws-test"
+    app.dependency_overrides[get_token_info] = lambda: test_info
     yield
-    if prev is None:
+    if prev_ws is None:
         app.dependency_overrides.pop(get_workspace, None)
     else:
-        app.dependency_overrides[get_workspace] = prev
+        app.dependency_overrides[get_workspace] = prev_ws
+    if prev_ti is None:
+        app.dependency_overrides.pop(get_token_info, None)
+    else:
+        app.dependency_overrides[get_token_info] = prev_ti
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_shared_memory.py
+++ b/tests/test_shared_memory.py
@@ -131,10 +131,14 @@ def test_private_chunk_workspace_isolated():
 def test_admin_can_change_visibility():
     from fastapi.testclient import TestClient
     from src.api.server import app
-    from src.api.auth import get_workspace
+    from src.api.auth import get_token_info, get_workspace
     import src.api.dependencies as _deps
 
+    # V2: PATCH /sources/{id}/visibility now checks ownership via TokenInfo.
+    # Admin scope ('*') bypasses the owner-check.
+    admin_info = TokenInfo(workspace_id="system", sub="0", scopes=("*",))
     app.dependency_overrides[get_workspace] = lambda: "test-ws"
+    app.dependency_overrides[get_token_info] = lambda: admin_info
     db = _db()
     src = Source(source_id="change-src", source_type="note", repo="", path="x")
     upsert_source(db, src, workspace_id="test-ws", visibility="private")
@@ -144,6 +148,7 @@ def test_admin_can_change_visibility():
     resp = client.patch(
         "/sources/change-src/visibility",
         json={"visibility": "public", "org_id": None},
+        headers={"Authorization": "Bearer test"},
     )
     assert resp.status_code == 200
     assert resp.json()["visibility"] == "public"

--- a/tests/test_v2_workspaces.py
+++ b/tests/test_v2_workspaces.py
@@ -1,0 +1,553 @@
+"""Iter 1 + Iter 2 V2-Workspaces — JWT memberships + 4 visibility-bug-fixes.
+
+Ref: docs/v2-workspaces-spec.md
+- Iter 1: TokenInfo.memberships, Membership-NamedTuple, _scope_filter mit org_ids-list
+- Iter 2: L7 (search passes user/org), L8 (PATCH owner-check), L6 (sync respects
+  org/user), L3 (ingest sets org_id from membership when visibility='org')
+"""
+from __future__ import annotations
+
+import datetime
+from unittest.mock import patch
+
+import pytest
+
+from src.memory.db_adapter import DBAdapter
+from src.memory.store import _init_schema, upsert_source, insert_chunk
+from src.memory.schema import Source, Chunk
+from src.api.jwt_auth import Membership, TokenInfo
+
+
+# ---------------------------------------------------------------------------
+# Helpers / Fixtures
+# ---------------------------------------------------------------------------
+
+def _db() -> DBAdapter:
+    adapter = DBAdapter.memory()
+    _init_schema(adapter)
+    return adapter
+
+
+def _insert_chunk(
+    db: DBAdapter,
+    source_id: str,
+    workspace_id: str,
+    visibility: str = "private",
+    org_id: str | None = None,
+    user_id: str | None = None,
+) -> str:
+    src = Source(source_id=source_id, source_type="note", repo="r", path="p")
+    upsert_source(
+        db, src, workspace_id=workspace_id, visibility=visibility,
+        org_id=org_id, user_id=user_id,
+    )
+    chunk_id = f"chk-{source_id}"
+    now = datetime.datetime.utcnow().isoformat()
+    chunk = Chunk(
+        chunk_id=chunk_id, source_id=source_id, text="hello",
+        text_hash="h1", dedup_key="d1", created_at=now,
+        workspace_id=workspace_id,
+    )
+    insert_chunk(db, chunk)
+    return chunk_id
+
+
+@pytest.fixture
+def mock_token_info() -> TokenInfo:
+    """User mit 1 personal + 1 organization membership."""
+    return TokenInfo(
+        workspace_id="ws-bene",
+        sub="42",
+        scopes=("mcp:memory",),
+        memberships=(
+            Membership(id="ws-bene", type="personal", role="owner"),
+            Membership(id="org-acme", type="organization", role="editor"),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Iter 1 — TokenInfo / Membership
+# ---------------------------------------------------------------------------
+
+class TestMembershipParsing:
+    """JWT-Claim-Vertrag V2: memberships[]."""
+
+    def test_membership_is_namedtuple_like(self):
+        m = Membership(id="org-1", type="organization", role="editor")
+        assert m.id == "org-1"
+        assert m.type == "organization"
+        assert m.role == "editor"
+
+    def test_token_info_memberships_default_empty(self):
+        ti = TokenInfo(workspace_id="ws-1", scopes=("mcp:memory",))
+        assert ti.memberships == ()
+
+    def test_token_info_org_ids_extracted_from_memberships(self):
+        ti = TokenInfo(
+            workspace_id="ws-1",
+            scopes=("mcp:memory",),
+            memberships=(
+                Membership(id="ws-personal", type="personal", role="owner"),
+                Membership(id="org-acme", type="organization", role="editor"),
+                Membership(id="org-lab", type="organization", role="viewer"),
+            ),
+        )
+        assert ti.org_ids == ("org-acme", "org-lab")
+
+    def test_token_info_org_ids_empty_when_no_memberships(self):
+        ti = TokenInfo(workspace_id="ws-1", scopes=("mcp:memory",))
+        assert ti.org_ids == ()
+
+    def test_token_info_org_ids_empty_when_only_personal(self):
+        ti = TokenInfo(
+            workspace_id="ws-1",
+            scopes=("mcp:memory",),
+            memberships=(Membership(id="ws-1", type="personal", role="owner"),),
+        )
+        assert ti.org_ids == ()
+
+
+class TestValidateJwtMemberships:
+    """validate_jwt_token parst memberships-claim, backward-compat ohne Feld."""
+
+    def _make_jwt(self, payload: dict, private_key, public_key, monkeypatch, tmp_path):
+        import jwt as _jwt
+        token = _jwt.encode(payload, private_key, algorithm="RS256")
+        # Public key on disk + env vars so validate_jwt_token can pick them up
+        keypath = tmp_path / "pub.pem"
+        keypath.write_text(public_key)
+        monkeypatch.setenv("JWT_PUBLIC_KEY_PATH", str(keypath))
+        monkeypatch.setenv("JWT_ISSUER", "https://app.linn.games")
+        monkeypatch.setenv("JWT_AUDIENCE", "mayringcoder")
+        from src.api import jwt_auth as _ja
+        _ja.reset_public_key_cache()
+        return token
+
+    @pytest.fixture
+    def keypair(self):
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        priv_pem = priv.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode()
+        pub_pem = priv.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+        return priv_pem, pub_pem
+
+    def test_validate_jwt_parses_memberships(self, monkeypatch, tmp_path, keypair):
+        from src.api.jwt_auth import validate_jwt_token
+        priv, pub = keypair
+        import time as _time
+        now = int(_time.time())
+        payload = {
+            "sub": "42",
+            "email": "bene@linn.games",
+            "iat": now,
+            "exp": now + 3600,
+            "iss": "https://app.linn.games",
+            "aud": "mayringcoder",
+            "scope": ["mcp:memory"],
+            "memberships": [
+                {"id": "ws-personal", "type": "personal", "role": "owner"},
+                {"id": "org-acme", "type": "organization", "role": "editor"},
+            ],
+        }
+        tok = self._make_jwt(payload, priv, pub, monkeypatch, tmp_path)
+        info = validate_jwt_token(tok)
+        assert info is not None
+        assert len(info.memberships) == 2
+        assert info.memberships[0].id == "ws-personal"
+        assert info.memberships[1].type == "organization"
+        assert info.org_ids == ("org-acme",)
+
+    def test_validate_jwt_backward_compat_no_memberships(
+        self, monkeypatch, tmp_path, keypair,
+    ):
+        """Alte JWTs ohne memberships-Feld funktionieren weiter."""
+        from src.api.jwt_auth import validate_jwt_token
+        priv, pub = keypair
+        import time as _time
+        now = int(_time.time())
+        payload = {
+            "sub": "42",
+            "email": "bene@linn.games",
+            "iat": now,
+            "exp": now + 3600,
+            "iss": "https://app.linn.games",
+            "aud": "mayringcoder",
+            "scope": ["mcp:memory"],
+        }
+        tok = self._make_jwt(payload, priv, pub, monkeypatch, tmp_path)
+        info = validate_jwt_token(tok)
+        assert info is not None
+        assert info.memberships == ()
+        assert info.org_ids == ()
+
+
+# ---------------------------------------------------------------------------
+# Iter 1 — _scope_filter mit org_ids-Liste
+# ---------------------------------------------------------------------------
+
+class TestScopeFilterOrgIds:
+    """V2: _scope_filter akzeptiert Liste von org_ids (statt single)."""
+
+    def test_scope_filter_includes_all_org_memberships(self):
+        from src.memory.retrieval import _scope_filter
+        db = _db()
+        cid_a = _insert_chunk(db, "src-a", "ws-owner-a", visibility="org", org_id="org-acme")
+        cid_b = _insert_chunk(db, "src-b", "ws-owner-b", visibility="org", org_id="org-lab")
+        cid_other = _insert_chunk(db, "src-c", "ws-owner-c", visibility="org", org_id="org-other")
+
+        results = _scope_filter(
+            db, workspace_id="ws-bene", org_ids=("org-acme", "org-lab"),
+        )
+        assert cid_a in results
+        assert cid_b in results
+        assert cid_other not in results
+
+    def test_scope_filter_excludes_non_member_org(self):
+        from src.memory.retrieval import _scope_filter
+        db = _db()
+        cid = _insert_chunk(db, "src-x", "ws-other", visibility="org", org_id="org-acme")
+        results = _scope_filter(
+            db, workspace_id="ws-bene", org_ids=("org-different",),
+        )
+        assert cid not in results
+
+    def test_scope_filter_backward_compat_no_memberships(self):
+        """Caller ohne org-memberships sieht nur public + own private."""
+        from src.memory.retrieval import _scope_filter
+        db = _db()
+        cid_pub = _insert_chunk(db, "pub", "ws-other", visibility="public")
+        cid_priv = _insert_chunk(db, "own", "ws-bene", visibility="private")
+        cid_org = _insert_chunk(db, "org", "ws-other", visibility="org", org_id="org-x")
+
+        # No org_ids passed → only public + own private
+        results = _scope_filter(db, workspace_id="ws-bene")
+        assert cid_pub in results
+        assert cid_priv in results
+        assert cid_org not in results
+
+    def test_scope_filter_legacy_org_id_single_still_works(self):
+        """Backward-Compat: single org_id-Argument bleibt akzeptiert."""
+        from src.memory.retrieval import _scope_filter
+        db = _db()
+        cid = _insert_chunk(db, "s", "ws-other", visibility="org", org_id="org-acme")
+        # Legacy callsite passes org_id (singular)
+        results = _scope_filter(db, workspace_id="ws-bene", org_id="org-acme")
+        assert cid in results
+
+
+# ---------------------------------------------------------------------------
+# Iter 2 — L7: REST /memory/search passes user_sub + org_ids
+# ---------------------------------------------------------------------------
+
+class TestSearchPassesUserAndOrgIds:
+    """L7: /memory/search-route muss user_sub + org_ids aus TokenInfo durchreichen."""
+
+    def test_search_passes_user_id_and_org_ids(self, monkeypatch):
+        from fastapi.testclient import TestClient
+        from src.api.server import app
+        from src.api.auth import get_token_info, get_workspace
+        import src.api.dependencies as _deps
+        import src.api.routes.memory as _mod
+
+        ti = TokenInfo(
+            workspace_id="ws-bene",
+            sub="42",
+            scopes=("mcp:memory",),
+            memberships=(
+                Membership(id="ws-bene", type="personal", role="owner"),
+                Membership(id="org-acme", type="organization", role="editor"),
+                Membership(id="org-lab", type="organization", role="viewer"),
+            ),
+        )
+        app.dependency_overrides[get_token_info] = lambda: ti
+        app.dependency_overrides[get_workspace] = lambda: "ws-bene"
+        db = _db()
+        _deps._conn = db
+
+        captured: dict = {}
+
+        def _fake_search(query, conn, chroma, ollama_url, opts, char_budget):
+            captured["opts"] = dict(opts)
+            return {"results": [], "prompt_context": "", "diagnostics": {}}
+
+        monkeypatch.setattr(_mod, "_run_search", _fake_search)
+
+        client = TestClient(app)
+        resp = client.post(
+            "/memory/search",
+            json={"query": "x", "top_k": 3},
+            headers={"Authorization": "Bearer test"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert captured["opts"]["workspace_id"] == "ws-bene"
+        assert captured["opts"]["user_id"] == "42"
+        # org_ids forwarded so 'org' visibility chunks surface
+        assert set(captured["opts"]["org_ids"]) == {"org-acme", "org-lab"}
+
+        app.dependency_overrides.clear()
+        _deps._conn = None
+
+
+# ---------------------------------------------------------------------------
+# Iter 2 — L8: PATCH /sources/{id}/visibility owner-check
+# ---------------------------------------------------------------------------
+
+class TestPatchVisibilityAuthorization:
+    """L8: PATCH /sources/{id}/visibility — owner/admin-only, sonst 403."""
+
+    def _setup_app_with_token(self, ti: TokenInfo, db: DBAdapter):
+        from src.api.server import app
+        from src.api.auth import get_token_info, get_workspace
+        import src.api.dependencies as _deps
+
+        app.dependency_overrides[get_token_info] = lambda: ti
+        app.dependency_overrides[get_workspace] = lambda: ti.workspace_id
+        _deps._conn = db
+        return app
+
+    def test_patch_visibility_owner_ok(self):
+        from fastapi.testclient import TestClient
+        ti = TokenInfo(workspace_id="ws-owner", sub="42", scopes=("mcp:memory",))
+        db = _db()
+        upsert_source(
+            db, Source(source_id="s1", source_type="note", repo="", path="x"),
+            workspace_id="ws-owner", visibility="private",
+        )
+        app = self._setup_app_with_token(ti, db)
+        client = TestClient(app)
+        resp = client.patch(
+            "/sources/s1/visibility",
+            json={"visibility": "public", "org_id": None},
+            headers={"Authorization": "Bearer test"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["visibility"] == "public"
+        app.dependency_overrides.clear()
+        import src.api.dependencies as _deps
+        _deps._conn = None
+
+    def test_patch_visibility_other_403(self):
+        """Cross-tenant: non-owner non-admin → 403."""
+        from fastapi.testclient import TestClient
+        # Source belongs to ws-owner / user-1; caller is ws-other / user-2
+        db = _db()
+        upsert_source(
+            db, Source(source_id="s2", source_type="note", repo="", path="x"),
+            workspace_id="ws-owner", visibility="private", user_id="1",
+        )
+        ti = TokenInfo(workspace_id="ws-other", sub="2", scopes=("mcp:memory",))
+        app = self._setup_app_with_token(ti, db)
+        client = TestClient(app)
+        resp = client.patch(
+            "/sources/s2/visibility",
+            json={"visibility": "public", "org_id": None},
+            headers={"Authorization": "Bearer test"},
+        )
+        assert resp.status_code == 403, resp.text
+        app.dependency_overrides.clear()
+        import src.api.dependencies as _deps
+        _deps._conn = None
+
+    def test_patch_visibility_admin_ok(self):
+        """Admin (scope='*' or 'admin') kann alles ändern."""
+        from fastapi.testclient import TestClient
+        db = _db()
+        upsert_source(
+            db, Source(source_id="s3", source_type="note", repo="", path="x"),
+            workspace_id="ws-someone", visibility="private",
+        )
+        ti = TokenInfo(workspace_id="system", sub="0", scopes=("*",))
+        app = self._setup_app_with_token(ti, db)
+        client = TestClient(app)
+        resp = client.patch(
+            "/sources/s3/visibility",
+            json={"visibility": "public", "org_id": None},
+            headers={"Authorization": "Bearer test"},
+        )
+        assert resp.status_code == 200, resp.text
+        app.dependency_overrides.clear()
+        import src.api.dependencies as _deps
+        _deps._conn = None
+
+    def test_patch_visibility_user_value_accepted(self):
+        """V2: 'user' must be a valid visibility option."""
+        from fastapi.testclient import TestClient
+        db = _db()
+        upsert_source(
+            db, Source(source_id="s4", source_type="note", repo="", path="x"),
+            workspace_id="ws-owner", visibility="private",
+        )
+        ti = TokenInfo(workspace_id="ws-owner", sub="42", scopes=("mcp:memory",))
+        app = self._setup_app_with_token(ti, db)
+        client = TestClient(app)
+        resp = client.patch(
+            "/sources/s4/visibility",
+            json={"visibility": "user", "org_id": None},
+            headers={"Authorization": "Bearer test"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["visibility"] == "user"
+        app.dependency_overrides.clear()
+        import src.api.dependencies as _deps
+        _deps._conn = None
+
+
+# ---------------------------------------------------------------------------
+# Iter 2 — L6: sync respects org/user visibility
+# ---------------------------------------------------------------------------
+
+class TestSyncRespectsOrgUserVisibility:
+    """L6: GET /memory/changes muss org/user-visibility ebenfalls liefern."""
+
+    def test_sync_respects_org_user_visibility(self):
+        from fastapi.testclient import TestClient
+        from src.api.server import app
+        from src.api.auth import get_token_info, get_workspace
+        import src.api.dependencies as _deps
+
+        db = _db()
+        # 4 chunks: public, private-own, private-other, org-member, user-own
+        cid_pub = _insert_chunk(db, "pub", "ws-other", visibility="public")
+        cid_own = _insert_chunk(db, "own", "ws-bene", visibility="private")
+        cid_other = _insert_chunk(db, "other", "ws-other", visibility="private")
+        cid_org = _insert_chunk(db, "org", "ws-acme", visibility="org", org_id="org-acme")
+        cid_user = _insert_chunk(db, "user", "ws-other-of-bene", visibility="user", user_id="42")
+
+        ti = TokenInfo(
+            workspace_id="ws-bene",
+            sub="42",
+            scopes=("mcp:memory",),
+            memberships=(
+                Membership(id="ws-bene", type="personal", role="owner"),
+                Membership(id="org-acme", type="organization", role="editor"),
+            ),
+        )
+        app.dependency_overrides[get_token_info] = lambda: ti
+        app.dependency_overrides[get_workspace] = lambda: "ws-bene"
+        _deps._conn = db
+
+        # Stub chroma.get to a no-op so the sync route doesn't hit a real Chroma
+        with patch.object(_deps, "get_chroma", lambda: None):
+            client = TestClient(app)
+            resp = client.get(
+                "/memory/changes",
+                params={"since": "1970-01-01T00:00:00", "limit": 100},
+                headers={"Authorization": "Bearer test"},
+            )
+            assert resp.status_code == 200, resp.text
+            ids = {c["chunk_id"] for c in resp.json()["chunks"]}
+            assert cid_pub in ids
+            assert cid_own in ids
+            assert cid_other not in ids   # other-tenant private must not leak
+            assert cid_org in ids          # member of org-acme
+            assert cid_user in ids         # same user across workspaces
+
+        app.dependency_overrides.clear()
+        _deps._conn = None
+
+
+# ---------------------------------------------------------------------------
+# Iter 2 — L3: ingest sets org_id from membership when visibility='org'
+# ---------------------------------------------------------------------------
+
+class TestIngestOrgIdResolution:
+    """L3: visibility='org' bei /memory/put resolved org_id aus membership."""
+
+    def test_ingest_org_visibility_uses_first_membership(self, monkeypatch):
+        """Wenn visibility='org' aber kein org_id im body → erste org-membership default."""
+        from fastapi.testclient import TestClient
+        from src.api.server import app
+        from src.api.auth import get_token_info, get_workspace
+        import src.api.dependencies as _deps
+        import src.api.routes.memory as _mod
+
+        db = _db()
+        ti = TokenInfo(
+            workspace_id="ws-bene",
+            sub="42",
+            scopes=("mcp:memory",),
+            memberships=(
+                Membership(id="ws-bene", type="personal", role="owner"),
+                Membership(id="org-acme", type="organization", role="editor"),
+            ),
+        )
+        app.dependency_overrides[get_token_info] = lambda: ti
+        app.dependency_overrides[get_workspace] = lambda: "ws-bene"
+        _deps._conn = db
+
+        captured: dict = {}
+
+        def _fake_ingest(source_dict, content, conn, chroma, ollama_url, model, opts, ws):
+            captured["source_dict"] = dict(source_dict)
+            return {"source_id": source_dict["source_id"], "chunk_ids": []}
+
+        monkeypatch.setattr(_mod, "_run_ingest", _fake_ingest)
+
+        client = TestClient(app)
+        resp = client.post(
+            "/memory/put",
+            json={
+                "source_id": "s-ingest-1",
+                "content": "hello",
+                "visibility": "org",
+            },
+            headers={"Authorization": "Bearer test"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert captured["source_dict"].get("visibility") == "org"
+        assert captured["source_dict"].get("org_id") == "org-acme"
+
+        app.dependency_overrides.clear()
+        _deps._conn = None
+
+    def test_ingest_org_id_must_be_member(self, monkeypatch):
+        """Wenn org_id aus body kommt → caller muss member dieser org sein, sonst 403."""
+        from fastapi.testclient import TestClient
+        from src.api.server import app
+        from src.api.auth import get_token_info, get_workspace
+        import src.api.dependencies as _deps
+        import src.api.routes.memory as _mod
+
+        db = _db()
+        ti = TokenInfo(
+            workspace_id="ws-bene",
+            sub="42",
+            scopes=("mcp:memory",),
+            memberships=(
+                Membership(id="ws-bene", type="personal", role="owner"),
+                Membership(id="org-acme", type="organization", role="editor"),
+            ),
+        )
+        app.dependency_overrides[get_token_info] = lambda: ti
+        app.dependency_overrides[get_workspace] = lambda: "ws-bene"
+        _deps._conn = db
+
+        # Fake ingest exists so we know route doesn't fall through to it
+        def _fake_ingest(*args, **kwargs):
+            return {"source_id": "x", "chunk_ids": []}
+        monkeypatch.setattr(_mod, "_run_ingest", _fake_ingest)
+
+        client = TestClient(app)
+        resp = client.post(
+            "/memory/put",
+            json={
+                "source_id": "s-ingest-2",
+                "content": "hi",
+                "visibility": "org",
+                "org_id": "org-not-a-member",
+            },
+            headers={"Authorization": "Bearer test"},
+        )
+        assert resp.status_code == 403, resp.text
+
+        app.dependency_overrides.clear()
+        _deps._conn = None


### PR DESCRIPTION
## Summary

Implements **Iter 1 (JWT-Foundation)** and **Iter 2 (4 Audit-Bug-Fixes)** of `docs/v2-workspaces-spec.md`. Multi-org membership now flows end-to-end and the V2 visibility semantics (`public` / `org` / `user` / `private`) work across REST, sync, and MCP.

### Iter 1 — JWT-Foundation
- New `Membership` NamedTuple (`id`, `type`, `role`) on `TokenInfo`
- `TokenInfo.memberships: tuple[Membership, ...]` parsed from the JWT `memberships[]` claim
- `TokenInfo.org_ids` property — derived from memberships; legacy `org_id` claim still honoured
- `_scope_filter` accepts an `org_ids` list and emits an `IN (...)` clause; the legacy single `org_id` arg keeps working (folded into the list internally)

**Backward-compat is hard-guaranteed**: an old JWT without `memberships[]` still validates and behaves identically to before — `org_ids` is just `()`.

### Iter 2 — Bug-Fixes (audit IDs)
- **L7** — `POST /memory/search` now passes `user_id` + `org_ids` from `TokenInfo` to retrieval. Before this, REST callers (Laravel, hooks) saw only `public` + own `private` chunks.
- **L8** — `PATCH /sources/{id}/visibility` enforces owner-or-admin check (was open to cross-tenant vandalism). `'user'` added to the visibility whitelist.
- **L6** — `GET /memory/changes` filter mirrors `_scope_filter`: public + own private + own user + chunks of orgs the caller is a member of.
- **L3** — `POST /memory/put` resolves `org_id` when `visibility='org'`: explicit `org_id` is verified against membership (else 403); without one, defaults to caller's first org-membership (logged).

The MCP search tool now uses the new `_effective_org_ids()` helper. The legacy `_effective_org_id()` was kept (and now falls back to first membership) so any other call-site stays working.

## Test plan
- [x] `pytest tests/test_v2_workspaces.py` — 19 new tests, all green
- [x] Full suite `pytest tests/` — **1374 passed, 7 skipped, 0 failed**
- [x] Backward-compat verified: `test_validate_jwt_backward_compat_no_memberships` + `test_scope_filter_backward_compat_no_memberships` + `test_scope_filter_legacy_org_id_single_still_works`
- [ ] Smoke once Laravel side ships V2 JWT (pending the parallel `app.linn.games` MR — `memberships[]` claim from `JwtIssuer`)

## Out of scope
- Iter 3 (org-management UI/API)
- Iter 4 (`POST /sources/{id}/share` endpoint)
- `claude-plugin/hooks/` changes — bleibt für später

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce multi-organization JWT memberships and align memory visibility behavior across REST, sync, and MCP with the V2 visibility model.

New Features:
- Add JWT membership support with a Membership type and TokenInfo.memberships/org_ids to represent multi-organization workspace membership.
- Extend memory APIs to accept visibility, org_id, and membership-derived org scopes so org- and user-level sharing works across workspaces.

Bug Fixes:
- Ensure REST /memory/search passes user and org membership context so org and user visibility chunks are returned correctly.
- Harden PATCH /sources/{id}/visibility with owner-or-admin authorization and support for the 'user' visibility level to prevent cross-tenant changes.
- Update /memory/changes sync filtering to include public, own private, user, and org-member chunks so resyncs see all shared data.
- Resolve org_id on /memory/put when visibility='org', validating explicit org_ids against memberships and defaulting to the first org membership when omitted.

Enhancements:
- Generalize retrieval scope filtering to accept multiple org_ids while preserving compatibility with single-org callers.
- Expose effective org_ids in MCP auth and propagate them through MCP memory search tooling for consistent visibility semantics.
- Expand tests with a dedicated V2 workspaces suite and adjustments to existing tests to cover JWT memberships and new visibility rules.