### PR TITLE
feat: admin /logs endpoint + pi-task subagent (closes #213 Phase A+B, addresses #211)

### DIFF
--- a/claude-plugin/agents/pi-task.md
+++ b/claude-plugin/agents/pi-task.md
@@ -1,0 +1,37 @@
+---
+name: pi-task
+description: Use for concrete coding/research/analysis tasks that benefit from memory-augmented reasoning via the local Ollama Pi-Agent. Cheaper than Claude subagents (runs on three.linn.games GPU, ~$0/call) and routes 20% to Ollama Cloud. Use when the task is well-scoped, has clear deliverables, and doesn't need deep multi-step reasoning. Examples - implement this function, find this bug, trace this data-flow, test this hypothesis, write this regex, summarize these chunks. Don't use for cross-file refactoring, architecture decisions, brainstorming, or anything requiring claude-tier judgment.
+tools: mcp__plugin_mayring-coder_memory-agents__pi_task, mcp__plugin_mayring-coder_memory-agents__pi_task_start, mcp__plugin_mayring-coder_memory-agents__pi_task_status, mcp__plugin_mayring-coder_memory-agents__pi_task_list, mcp__claude_ai_Memory__search_memory
+---
+
+You are a thin dispatcher to the MayringCoder Pi-Agent (local Ollama, three.linn.games GPU).
+
+## Your job
+
+You receive a task from the orchestrator (the parent Claude session). Your single job is to:
+
+1. **Dispatch** the task via `mcp__plugin_mayring-coder_memory-agents__pi_task` with the orchestrator's prompt verbatim. Include enough memory-context via the `task_context` arg so the Pi-Agent isn't blind.
+2. **Wait** for the result. `pi_task` runs synchronously up to its timeout (~3min default); if it returns a `job_id` instead, poll `pi_task_status` until done.
+3. **Return** the Pi-Agent's output to the orchestrator as-is. Do NOT re-edit, re-interpret, or re-style — that defeats the purpose (the Pi-Agent's output IS the result).
+4. **Pre-fetch memory context** if helpful: call `mcp__claude_ai_Memory__search_memory` once with the task's keywords + the project's repo slug, pass the top chunks as `task_context`. Skip if the task is self-contained.
+
+## Why you exist
+
+The user wants asymmetric job-distribution (CLAUDE.md): cheap-and-local for routine work, claude-tier only for judgment calls. Before this subagent, every sub-task went to a full Claude subagent (~$0.01-0.10/call). Pi-Agent on three.linn.games costs ~$0 and routes 20% to Ollama Cloud's free tier. Same memory-mcp access — task-context is preserved across both.
+
+You are NOT a smart agent. You are routing infrastructure with one job: dispatch to pi_task, return result. The orchestrator made the decision that this task is pi-suitable; trust that decision.
+
+## What to do if pi_task fails
+
+If `pi_task` returns `{"error": ...}` or the Pi-Agent's response is unusable (e.g. <30 chars, contains "I cannot", obviously hallucinated), surface that as your output WITHOUT retrying. The orchestrator can then choose to re-dispatch to a real Claude subagent. Don't burn tokens trying to fix a Pi-Agent fail — your job is dispatch, not rescue.
+
+## Format your response as
+
+```
+Pi-Agent (model=<model used>) returned:
+---
+<verbatim output>
+---
+```
+
+That's it. No summary, no analysis, no "here's what I think". Verbatim, framed.

--- a/src/api/mcp_memory_tools.py
+++ b/src/api/mcp_memory_tools.py
@@ -460,3 +460,56 @@ def register_memory_tools(mcp: FastMCP) -> None:
             return {"chunk_id": chunk_id, "recorded": True}
         except Exception as exc:
             return {"error": str(exc)}
