### PR TITLE
feat(reranker): rating-skala als sample_weight (closes #209)

### DIFF
--- a/tests/test_export_retrieval_dataset.py
+++ b/tests/test_export_retrieval_dataset.py
@@ -163,3 +163,132 @@ def test_label_uses_event_was_referenced_not_chunk_global(tmp_path):
     rows = [json.loads(l) for l in out.read_text().splitlines()]
     labels_by_query = {r["query"]: r["label"] for r in rows}
     assert labels_by_query == {"q1": 1, "q2": 0}
+
+
+# ── Tests for #209 rating-weighted samples ────────────────────────
+
+def _insert_rating(conn, chunk_id: str, rating: str) -> None:
+    conn.execute(
+        "INSERT INTO chunk_feedback (chunk_id, signal, metadata, created_at) "
+        "VALUES (?, ?, '{}', datetime('now'))",
+        (chunk_id, rating),
+    )
+
+
+def _export_to_jsonl(tmp_path, conn) -> list[dict]:
+    """Helper: run the exporter on the test DB, return parsed rows."""
+    from tools.export_retrieval_dataset import export
+    out_path = tmp_path / "ds.jsonl"
+    db_path = tmp_path / "test.db"
+    # The conn passed in already points to db_path
+    export(db_path, out_path, days=30, negative_mode="unlabeled")
+    return [json.loads(line) for line in out_path.read_text().splitlines()]
+
+
+def test_rating_5_sets_label_1_with_high_weight(tmp_path):
+    db_path = tmp_path / "test.db"
+    conn = _build_db(db_path)
+    conn.execute("INSERT INTO chunks (chunk_id, igio_axis) VALUES (?, '')", ("chk_top",))
+    _insert_event(conn, "real query", ["chk_top"],
+                  {"chk_top": {"v": 0.7, "s": 0.5, "r": 0.3, "a": 0.0,
+                               "pt": 0.0, "re": 0.0}},
+                  was_referenced=0)  # was_referenced=0, but user rated 5★
+    _insert_rating(conn, "chk_top", "5")
+    conn.commit()
+    conn.close()
+
+    rows = _export_to_jsonl(tmp_path, None)
+    assert len(rows) == 1
+    # Rating 5★ überstimmt das was_referenced=0 — chunk wird positiv.
+    assert rows[0]["label"] == 1
+    assert rows[0]["sample_weight"] >= 1.0
+
+
+def test_rating_1_sets_label_0_with_high_weight(tmp_path):
+    db_path = tmp_path / "test.db"
+    conn = _build_db(db_path)
+    conn.execute("INSERT INTO chunks (chunk_id, igio_axis) VALUES (?, '')", ("chk_bad",))
+    _insert_event(conn, "real query", ["chk_bad"],
+                  {"chk_bad": {"v": 0.6, "s": 0.4, "r": 0.5, "a": 0.0,
+                               "pt": 0.0, "re": 0.0}},
+                  was_referenced=1)  # referenced but rated 1★ later
+    _insert_rating(conn, "chk_bad", "1")
+    conn.commit()
+    conn.close()
+
+    rows = _export_to_jsonl(tmp_path, None)
+    assert rows[0]["label"] == 0
+    assert rows[0]["sample_weight"] >= 1.0
+
+
+def test_rating_3_is_omitted_no_signal(tmp_path):
+    """Neutral 3★ ratings should NOT influence label — fall back to was_referenced + default weight."""
+    db_path = tmp_path / "test.db"
+    conn = _build_db(db_path)
+    conn.execute("INSERT INTO chunks (chunk_id, igio_axis) VALUES (?, '')", ("chk_mid",))
+    _insert_event(conn, "real query", ["chk_mid"],
+                  {"chk_mid": {"v": 0.5, "s": 0.5, "r": 0.5, "a": 0.0,
+                               "pt": 0.0, "re": 0.0}},
+                  was_referenced=1)
+    _insert_rating(conn, "chk_mid", "3")
+    conn.commit()
+    conn.close()
+
+    rows = _export_to_jsonl(tmp_path, None)
+    # was_referenced bleibt das label, weight ist default 1.0
+    assert rows[0]["label"] == 1
+    assert rows[0]["sample_weight"] == 1.0
+
+
+def test_no_rating_uses_was_referenced_default_weight(tmp_path):
+    db_path = tmp_path / "test.db"
+    conn = _build_db(db_path)
+    conn.execute("INSERT INTO chunks (chunk_id, igio_axis) VALUES (?, '')", ("chk_no_fb",))
+    _insert_event(conn, "real query", ["chk_no_fb"],
+                  {"chk_no_fb": {"v": 0.5, "s": 0.4, "r": 0.3, "a": 0.0,
+                                 "pt": 0.0, "re": 0.0}},
+                  was_referenced=1)
+    conn.commit()
+    conn.close()
+
+    rows = _export_to_jsonl(tmp_path, None)
+    assert rows[0]["label"] == 1
+    assert rows[0]["sample_weight"] == 1.0
+
+
+def test_multiple_ratings_get_n_bonus(tmp_path):
+    """3× 5★ feedback sollte weight > 1× 5★ haben (mehr confidence)."""
+    db_path = tmp_path / "test.db"
+    conn = _build_db(db_path)
+    conn.execute("INSERT INTO chunks (chunk_id, igio_axis) VALUES (?, '')", ("chk_consensus",))
+    _insert_event(conn, "real query", ["chk_consensus"],
+                  {"chk_consensus": {"v": 0.7, "s": 0.5, "r": 0.5, "a": 0.0,
+                                     "pt": 0.0, "re": 0.0}},
+                  was_referenced=1)
+    for _ in range(3):
+        _insert_rating(conn, "chk_consensus", "5")
+    conn.commit()
+    conn.close()
+
+    rows = _export_to_jsonl(tmp_path, None)
+    # n=3 → weight = 1.0 * (1 + 0.1 * 2) = 1.2
+    assert rows[0]["sample_weight"] == pytest.approx(1.2)
+
+
+def test_legacy_positive_signal_maps_to_rating_4(tmp_path):
+    """Pre-rating-migration callers used 'positive'/'negative' — accept those too."""
+    db_path = tmp_path / "test.db"
+    conn = _build_db(db_path)
+    conn.execute("INSERT INTO chunks (chunk_id, igio_axis) VALUES (?, '')", ("chk_legacy",))
+    _insert_event(conn, "real query", ["chk_legacy"],
+                  {"chk_legacy": {"v": 0.4, "s": 0.4, "r": 0.4, "a": 0.0,
+                                  "pt": 0.0, "re": 0.0}},
+                  was_referenced=0)  # not referenced, but legacy 'positive'
+    _insert_rating(conn, "chk_legacy", "positive")
+    conn.commit()
+    conn.close()
+
+    rows = _export_to_jsonl(tmp_path, None)
+    # positive → rating-equiv 4 → weak positive (label=1, weight=0.5)
+    assert rows[0]["label"] == 1
+    assert rows[0]["sample_weight"] == pytest.approx(0.5)

--- a/tools/export_retrieval_dataset.py
+++ b/tools/export_retrieval_dataset.py
@@ -77,27 +77,57 @@ def _igio_axis_map(conn: sqlite3.Connection) -> dict[str, str]:
     return out
 
 
-def _label_map(conn: sqlite3.Connection, days: int) -> dict[str, int]:
-    """{chunk_id: 1 if positive feedback dominates else 0/-1}."""
+def _label_map(
+    conn: sqlite3.Connection, days: int
+) -> dict[str, tuple[int, float]]:
+    """{chunk_id: (label, sample_weight)} from rating 1..5 feedback.
+
+    WHY(#209, rating-weighted): vor diesem fix wurde rating 1..5 binär
+    kollabiert — "5★ primary source" und "1★ irrelevant" wurden gleich
+    behandelt (beide → pos), und neutrale 3★ leakten als pos-signal rein.
+    Resultat: model lernt nichts aus der Skala.
+
+    Neuer mapping:
+      rating 5  → label 1, weight 1.0  (starkes positiv)
+      rating 4  → label 1, weight 0.5
+      rating 3  → omit (neutral)
+      rating 2  → label 0, weight 0.5
+      rating 1  → label 0, weight 1.0  (starkes negativ)
+
+    Bei mehreren ratings: avg(rating) entscheidet, weight wird mit
+    n-bonus (1 + 0.1*(n-1)) skaliert sodass mehr feedback = höheres
+    confidence. Legacy-signals werden auf rating-äquivalente gemappt:
+    positive → 4, negative → 2 (default weight 0.5 weil low confidence).
+    """
     rows = conn.execute(
         "SELECT chunk_id, signal FROM chunk_feedback "
         "WHERE created_at > datetime('now', ?)",
         (f"-{days} days",),
     ).fetchall()
-    counts: dict[str, dict[str, int]] = {}
+
+    chunk_ratings: dict[str, list[float]] = {}
     for cid, sig in rows:
-        bucket = counts.setdefault(cid, {"pos": 0, "neg": 0})
-        if sig in ("positive", "1", "2", "3", "4", "5"):
-            bucket["pos"] += 1
+        if sig in ("1", "2", "3", "4", "5"):
+            chunk_ratings.setdefault(cid, []).append(float(sig))
+        elif sig == "positive":
+            chunk_ratings.setdefault(cid, []).append(4.0)
         elif sig == "negative":
-            bucket["neg"] += 1
-    out: dict[str, int] = {}
-    for cid, c in counts.items():
-        if c["pos"] > c["neg"]:
-            out[cid] = 1
-        elif c["neg"] > c["pos"]:
-            out[cid] = -1
-        # else unknown → omit
+            chunk_ratings.setdefault(cid, []).append(2.0)
+
+    out: dict[str, tuple[int, float]] = {}
+    for cid, ratings in chunk_ratings.items():
+        avg = sum(ratings) / len(ratings)
+        n_bonus = 1 + 0.1 * (len(ratings) - 1)
+
+        if avg >= 4.5:
+            out[cid] = (1, 1.0 * n_bonus)
+        elif avg >= 3.5:
+            out[cid] = (1, 0.5 * n_bonus)
+        elif avg <= 1.5:
+            out[cid] = (0, 1.0 * n_bonus)
+        elif avg <= 2.5:
+            out[cid] = (0, 0.5 * n_bonus)
+        # avg in (2.5, 3.5) → omit (neutral, no training signal)
     return out
 
 
@@ -156,6 +186,13 @@ def export(
     conn.row_factory = sqlite3.Row
     try:
         igio_map = _igio_axis_map(conn)
+        # WHY(#209, rating-weighted): chunks die EXPLIZITES rating-feedback
+        # haben bekommen einen sample_weight basierend auf der rating-skala
+        # (5★ = strong positive, 1★ = strong negative). Chunks ohne explicit
+        # rating bleiben bei weight=1.0 (default).
+        # Das gibt dem trainer mehr signal aus der 5-stufen-skala ohne sie
+        # ins label zu mappen (das bleibt was_referenced, kein leakage).
+        rating_weights = _label_map(conn, days)
         # Label aus dem PER-EVENT-Signal `was_referenced` statt aus dem
         # GLOBALEN chunk_feedback-Aggregat. Das alte _label_map(conn,days)
         # gab pro chunk_id ein binary "irgendwo schonmal positives
@@ -195,13 +232,28 @@ def export(
                     feats = _normalize_features(stage.get(cid), cid, igio_map)
                     if feats is None:
                         continue
+                    # WHY(#209): rating-weight (1..5★) als sample_weight.
+                    # explicit rating → weight 0.5..1.1; ohne rating → 1.0.
+                    # Plus: bei Konflikt zwischen was_referenced=0 und
+                    # avg_rating>=4 (chunk wurde NICHT referenziert in der
+                    # antwort, aber user hat ihn später als 5★ gerated):
+                    # rating überstimmt label, weil der user die ground
+                    # truth ist (was_referenced ist nur ein proxy).
+                    rating_info = rating_weights.get(cid)
+                    final_label = ev_label
+                    final_weight = 1.0
+                    if rating_info is not None:
+                        rating_label, rating_weight = rating_info
+                        final_label = rating_label
+                        final_weight = rating_weight
                     f.write(json.dumps({
-                        "query":        row["query"],
-                        "chunk_id":     cid,
-                        "features":     feats,
-                        "label":        ev_label,
-                        "captured_at":  row["captured_at"],
-                        "workspace_id": row["workspace_id"] or "",
+                        "query":         row["query"],
+                        "chunk_id":      cid,
+                        "features":      feats,
+                        "label":         final_label,
+                        "sample_weight": final_weight,
+                        "captured_at":   row["captured_at"],
+                        "workspace_id":  row["workspace_id"] or "",
                     }) + "\n")
                     written += 1
         return written

--- a/tools/train_reranker.py
+++ b/tools/train_reranker.py
@@ -65,9 +65,18 @@ MIN_ROWS = 50
 MIN_POSITIVES = 10
 
 
-def _load(path: Path) -> tuple[list[list[float]], list[int], list[str]]:
+def _load(
+    path: Path,
+) -> tuple[list[list[float]], list[int], list[float], list[str]]:
+    """Return (X, y, sample_weight, chunk_ids).
+
+    sample_weight per row (#209): rating 5★ = 1.0, 4★ = 0.5, 2★ = 0.5,
+    1★ = 1.0 (negativ). Rows ohne explicit rating bekommen 1.0.
+    Multi-rating chunks bekommen n-bonus (1 + 0.1*(n-1), clipped).
+    """
     X: list[list[float]] = []
     y: list[int] = []
+    w: list[float] = []
     cids: list[str] = []
     with path.open(encoding="utf-8") as f:
         for line in f:
@@ -75,8 +84,9 @@ def _load(path: Path) -> tuple[list[list[float]], list[int], list[str]]:
             feats = row.get("features") or {}
             X.append([float(feats.get(k, 0.0)) for k in FEATURES])
             y.append(int(row.get("label", 0)))
+            w.append(float(row.get("sample_weight", 1.0)))
             cids.append(row.get("chunk_id", ""))
-    return X, y, cids
+    return X, y, w, cids
 
 
 def _ndcg_at_k(labels: list[int], k: int) -> float:
@@ -97,7 +107,7 @@ def train(in_path: Path, out_path: Path) -> int:
     except ImportError:
         print("Fehler: sklearn nicht installiert (pip install scikit-learn)")
         return 2
-    X, y, _cids = _load(in_path)
+    X, y, w, _cids = _load(in_path)
     if len(X) < MIN_ROWS:
         print(f"zu wenig Daten: {len(X)} rows < {MIN_ROWS} (warte auf mehr Feedback)")
         return 1
@@ -105,8 +115,12 @@ def train(in_path: Path, out_path: Path) -> int:
     if pos < MIN_POSITIVES:
         print(f"zu wenig Positives: {pos} < {MIN_POSITIVES}")
         return 1
-    Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.2, random_state=42,
-                                          stratify=y if pos < len(y) else None)
+    # WHY(#209): split inkl. sample_weight, sodass die ratings auch in
+    # train/test korrekt mitgeführt werden.
+    Xtr, Xte, ytr, yte, wtr, _wte = train_test_split(
+        X, y, w, test_size=0.2, random_state=42,
+        stratify=y if pos < len(y) else None,
+    )
     # L2 (Ridge) mit C=0.1 = stark regularisiert. Multikollinearität
     # zwischen v↔s (corr=+0.51), v↔r (+0.43), s↔r (+0.66) führt unter
     # default-C zu willkürlichen Vorzeichen-Flips zwischen den
@@ -116,7 +130,11 @@ def train(in_path: Path, out_path: Path) -> int:
     # ihren echten Effekt-Anteil. AUC nahezu identisch zu unregulierter
     # version; Weights sind interpretierbarer + multi-tenant-stabiler.
     clf = LogisticRegression(max_iter=500, class_weight="balanced", C=0.1)
-    clf.fit(Xtr, ytr)
+    # WHY(#209): sample_weight führt rating-skala 1..5 als training-signal
+    # ein. 5★-feedback bekommt doppelt so viel pull wie 4★. Zusammen mit
+    # class_weight='balanced' (klassen-imbalance) ergibt sich effektives
+    # gewicht = class_weight * sample_weight.
+    clf.fit(Xtr, ytr, sample_weight=wtr)
     proba = clf.predict_proba(Xte)[:, 1]
     auc = float(roc_auc_score(yte, proba)) if len(set(yte)) > 1 else 0.0
     sorted_pairs = sorted(zip(proba, yte), key=lambda p: p[0], reverse=True)


### PR DESCRIPTION
## Summary
Issue #209: rating-skala 1..5 wurde im trainer binär kollabiert. Fix: rating als sample_weight, neutral 3★ omitted, n-bonus für consensus.

## Changes
- \`tools/export_retrieval_dataset.py\` \`_label_map\` returns \`(label, weight)\` aus rating-skala
- \`tools/export_retrieval_dataset.py\` \`export()\`: rating überstimmt was_referenced + emits \`sample_weight\` field
- \`tools/train_reranker.py\` \`_load()\` returns weights too + \`clf.fit(sample_weight=wtr)\`

## Test plan
- [x] 6 neue tests grün (rating 5/1/3/no-rating/multi/legacy)
- [x] 4 existing train_reranker tests grün
- [x] 35 adjacent export/training/sanity tests grün
- [ ] Validate post-merge: nächster cron-run nutzt sample_weights, NDCG@5 messen

## Closes
- #209

Verweist auf #180: weniger noise im training-signal sollte das degenerate-weight-problem in #180 indirekt mildern (besseres signal-to-noise-ratio). Die sf-dominance war schon adressiert (sf dropped, ridge C=0.1, sanity-gate v/s>=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)