### PR TITLE
fix(smoke): cleanup conversation source from micro_batch check

### DIFF
--- a/tools/smoke_test_production.py
+++ b/tools/smoke_test_production.py
@@ -411,10 +411,23 @@ def check_micro_batch_indexes(api: str, token: str) -> CheckResult:
     )
     indexed = bool((body or {}).get("indexed"))
     sid = (body or {}).get("source_id", "")
+
+    # WHY(2026-05-11): cleanup — vorher hat jeder smoke-run eine
+    # conversation:system:smoke-{ts}-source hinterlassen → workspace=system
+    # füllte sich mit test-müll (211 chunks in 6h). Nach der index-prüfung
+    # invalidieren wir die source wieder. Best-effort: ein fehlgeschlagener
+    # cleanup macht den check nicht rot (der eigentliche test ist indexed=True).
+    if sid:
+        try:
+            _http("POST", f"{api}/memory/invalidate", token,
+                  body={"source_id": sid}, timeout=10.0)
+        except Exception:
+            pass
+
     return CheckResult(
         "micro_batch_indexes",
         code == 200 and indexed,
-        f"http={code} time={dt:.2f}s indexed={indexed} source_id={sid}",
+        f"http={code} time={dt:.2f}s indexed={indexed} source_id={sid} (cleaned up)",
     )
 
 


### PR DESCRIPTION
User-Report: job-history showed constant `conversation:system:smoke-*` ingest-events — each smoke run (every ~5min + every deploy) left a source in workspace=system (211 chunks in 6h of test garbage).

Fix: `check_micro_batch_indexes` invalidates the source after the index check (POST /memory/invalidate). Best-effort — a failed cleanup doesn't fail the check (indexed=True remains the pass criterion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)