+
+    @mcp.tool()
+    def live_logs(
+        service: str,
+        since: str = "5m",
+        grep: str | None = None,
+        limit: int = 200,
+    ) -> dict:
+        """Tail docker-container logs without SSH — Phase B of Issue #213.
+
+        Replaces manual ``ssh u-server docker logs ...`` calls for deploy-
+        debug / smoke-fail / cloud-routing investigations.
+
+        Args:
+            service: api | pi | mcp | webui | nginx
+            since:   1m | 5m | 15m | 30m | 1h | 6h | 24h (whitelist)
+            grep:    case-insensitive substring filter (optional)
+            limit:   max lines returned (1..500)
+
+        Returns:
+            {service, container, since, grep, total, truncated, lines:
+             [{container, raw, level}]}
+
+        Auth: admin scope required. Secret-redaction applied
+        (JWT/Bearer/hex/password/conn-strs maskiert).
+
+        Rate: 5 calls/min/admin.
+        """
+        from fastapi import HTTPException as _HTTPException
+        from src.api.routes.admin_logs import admin_logs as _impl
+        from src.api.jwt_auth import TokenInfo as _TokenInfo
+
+        # The MCP session already validated the JWT — we synthesize a
+        # TokenInfo with admin scope inferred from the same auth context
+        # that registered this tool. Without a per-session token-info
+        # here, fall through to the same _is_admin check by re-reading
+        # the session header.
+        try:
+            from src.api.mcp_auth import _current_token_info
+            info = _current_token_info()
+            if info is None:
+                return {"error": "no token info — MCP session not authenticated"}
+        except Exception:
+            return {"error": "no token info available — call via authenticated MCP session"}
+
+        try:
+            return _impl(
+                service=service, since=since, grep=grep, limit=limit, info=info,
+            )
+        except _HTTPException as e:
+            return {"error": str(e.detail), "status": e.status_code}
+        except Exception as exc:
+            return {"error": str(exc)}

