### PR TITLE
fix(hook): ci_security_warner widen run-window 10→30

### DIFF
--- a/claude-plugin/hooks/ci_security_warner.py
+++ b/claude-plugin/hooks/ci_security_warner.py
@@ -74,10 +74,15 @@ def _save_state(state: dict) -> None:
 
 
 def _check_ci(repo: str, state: dict) -> list[str]:
-    """Return warning lines if CI has new failures since last check."""
+    """Return warning lines if CI has new failures since last check.
+
+    WHY(2026-05-11): limit 10→30. Bei aktiven repos (deploy + smoke +
+    build + linter + ingest pro merge) fielen failed runs aus dem
+    limit-10-window bevor der hook sie sah → unbemerkte fails.
+    """
     runs = _gh([
         "run", "list", "--repo", repo,
-        "--limit", "10",
+        "--limit", "30",
         "--json", "databaseId,name,conclusion,status,event",
     ])
     if not runs:


### PR DESCRIPTION
User-report (3×): hook meldet trotz /reload-plugins nichts. Root causes: (1) plugin-cache war stale (ci_security_warner.py fehlte — vorher gefixt), (2) limit-10-window zu klein → ein failed run fiel aus den letzten 10 raus bevor der hook lief. Fix: limit 10→30.

Der hook ist KORREKT silent wenn aktuell nichts kaputt ist (per spec). Manuell verifiziert: exit 0, gh CLI da, state-file wird geschrieben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)