### PR TITLE
fix(perf): task-derive out of /memory/search hot path (no inline mistral)

### DIFF
--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -125,21 +125,28 @@ async def memory_search(
                 c.lower().strip() for c in request.category_hint if c and c.strip()
             ]
 
-        # WHY(2026-05-11, task-categorization): Mayring-konformer
-        # task-derive aus dem query. Cascade: erst embedding-similarity
-        # zu existierenden tasks, sonst mistral-call. Resultat wird zum
-        # boost im _rerank für chunks die bei semantisch ähnlichen tasks
-        # schon positiv bewertet wurden. Ist die saubere Ablösung der
-        # alten tech-label-cluster ([neu]configuration etc).
+        # WHY(2026-05-11, task-categorization + perf-fix): nur der schnelle
+        # embedding-sim-check inline (~50-150ms) — KEIN mistral im hot path
+        # (das machte /memory/search 5-30s langsamer, hat die hook-9s-
+        # timeouts ausgelöst). Wenn eine existierende task matched → boost.
+        # Wenn nicht → background-thread erstellt die neue task (mistral),
+        # ohne die such-response zu verzögern.
         try:
-            from src.memory.task_derivation import derive_task
-            task = derive_task(
+            from src.memory.task_derivation import (
+                derive_task_fast, derive_task_background,
+            )
+            from src.memory.store import MEMORY_DB_PATH
+            task = derive_task_fast(
                 request.query, _get_conn(), _OLLAMA_URL, workspace_id,
             )
             if task:
                 opts["task_id"] = task["task_id"]
+            else:
+                # No existing task matched — create one async (fire-and-forget).
+                derive_task_background(
+                    request.query, MEMORY_DB_PATH, _OLLAMA_URL, workspace_id,
+                )
         except Exception as exc:
-            # task-derive ist optional — fail soft (Logger im modul warnt).
             import logging
             logging.getLogger(__name__).warning("task-derive skipped: %s", exc)
 

--- a/src/memory/task_derivation.py
+++ b/src/memory/task_derivation.py
@@ -157,6 +157,88 @@ def _now_iso() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
 
+def derive_task_fast(
+    prompt: str,
+    conn: DBAdapter,
+    ollama_url: str,
+    workspace_id: str = "default",
+    *,
+    sim_threshold: float = _TASK_SIM_THRESHOLD,
+) -> Optional[dict]:
+    """Hot-path-safe task lookup: embed + similarity-check only, NO mistral.
+
+    WHY(2026-05-11): derive_task() macht im cascade-fall-through einen
+    mistral-call (bis 30s timeout) — das in /memory/search inline zu
+    haben hat jeden such-call 5-30s langsamer gemacht (+ die hook-9s-
+    budget-timeouts ausgelöst). Diese fast-variante macht NUR den
+    embedding-sim-check (~50-150ms): wenn eine existierende task matched,
+    return sie (+ occurrence_count++); sonst None — KEINE neue task-row.
+    Neue tasks werden async via derive_task_background() erstellt.
+
+    Returns {"task_id", "title", "reused": True} bei match, sonst None.
+    """
+    prompt = (prompt or "").strip()
+    if len(prompt) < 5:
+        return None
+
+    prompt_emb = _embed_text(prompt, ollama_url)
+    if prompt_emb is None:
+        return None
+
+    existing = _load_task_embeddings(conn, workspace_id)
+    best_task_id: Optional[str] = None
+    best_title: Optional[str] = None
+    best_sim = 0.0
+    for task_id, title, vec in existing:
+        sim = _cosine(prompt_emb, vec)
+        if sim > best_sim:
+            best_sim = sim
+            best_task_id = task_id
+            best_title = title
+
+    if best_task_id is not None and best_sim >= sim_threshold:
+        conn.execute(
+            """UPDATE task_categories
+               SET occurrence_count = occurrence_count + 1,
+                   last_used_at = ?
+               WHERE task_id = ?""",
+            (_now_iso(), best_task_id),
+        )
+        return {"task_id": best_task_id, "title": best_title, "reused": True}
+    return None
+
+
+def derive_task_background(
+    prompt: str,
+    db_path,
+    ollama_url: str,
+    workspace_id: str = "default",
+) -> None:
+    """Fire-and-forget: create a new task_category for a prompt in a daemon thread.
+
+    WHY(2026-05-11): /memory/search calls derive_task_fast (cheap) for the
+    boost. If no existing task matched, this kicks off the mistral-creation
+    in the background so the search response isn't delayed — the NEXT query
+    on the same topic will find the new task. Opens its own DB connection
+    (caller's conn may be on another thread).
+    """
+    import threading
+
+    def _work() -> None:
+        try:
+            from src.memory.store import init_memory_db
+            conn = init_memory_db(db_path)
+            try:
+                derive_task(prompt, conn, ollama_url, workspace_id)
+            finally:
+                conn.close()
+        except Exception as e:
+            _log.warning("derive_task_background failed: %s", e)
+
+    t = threading.Thread(target=_work, daemon=True)
+    t.start()
+
+
 def derive_task(
     prompt: str,
     conn: DBAdapter,
@@ -166,7 +248,12 @@ def derive_task(
     model: Optional[str] = None,
     sim_threshold: float = _TASK_SIM_THRESHOLD,
 ) -> Optional[dict]:
-    """Derive (or reuse) a task_category for a user prompt.
+    """Derive (or reuse) a task_category for a user prompt — FULL cascade.
+
+    NOT for the hot path (it may make a 30s mistral call) — use
+    derive_task_fast() for /memory/search, derive_task_background() to
+    create new tasks async, and this directly only from explicit/batch
+    callers (pi_task, a periodic job).
 
     Cascade:
       1. Embed prompt

--- a/tests/test_task_derivation.py
+++ b/tests/test_task_derivation.py
@@ -242,3 +242,51 @@ def test_add_feedback_no_link_without_task_id_metadata(conn):
     # No task_chunk_links should have been created
     rows = conn.execute("SELECT 1 FROM task_chunk_links").fetchall()
     assert rows == []
+
+
+# ── derive_task_fast (hot-path, no mistral) ──────────────────────
+
+def test_derive_task_fast_returns_existing_match(conn):
+    """derive_task_fast: existing task with high sim → return it, no mistral."""
+    emb = [0.42] * 768
+    conn.execute(
+        """INSERT INTO task_categories (task_id, title, embedding_id, first_seen_at, last_used_at, workspace_id)
+           VALUES ('task_known', 'Known Task', ?, ?, ?, 'default')""",
+        (json.dumps(emb), "2026-05-11T00:00:00Z", "2026-05-11T00:00:00Z"),
+    )
+    from src.memory.task_derivation import derive_task_fast
+    with patch("src.memory.task_derivation._embed_text", return_value=emb):
+        # _call_mistral must NEVER be called in the fast path
+        with patch("src.memory.task_derivation._call_mistral_for_task") as mock_mistral:
+            result = derive_task_fast("any prompt", conn, "http://ollama:11434", "default")
+    assert result is not None
+    assert result["task_id"] == "task_known"
+    assert result["reused"] is True
+    mock_mistral.assert_not_called()
+
+
+def test_derive_task_fast_returns_none_when_no_match(conn):
+    """derive_task_fast: no existing task → None (does NOT create one)."""
+    from src.memory.task_derivation import derive_task_fast
+    with patch("src.memory.task_derivation._embed_text", return_value=[0.9] * 768):
+        with patch("src.memory.task_derivation._call_mistral_for_task") as mock_mistral:
+            result = derive_task_fast("brand new topic", conn, "http://ollama:11434", "default")
+    assert result is None
+    mock_mistral.assert_not_called()
+    # No new row created
+    count = conn.execute("SELECT COUNT(*) FROM task_categories").fetchone()[0]
+    assert count == 0
+
+
+def test_derive_task_fast_increments_occurrence_on_match(conn):
+    emb = [0.33] * 768
+    conn.execute(
+        """INSERT INTO task_categories (task_id, title, embedding_id, occurrence_count, first_seen_at, last_used_at, workspace_id)
+           VALUES ('task_c', 'T', ?, 5, ?, ?, 'default')""",
+        (json.dumps(emb), "2026-05-11T00:00:00Z", "2026-05-11T00:00:00Z"),
+    )
+    from src.memory.task_derivation import derive_task_fast
+    with patch("src.memory.task_derivation._embed_text", return_value=emb):
+        derive_task_fast("prompt text", conn, "http://ollama:11434", "default")
+    n = conn.execute("SELECT occurrence_count FROM task_categories WHERE task_id='task_c'").fetchone()[0]
+    assert n == 6


### PR DESCRIPTION
## Why
PR #223 put `derive_task()` inline in `/memory/search` — it makes a mistral call (up to 30s timeout) when no existing task matches. Result: every search got 5-30s slower. Symptoms: smoke `rag_function_search_finds_source` timeout, `'TIMEOUT after 9.0s — server is slow'` in the memory-inject hook.

## Fix — split into 3 functions
- **`derive_task_fast()`** — embedding-sim-check only (~50-150ms), no mistral, no row-creation. Match → return + occurrence++; else None. This is what `/memory/search` uses now.
- **`derive_task_background()`** — fire-and-forget daemon thread that creates the new task via mistral. Doesn't delay the search response; the next query on the same topic finds it.
- **`derive_task()`** — unchanged FULL cascade, for explicit/batch callers only.

## Test plan
- [x] +3 tests (fast match/no-match/increment)
- [x] adjacent memory/task/retrieval tests pass
- [ ] After deploy: `/memory/search` latency back to normal, smoke `rag_function_search_finds_source` green, hook 9s-timeouts gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)