--- a/src/api/routes/admin_logs.py
+++ b/src/api/routes/admin_logs.py
@@ -1,0 +1,201 @@
+"""Admin-only log-tail endpoint — Phase A of Issue #213.
+
+User-Use-Case: claude-code agent (= ich) muss heute mehrfach via
+`ssh nileneb@u-server 'docker logs mayring-mayring-api-1 --since 5m'`
+für deploy-fail-diagnose / smoke-debug / cloud-routing-check. Das
+skaliert nicht und der agent kann's nicht selbst.
+
+Endpoint: GET /admin/logs?service=api|pi|mcp|webui&since=5m&grep=...
+
+Auth: admin scope im JWT (TokenInfo.scopes enthält '*' oder 'admin').
+Rate: 5 calls/min/admin (in-memory token bucket).
+Quelle: `docker logs --since=...` als subprocess (whitelisted service-name).
+Secret-redaction: env-vars + JWT-payload patterns vor return maskiert.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import time
+from collections import deque
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from src.api.auth import get_token_info
+from src.api.jwt_auth import TokenInfo
+
+router = APIRouter()
+
+
+# WHY(#213): nur whitelisted services. Beliebige docker-container-namen
+# wären command-injection oder remote-host-exfil-risiko.
+_ALLOWED_SERVICES = {
+    "api": "mayring-mayring-api-1",
+    "pi": "mayring-mayring-pi-1",
+    "mcp": "mayring-mayring-mcp-1",
+    "webui": "mayring-mayring-webui-1",
+    "nginx": "mayring-mayring-nginx-1",
+}
+
+# Allowed --since-values (per docker-logs syntax). Beliebige strings
+# wären erneut injection-vektor. Auch hier whitelisted statt regex.
+_ALLOWED_SINCE = {"1m", "5m", "15m", "30m", "1h", "6h", "24h"}
+
+_MAX_LINES = 500
+
+
+def _is_admin(info: TokenInfo) -> bool:
+    return "*" in info.scopes or "admin" in info.scopes
+
+
+# Rate-limiter — per-user token bucket in-memory.
+# 5 calls/min/user = window von 12s zwischen calls (smooth) ODER burst.
+# Process-local: ein api-replica pro u-server reicht, kein Redis nötig.
+_RATE_BUCKET: dict[str, deque[float]] = {}
+_RATE_WINDOW = 60.0
+_RATE_LIMIT = 5
+
+
+def _check_rate_limit(user_id: str) -> None:
+    now = time.monotonic()
+    bucket = _RATE_BUCKET.setdefault(user_id, deque(maxlen=_RATE_LIMIT))
+    # Drop expired
+    while bucket and bucket[0] < now - _RATE_WINDOW:
+        bucket.popleft()
+    if len(bucket) >= _RATE_LIMIT:
+        oldest = bucket[0]
+        retry_after = int(_RATE_WINDOW - (now - oldest)) + 1
+        raise HTTPException(
+            status_code=429,
+            detail=f"Rate limit: {_RATE_LIMIT} calls/min. Retry in {retry_after}s.",
+        )
+    bucket.append(now)
+
+
+# Secret-redaction patterns. Conservative — bei doppelt-anwendung lieber
+# falsch maskiert als secret leakage.
+_REDACT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # eyJ... = JWT header (Base64 of {"alg":...}). Maskiere full token.
+    (re.compile(r"eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]+"),
+     "<JWT_REDACTED>"),
+    # Bearer + 20+ char token
+    (re.compile(r"(Bearer|Authorization:\s*Bearer)\s+[A-Za-z0-9_\-]{20,}", re.IGNORECASE),
+     r"\1 <REDACTED>"),
+    # Generic 32+ char hex (potential api-key or service-token)
+    (re.compile(r"\b[A-Fa-f0-9]{32,}\b"), "<HEX_REDACTED>"),
+    # password=... / pwd=... / secret=... / token=... in URL/log-context
+    (re.compile(r"(password|pwd|secret|token|api[_-]?key)=([^\s&'\"]+)", re.IGNORECASE),
+     r"\1=<REDACTED>"),
+    # postgres connection strings with password
+    (re.compile(r"://([^:]+):([^@]+)@"), r"://\1:<REDACTED>@"),
+]
+
+
+def _redact(text: str) -> str:
+    for pat, repl in _REDACT_PATTERNS:
+        text = pat.sub(repl, text)
+    return text
+
+
+def _parse_line(raw: str) -> dict[str, Any]:
+    """Try to extract structured fields from a docker-log line."""
+    # docker logs prefix: timestamp container-name | rest
+    # If line starts with ISO timestamp (--timestamps not used here so
+    # rarely), try to parse. Otherwise return raw text.
+    line = _redact(raw.rstrip("\n"))
+    # Detect level by keyword
+    level = "info"
+    upper = line.upper()
+    if " ERROR" in upper or " CRITICAL" in upper or " FATAL" in upper:
+        level = "error"
+    elif " WARN" in upper:
+        level = "warning"
+    elif " DEBUG" in upper:
+        level = "debug"
+    return {"raw": line, "level": level}
+
+
+@router.get("/admin/logs")
+def admin_logs(
+    service: str = Query(..., description="api | pi | mcp | webui | nginx"),
+    since: str = Query("5m", description="1m, 5m, 15m, 30m, 1h, 6h, 24h"),
+    grep: str | None = Query(None, description="case-insensitive substring filter"),
+    limit: int = Query(200, ge=1, le=_MAX_LINES),
+    info: TokenInfo = Depends(get_token_info),
+) -> dict:
+    """Return docker-container logs for an admin caller.
+
+    WHY(#213): replaces manual `ssh u-server docker logs ...` workflow.
+    Secrets in log lines are redacted (JWT/Bearer/hex/password/conn-strs).
+    """
+    if not _is_admin(info):
+        raise HTTPException(status_code=403, detail="admin scope required")
+
+    if service not in _ALLOWED_SERVICES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"service must be one of: {sorted(_ALLOWED_SERVICES)}",
+        )
+    if since not in _ALLOWED_SINCE:
+        raise HTTPException(
+            status_code=400,
+            detail=f"since must be one of: {sorted(_ALLOWED_SINCE)}",
+        )
+
+    _check_rate_limit(info.sub or "anon")
+
+    container = _ALLOWED_SERVICES[service]
+    try:
+        proc = subprocess.run(
+            ["docker", "logs", "--since", since, "--tail", str(limit * 2), container],
+            capture_output=True, text=True, timeout=8,
+        )
+    except subprocess.TimeoutExpired:
+        raise HTTPException(status_code=504, detail="docker logs timed out")
+    except FileNotFoundError:
+        raise HTTPException(status_code=500, detail="docker CLI not available")
+
+    # docker logs schreibt stdout + stderr getrennt — beide einsammeln
+    raw = (proc.stdout or "") + (proc.stderr or "")
+    if proc.returncode != 0 and not raw:
+        raise HTTPException(
+            status_code=500,
+            detail=f"docker logs failed (exit {proc.returncode})",
+        )
+
+    lines = [l for l in raw.split("\n") if l.strip()]
+
+    if grep:
+        needle = grep.lower()
+        lines = [l for l in lines if needle in l.lower()]
+
+    # tail-style: last N lines
+    truncated = len(lines) > limit
+    lines = lines[-limit:]
+
+    parsed = [{"container": container, **_parse_line(l)} for l in lines]
+
+    return {
+        "service": service,
+        "container": container,
+        "since": since,
+        "grep": grep,
+        "total": len(parsed),
+        "truncated": truncated,
+        "lines": parsed,
+    }
+
+
+@router.get("/admin/logs/services")
+def admin_logs_services(info: TokenInfo = Depends(get_token_info)) -> dict:
+    """List available service names + container mappings."""
+    if not _is_admin(info):
+        raise HTTPException(status_code=403, detail="admin scope required")
+    return {
+        "services": _ALLOWED_SERVICES,
+        "since_options": sorted(_ALLOWED_SINCE),
+        "max_lines": _MAX_LINES,
+        "rate_limit": f"{_RATE_LIMIT}/min",
+    }

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -79,6 +79,8 @@ app.include_router(_reranker_admin.router)
 app.include_router(_pi_stats.router)
 from src.api.routes import reconcile_admin as _reconcile_admin
 app.include_router(_reconcile_admin.router)
+from src.api.routes import admin_logs as _admin_logs
+app.include_router(_admin_logs.router)
 
 
 @app.on_event("startup")

--- a/tests/test_admin_logs.py
+++ b/tests/test_admin_logs.py
@@ -1,0 +1,176 @@
+"""Tests for /admin/logs endpoint (Phase A of Issue #213)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.api.jwt_auth import TokenInfo
+from src.api.routes.admin_logs import (
+    _check_rate_limit,
+    _is_admin,
+    _parse_line,
+    _redact,
+    _RATE_BUCKET,
+    admin_logs,
+    admin_logs_services,
+)
+
+
+def _admin_info(user_id: str = "user_a") -> TokenInfo:
+    return TokenInfo(workspace_id="default", scopes=("admin",), sub=user_id)
+
+
+def _user_info(user_id: str = "user_b") -> TokenInfo:
+    return TokenInfo(workspace_id="default", scopes=("user",), sub=user_id)
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_bucket():
+    _RATE_BUCKET.clear()
+    yield
+    _RATE_BUCKET.clear()
+
+
+def test_is_admin_recognizes_admin_scope():
+    assert _is_admin(_admin_info()) is True
+
+
+def test_is_admin_recognizes_wildcard_scope():
+    info = TokenInfo(workspace_id="default", scopes=("*",), sub="x")
+    assert _is_admin(info) is True
+
+
+def test_is_admin_rejects_user_scope():
+    assert _is_admin(_user_info()) is False
+
+
+def test_redact_jwt_in_log_line():
+    line = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.signature_part_xxx"
+    out = _redact(line)
+    assert "eyJ" not in out or "REDACTED" in out
+
+
+def test_redact_postgres_password_in_conn_string():
+    line = "postgres://user:supersecret@db:5432/linn"
+    out = _redact(line)
+    assert "supersecret" not in out
+    assert "REDACTED" in out
+
+
+def test_redact_password_param():
+    line = "request: password=mySecret123 next-param"
+    out = _redact(line)
+    assert "mySecret123" not in out
+    assert "REDACTED" in out
+
+
+def test_redact_hex_token():
+    line = "token: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4 in line"
+    out = _redact(line)
+    assert "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4" not in out
+
+
+def test_parse_line_detects_error_level():
+    out = _parse_line("[2026-05-11] ERROR something broke")
+    assert out["level"] == "error"
+
+
+def test_parse_line_detects_warning_level():
+    # _parse_line looks for ' WARN' (space-prefixed). Match real log format.
+    out = _parse_line("[timestamp] WARN: slow query")
+    assert out["level"] == "warning"
+
+
+def test_parse_line_defaults_to_info():
+    out = _parse_line("just a regular log line")
+    assert out["level"] == "info"
+
+
+def test_rate_limit_allows_5_calls_then_blocks():
+    user = "user_rate_test"
+    for _ in range(5):
+        _check_rate_limit(user)  # no raise
+    with pytest.raises(HTTPException) as exc_info:
+        _check_rate_limit(user)
+    assert exc_info.value.status_code == 429
+
+
+def test_rate_limit_isolated_per_user():
+    _check_rate_limit("user_x")
+    _check_rate_limit("user_x")
+    _check_rate_limit("user_x")
+    _check_rate_limit("user_x")
+    _check_rate_limit("user_x")
+    # user_y should have its own bucket
+    _check_rate_limit("user_y")  # no raise
+
+
+def test_endpoint_rejects_non_admin():
+    with pytest.raises(HTTPException) as exc_info:
+        admin_logs(service="api", since="5m", grep=None, limit=200, info=_user_info())
+    assert exc_info.value.status_code == 403
+
+
+def test_endpoint_rejects_unknown_service():
+    with pytest.raises(HTTPException) as exc_info:
+        admin_logs(service="evil-container", since="5m", grep=None, limit=200, info=_admin_info())
+    assert exc_info.value.status_code == 400
+
+
+def test_endpoint_rejects_unknown_since():
+    with pytest.raises(HTTPException) as exc_info:
+        admin_logs(service="api", since="1ns", grep=None, limit=200, info=_admin_info())
+    assert exc_info.value.status_code == 400
+
+
+def test_endpoint_returns_lines_on_success():
+    with patch("src.api.routes.admin_logs.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="INFO request handled\n[ts] ERROR boom\n",
+            stderr="",
+        )
+        result = admin_logs(service="api", since="5m", grep=None, limit=200, info=_admin_info("user_success"))
+    assert result["service"] == "api"
+    assert result["total"] == 2
+    assert result["lines"][1]["level"] == "error"
+
+
+def test_endpoint_applies_grep_filter():
+    with patch("src.api.routes.admin_logs.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="line1 hello\nline2 world\nline3 hello again\n",
+            stderr="",
+        )
+        result = admin_logs(service="api", since="5m", grep="hello", limit=200, info=_admin_info("user_grep"))
+    assert result["total"] == 2
+    assert all("hello" in l["raw"].lower() for l in result["lines"])
+
+
+def test_endpoint_redacts_secrets():
+    with patch("src.api.routes.admin_logs.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="auth header: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.signature\n",
+            stderr="",
+        )
+        result = admin_logs(service="api", since="5m", grep=None, limit=200, info=_admin_info("user_redact"))
+    line = result["lines"][0]["raw"]
+    assert "signature" not in line or "REDACTED" in line
+
+
+def test_services_endpoint_lists_whitelist():
+    out = admin_logs_services(info=_admin_info())
+    assert "api" in out["services"]
+    assert "pi" in out["services"]
+    assert "5/min" in out["rate_limit"]
+
+
+def test_services_endpoint_rejects_non_admin():
+    with pytest.raises(HTTPException) as exc_info:
+        admin_logs_services(info=_user_info())
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary
Two closely-related deliverables in one PR:

### #213 Phase A+B: admin logs without SSH
- \`GET /admin/logs?service=...&since=...&grep=...\` — admin-only, rate-limited (5/min), secret-redacted (JWT/Bearer/hex/password/conn-strs)
- \`mcp__plugin_mayring-coder_memory-agents__live_logs\` — exposes the endpoint to claude-code via plugin's MCP server

Phase C (Laravel proxy) + Phase D (UI tab) stay as follow-up in app.linn.games — separate session, different repo.

### #211: Pi-Task as first-class subagent
\`claude-plugin/agents/pi-task.md\` — first subagent definition in the plugin. Was missing — pi-agent existed as MCP-tools but Claude-Code's \`Agent\` tool didn't know about it as a \`subagent_type\`. Now \`Agent(subagent_type="pi-task", prompt="...")\` works the same as general-purpose, but routes to local Ollama instead of Claude.

Today's diagnostic: pi-jobs queue had **0 jobs in 6h** despite active session. Infrastructure was healthy, just nothing dispatched. The subagent definition makes routing operational.

## Test plan
- [x] 20 admin_logs unit tests
- [x] 34 adjacent regression tests
- [ ] After merge: call \`Agent(subagent_type="pi-task", prompt="...")\` and observe ollama_client cloud-primary log line
- [ ] After merge: \`mcp__plugin_mayring-coder_memory-agents__live_logs(service="api", since="5m")\` returns redacted log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)