### PR TITLE
fix(smoke): bust /stats/summary cache on feedback + coverage-map #209/#211/#213

### DIFF
--- a/docs/smoke_coverage_map.md
+++ b/docs/smoke_coverage_map.md
@@ -143,4 +143,12 @@ Live verifiziert via `pytest tests/test_*` 158/158 passed @ 2026-05-08.
 |---|---|---|
 | 182 | IGIO-Backfill hält SQLite-Lock zu lang | Pytest `tests/test_igio_backfill.py` chunked-commit + smoke `db_wal_journal_active` (Lock-acquire-Probe unter 1s) |
 | 183 | Pi-Agent: Job-Verteilung & In-Process-Queue stabilisieren | API: `pi_tasks_schema` + `/pi-jobs/stats` (job_class p50/p95) + Pytest `tests/test_pi_queue.py` (3-lane priority routing, with_lanes(), classify_pi_job) |
-| 192 | Ollama-API-Skalierung: parallel-jobs + Pi-Worker-Pool | host: OLLAMA_NUM_PARALLEL=4 + MAX_LOADED_MODELS=3 (systemd override) · code: PiQueue 3-lane (commit d0b2e5f) · resilience: cloud-fallback (commit da3ba6c) — falls lokal überlastet, OLLAMA_CLOUD_API_KEY triggert ollama.com bei letztem Retry |
+| 192 | Ollama-API-Skalierung: parallel-jobs + Pi-Worker-Pool | host: OLLAMA_NUM_PARALLEL=4 + MAX_LOADED_MODELS=3 (systemd override) · code: PiQueue 3-lane defaults 4/4/2 (PR #219) · resilience: cloud-fallback OLLAMA_CLOUD_API_KEY |
+
+## Recently Closed (today, 2026-05-11)
+
+| # | Description | Coverage |
+|---|---|---|
+| 209 | Reranker-Training: rating-basiert statt binary | `tools/export_retrieval_dataset.py::_label_map` rating 1..5 → (label, sample_weight); `tools/train_reranker.py` `clf.fit(sample_weight=…)`; Pytest `tests/test_export_retrieval_dataset.py` (6 rating-weighted tests) — PR #216 |
+| 211 | Pi-Agent als first-class tool-replacement | `claude-plugin/agents/` (subagent-def, später dropped) + 3 spezialisierte MCP-tools `pi_categorize`/`pi_judge_relevance`/`pi_summarize_for_memory` (`src/api/mcp_agent_tools.py`) + CLAUDE.md decision-table; Pytest `tests/test_pi_specialized_tools.py` (11 tests) — PR #218/#223 |
+| 213 | Log-Endpoints ohne SSH (Phase A+B) | API: `GET /admin/logs?service=...&since=...&grep=...` (admin-scope, rate-limit 5/min, secret-redaction) + MCP-tool `live_logs`; Pytest `tests/test_admin_logs.py` (20 tests) — PR #218. Phase C+D (Laravel-proxy + UI) → app.linn.games separat |

--- a/src/api/mcp_memory_tools.py
+++ b/src/api/mcp_memory_tools.py
@@ -457,6 +457,13 @@ def register_memory_tools(mcp: FastMCP) -> None:
                 )
             add_feedback(conn, chunk_id, signal, enriched)
             invalidate_query_cache()
+            # WHY(2026-05-11): /stats/summary cached die feedback-count 30s
+            # → smoke `feedback_count_delta` würde 0 sehen. Cache busten.
+            try:
+                from src.api.server import bust_stats_cache
+                bust_stats_cache()
+            except Exception:
+                pass
             return {"chunk_id": chunk_id, "recorded": True}
         except Exception as exc:
             return {"error": str(exc)}

--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -614,6 +614,7 @@ async def memory_feedback(
         # positive-signal für die Memory-Effizienz-quote).
         if int(request.signal) >= 4:
             _mark_referenced([ch.chunk_id for ch in chunks])
+        _bust_stats()
         return {
             "workspace_id": workspace_id,
             "source_id": cid,
@@ -624,7 +625,17 @@ async def memory_feedback(
     add_feedback(_get_conn(), cid, request.signal, request.metadata or {})
     if int(request.signal) >= 4:
         _mark_referenced([cid])
+    _bust_stats()
     return {"workspace_id": workspace_id, "chunk_id": cid, "recorded": True}
+
+
+def _bust_stats() -> None:
+    """Lazy-import bust_stats_cache to avoid an import cycle (server↔routes)."""
+    try:
+        from src.api.server import bust_stats_cache
+        bust_stats_cache()
+    except Exception:
+        pass  # cache-invalidation is best-effort; a stale stats page isn't fatal
 
 
 @router.post("/search")

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -211,6 +211,20 @@ _STATS_CACHE: dict[str, Any] = {"fresh": None, "stale": None, "expires_at": 0.0}
 _STATS_CACHE_TTL = 30.0
 
 
+def bust_stats_cache() -> None:
+    """Invalidate the /stats/summary fresh-slot so the next call recomputes.
+
+    WHY(2026-05-11, smoke-fix): the 30s TTL-cache broke the post-deploy
+    smoke (`feedback_count_delta`, `stop_hook_e2e`) — those checks post
+    feedback then immediately re-read /stats/summary expecting the count
+    to have grown, but the cache served the stale count. Callers that
+    mutate counts (feedback insert, ingest) must call this. The 'stale'
+    slot is kept (it's only the disaster-fallback if a live query crashes).
+    """
+    _STATS_CACHE["fresh"] = None
+    _STATS_CACHE["expires_at"] = 0.0
+
+
 def _stats_summary_uncached() -> dict:
     """The actual sqlite-heavy work. Wrapped by stats_summary() with cache."""
     from src.api.job_queue import _JOBS

--- a/tests/test_stats_summary_cache.py
+++ b/tests/test_stats_summary_cache.py
@@ -128,3 +128,15 @@ def test_recovery_after_crash_updates_cache():
         result = stats_summary(workspace_id="default")
     assert result["_cache_status"] == "fresh"
     assert result["chunks"]["active"] == 999  # cache updated to new numbers
+
+
+def test_bust_stats_cache_clears_fresh_keeps_stale():
+    from src.api.server import bust_stats_cache, _STATS_CACHE
+    _STATS_CACHE["fresh"] = {"x": 1}
+    _STATS_CACHE["stale"] = {"x": 1}
+    _STATS_CACHE["expires_at"] = 9e9  # far future
+    bust_stats_cache()
+    assert _STATS_CACHE["fresh"] is None
+    assert _STATS_CACHE["expires_at"] == 0.0
+    # stale slot preserved (disaster-fallback)
+    assert _STATS_CACHE["stale"] == {"x": 1}


### PR DESCRIPTION
## Why
Post-deploy-smoke (production) failed 5× in a row — three root-causes, all from today's PRs:

1. **`coverage_map_complete`**: `missing_from_map=['209']` — #209 (PR #216) was closed but not added to `docs/smoke_coverage_map.md`. Fix: added #209 + #211 + #213.
2. **`feedback_count_delta`**: `pre.total=208 post.total=208 delta=0` — my stats-TTL-cache (PR #221) served the feedback-count stale for 30s. Fix: `bust_stats_cache()` on every feedback-write (lazy-import vs cycle; 'stale' slot kept).
3. **`stop_hook_e2e`**: same cache cause — fixed by the same change.

## Test plan
- [x] +1 test (bust clears fresh, keeps stale)
- [x] 230 adjacent tests pass
- [ ] After deploy: post-deploy-smoke should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)