### PR TITLE
feat(nginx): rate-limit REST endpoints against hook-storms (#192)

### DIFF
--- a/docker/nginx/mcp.conf
+++ b/docker/nginx/mcp.conf
@@ -1,6 +1,15 @@
 # ── MayringCoder MCP HTTP Transport ──────────────────────────────────────────
 # Synology NAS strips Authorization header — re-inject from ?token= query param.
 # JWT payload: {"workspace_id": "uuid"} — decoded by FastMCP _JWTAuthMiddleware.
+
+# WHY(#192, hook-storm-protection): jede subagent-session feuert
+# /memory/search aus dem UserPromptSubmit-hook — bei mehreren parallelen
+# sessions konnte das den mayring-api-container überfluten (SQLite
+# write-locks, 9s-hook-budget-timeouts). 20 req/s pro client-IP mit
+# burst 50 ist großzügig (ein populate-batch macht ~1.5 req/s) aber
+# blockt echte storm-szenarien. zone-mem 10m ≈ ~160k client-IPs.
+limit_req_zone $binary_remote_addr zone=mayring_rest:10m rate=20r/s;
+
 server {
     listen 80;
     server_name mcp.linn.games;
@@ -62,6 +71,11 @@ server {
     # `stats` was missing — Laravel MayringMcpClient.getStats() calls
     # /stats/summary and was hitting the MCP upstream returning 404.
     location ~* ^/(conversation|memory|ingest|analyze|search|overview|turbulence|benchmark|jobs|populate|papers|issues|wiki|ambient|predictive|reports|health|stats|pi-task|pi_task|duel|feedback)(/|_|$) {
+        # WHY(#192): rate-limit gegen hook-storms (s. limit_req_zone oben).
+        # burst 50 + nodelay = bis 50 requests sofort durch, dann throttle
+        # auf 20r/s; >50 in burst → 503. health-checks (30s) + populate
+        # (~1.5r/s) liegen weit darunter.
+        limit_req zone=mayring_rest burst=50 nodelay;
         set $mayring_api_upstream http://mayring-api:8090;
         proxy_pass $mayring_api_upstream;
         proxy_http_version 1.1;


### PR DESCRIPTION
## Why
#192 Option D — nginx limit_req_zone for the REST endpoints. Each subagent session fires /memory/search from the UserPromptSubmit hook; multiple parallel sessions could flood mayring-api (SQLite write-locks, 9s hook-budget timeouts).

## What
- `limit_req_zone zone=mayring_rest`, 20r/s per client-IP, 10m mem (~160k IPs)
- `limit_req burst=50 nodelay` on the broad REST location (/conversation|memory|ingest|...|stats|pi-task|feedback)
- 20r/s is generous: a populate-batch is ~1.5r/s, health-checks 30s interval. >50 burst → 503.
- `nginx -t`: ok

## Not in this PR (#192 Option B deprioritized)
ProcessPoolExecutor — pi-tasks are I/O-bound (HTTP to Ollama, GIL released during I/O), so the GIL isn't the bottleneck. The real bottleneck is `OLLAMA_NUM_PARALLEL` (server config). ProcessPool would be premature optimization with uncertain payoff. Commented on #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)