### PR TITLE
fix(#195): /stats/workspaces lists all memberships (V2 follow-up)

### DIFF
--- a/src/api/routes/dashboard.py
+++ b/src/api/routes/dashboard.py
@@ -363,15 +363,28 @@ async def activations(
 
 @router.get("/stats/workspaces")
 async def workspaces(workspace_id: str = Depends(get_workspace)) -> dict:
-    """Per-workspace activity. Admins see all, tenants see just their own.
+    """Per-workspace activity.
 
-    Useful to spot drift (one user with 3 parallel workspaces) or stale
-    workspaces that haven't been touched in months.
+    Admins see all workspaces in the DB. Tenants see every workspace they're
+    a member of — derived from the JWT `memberships[]` claim (V2). For
+    backward-compat with old JWTs without memberships, falls back to the
+    single active workspace_id.
     """
     from src.api.mcp_auth import _TOKEN_CTX
 
     info = _TOKEN_CTX.get()
     is_admin = bool(info and "admin" in (info.scopes or ()))
+    # WHY(#195, v2): pre-V2 the non-admin branch listed exactly one row
+    # (the active workspace). After V2 a user in N workspaces sees all N.
+    # Source-of-truth is the JWT `memberships[]` claim from Laravel; falls
+    # back to {workspace_id} for legacy JWTs without the field.
+    member_ws_ids: set[str] = {workspace_id}
+    member_ws_types: dict[str, str] = {}
+    if info and getattr(info, "memberships", None):
+        for m in info.memberships:
+            if m.id:
+                member_ws_ids.add(m.id)
+                member_ws_types[m.id] = m.type
 
     conn = _conn()
     if is_admin:
@@ -384,12 +397,16 @@ async def workspaces(workspace_id: str = Depends(get_workspace)) -> dict:
             "GROUP BY c.workspace_id ORDER BY 4 DESC"
         ).fetchall()
     else:
+        # SAFE: placeholders is "?,?,?" — no user-input concatenation.
+        placeholders = ",".join("?" * len(member_ws_ids))
         rows = conn.execute(
-            "SELECT ?, COUNT(DISTINCT c.chunk_id), "
-            "       COUNT(DISTINCT s.source_id), MAX(c.created_at) "
-            "FROM chunks c LEFT JOIN sources s ON s.workspace_id = c.workspace_id "
-            "WHERE c.workspace_id = ?",
-            (workspace_id, workspace_id),
+            f"SELECT c.workspace_id, "
+            f"       COUNT(DISTINCT c.chunk_id), "
+            f"       COUNT(DISTINCT s.source_id), MAX(c.created_at) "
+            f"FROM chunks c LEFT JOIN sources s ON s.workspace_id = c.workspace_id "
+            f"WHERE c.workspace_id IN ({placeholders}) "
+            f"GROUP BY c.workspace_id ORDER BY 4 DESC",
+            tuple(member_ws_ids),
         ).fetchall()
 
     return {
@@ -397,6 +414,7 @@ async def workspaces(workspace_id: str = Depends(get_workspace)) -> dict:
         "workspaces": [
             {
                 "workspace_id": r[0],
+                "type": member_ws_types.get(r[0], "personal" if r[0] == workspace_id else "unknown"),
                 "chunks": r[1],
                 "sources": r[2],
                 "last_activity": r[3],

--- a/tests/test_dashboard_endpoints.py
+++ b/tests/test_dashboard_endpoints.py
@@ -186,7 +186,7 @@ def test_pi_tasks_no_pi_jobs_table_returns_empty(seeded_db):
 # ---------------------------------------------------------------------------
 
 def test_workspaces_tenant_sees_only_own(seeded_db, monkeypatch):
-    """Non-admin token: scoped to own workspace_id."""
+    """Non-admin token without memberships: scoped to active workspace_id only."""
     from src.api.jwt_auth import TokenInfo
     from src.api import mcp_auth as mcp_mod
     mcp_mod._TOKEN_CTX.set(TokenInfo(workspace_id="user-2", scopes=()))
@@ -195,6 +195,44 @@ def test_workspaces_tenant_sees_only_own(seeded_db, monkeypatch):
         assert len(res["workspaces"]) == 1
         assert res["workspaces"][0]["workspace_id"] == "user-2"
         assert res["workspaces"][0]["chunks"] == 1
+    finally:
+        mcp_mod._TOKEN_CTX.set(None)
+
+
+def test_workspaces_tenant_with_memberships_sees_all(seeded_db, monkeypatch):
+    """V2: token with memberships[] lists every ws the user is a member of.
+    Regression for #195: pre-V2 the non-admin branch returned exactly 1 row,
+    hiding org-workspaces from the dashboard even when chunks were ingested."""
+    from src.api.jwt_auth import TokenInfo, Membership
+    from src.api import mcp_auth as mcp_mod
+    # Seed: insert source FIRST (FK from chunks.source_id), then chunk.
+    seeded_db.execute(
+        "INSERT INTO sources (source_id, workspace_id, source_type, repo, path, captured_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("src-org", "ws-acme", "memory", "", "manual", "2026-05-10T10:00:00Z"),
+    )
+    seeded_db.execute(
+        "INSERT INTO chunks (chunk_id, source_id, workspace_id, text, "
+        "created_at, is_active) VALUES (?, ?, ?, ?, ?, 1)",
+        ("c-org-1", "src-org", "ws-acme", "org-content", "2026-05-10T10:00:00Z"),
+    )
+    seeded_db.commit()
+
+    mcp_mod._TOKEN_CTX.set(TokenInfo(
+        workspace_id="user-2",
+        scopes=(),
+        memberships=(
+            Membership(id="user-2", type="personal", role="owner"),
+            Membership(id="ws-acme", type="organization", role="editor"),
+        ),
+    ))
+    try:
+        res = _run(dashboard.workspaces(workspace_id="user-2"))
+        ws_ids = {w["workspace_id"] for w in res["workspaces"]}
+        assert ws_ids == {"user-2", "ws-acme"}
+        types = {w["workspace_id"]: w["type"] for w in res["workspaces"]}
+        assert types["user-2"] == "personal"
+        assert types["ws-acme"] == "organization"
     finally:
         mcp_mod._TOKEN_CTX.set(None)
 


### PR DESCRIPTION
Follow-up zu PR #197. Schließt das letzte sichtbare V2-Iter-Problem: Dashboard zeigt jetzt alle Workspaces des Users statt nur aktive.

## Closes
Bug aus #195 — "non-admin sieht nur 1 row in /stats/workspaces".

## Test
`pytest tests/test_dashboard_endpoints.py -k workspaces_tenant` → 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the /stats/workspaces dashboard endpoint so non-admin users with JWT workspace memberships see activity for all their workspaces instead of just the active one.

Bug Fixes:
- Ensure non-admin users see all member workspaces in /stats/workspaces, addressing the issue where only a single workspace row was returned.

Enhancements:
- Expose workspace type in the /stats/workspaces response for tenant users based on JWT membership metadata.
- Clarify endpoint documentation and inline comments to describe V2 JWT membership behavior and legacy fallback.

Tests:
- Add a regression test verifying that a tenant with multiple workspace memberships sees all associated workspaces and their types in the dashboard.