### PR TITLE
fix(codeql): stack-trace-exposure in /stats/summary error paths

### DIFF
--- a/src/api/server.py
+++ b/src/api/server.py
@@ -338,14 +338,23 @@ def stats_summary(workspace_id: str = Depends(get_workspace)) -> dict:
             _logging.getLogger(__name__).warning(
                 "stats/summary: serving stale cache after live-query fail: %s", exc,
             )
+            # WHY(2026-05-11, codeql py/stack-trace-exposure): no raw exc
+            # text in the body — only the exception *class* (safe, helps the
+            # dashboard show "why stale" without leaking internals). Full
+            # detail is in the warning log above.
             return {
                 **_STATS_CACHE["stale"],
                 "_cache_status": "stale",
-                "_stale_reason": str(exc)[:200],
+                "_stale_reason": type(exc).__name__,
             }
         # No cache at all — first call ever AND DB broken.
+        # WHY(2026-05-11, codeql py/stack-trace-exposure): don't leak the
+        # exception text in the HTTP body — log it server-side, return a
+        # generic message. The detailed error is in the warning log above.
+        import logging as _logging
+        _logging.getLogger(__name__).error("stats/summary unavailable (no cache, DB error): %s", exc)
         from fastapi import HTTPException
-        raise HTTPException(status_code=503, detail=f"stats/summary unavailable: {exc}")
+        raise HTTPException(status_code=503, detail="stats/summary temporarily unavailable")
 
 
 def main() -> None:

--- a/tests/test_stats_summary_cache.py
+++ b/tests/test_stats_summary_cache.py
@@ -76,7 +76,7 @@ def test_db_crash_returns_stale_cache():
     with patch("src.api.server._stats_summary_uncached", side_effect=RuntimeError("DB timeout")):
         result = stats_summary(workspace_id="default")
     assert result["_cache_status"] == "stale"
-    assert "DB timeout" in result["_stale_reason"]
+    assert result["_stale_reason"] == "RuntimeError"
     assert result["chunks"]["active"] == 100  # cached data preserved
 
 
@@ -87,7 +87,7 @@ def test_db_crash_without_cache_returns_503():
         with pytest.raises(HTTPException) as exc_info:
             stats_summary(workspace_id="default")
     assert exc_info.value.status_code == 503
-    assert "DB locked" in exc_info.value.detail
+    assert exc_info.value.detail == "stats/summary temporarily unavailable"
 
 
 def test_consecutive_crashes_keep_serving_stale_forever():


### PR DESCRIPTION
## CodeQL alert
`py/stack-trace-exposure` (open, medium) at `src/api/server.py:341` — the 503 error path leaked the raw exception text into the HTTP body. Same pattern in the stale-fallback (`_stale_reason: str(exc)[:200]`).

## Fix
- 503 path: log full exc server-side, return generic `"stats/summary temporarily unavailable"`
- stale-fallback: `_stale_reason` = `type(exc).__name__` only

## Test plan
- [x] 2 assertions updated, 8 stats-cache tests pass
- [ ] After merge: CodeQL re-scan → alert resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)