### PR TITLE
feat(mayring): KISS task-anchored prompts + pi_mark_categories textmarker

### DIFF
--- a/claude-plugin/CLAUDE.md
+++ b/claude-plugin/CLAUDE.md
@@ -85,7 +85,8 @@ mcp__plugin_mayring-coder_memory-agents__pi_task(
 | Konkrete Implementierung mit Memory-Kontext | `pi_task` (free-form) | lokales Ollama, ~$0, three.linn.games GPU |
 | Find / locate / patch this bug | `pi_task` | scoped retrieval via repo_slug |
 | Test-Loop iterieren | `pi_task` | |
-| **Chunk(s) Mayring-kategorisieren** | `pi_categorize` | enges schema: text in, `{labels:[{label,confidence}]}` out. Codebook-constrained |
+| **Chunk(s) Mayring-kategorisieren (labels)** | `pi_categorize(text, task, codebook?, mode)` | gibt `{labels:[str]}` für den ganzen chunk. `task` = das Thema worauf untersucht wird (Mayring Selektionskriterium); `mode` = inductive/deductive/hybrid. Nutzt die kanonischen `prompts/mayring_{mode}.md` |
+| **Mayring-kategorisieren MIT Textbeleg pro Kategorie** | `pi_mark_categories(text, task, codebook?)` | "Textmarker" — markiert konkrete Abschnitte + ordnet jedem eine Kategorie zu MIT paraphrase-begründung. `{markings:[{span:[start,end], excerpt, category, reasoning}]}`. Nutze das wenn die Kategorie nachvollziehbar am Text hängen soll (statt nur "chunk hat label x") |
 | **Chunk-Relevanz zu einer Query bewerten** | `pi_judge_relevance` | ersetzt LLM-judge im stop_hook/rerank — 0..1 score pro chunk |
 | **Text für Memory-Ingest reduzieren** | `pi_summarize_for_memory` | 3-step Mayring (paraphrase→generalize→reduce) + suggested_source_id |
 | Architektur-Trajektorie einer Datei | `diff_history` | git log --follow -p → trajectory/obsolete/active |

--- a/prompts/mayring_deduktiv.md
+++ b/prompts/mayring_deduktiv.md
@@ -1,11 +1,14 @@
-You are a qualitative content analyst applying Mayring's deductive content analysis method.
+Du bist ein qualitativer Inhaltsanalytiker (Mayring, deduktive Inhaltsanalyse).
 
-Use ONLY the following predefined categories: {{categories}}
+Aus `{{task}}` bekommst du das Thema oder die Themen, auf die du den Text untersuchen sollst.
 
-Instructions:
-- Assign 1 to 3 categories from the list above to the text chunk below.
-- Choose only categories that clearly apply.
-- Respond with ONLY a comma-separated list of category names from the provided list.
-- Do NOT invent new categories. Do NOT explain your choice.
+Vorgegebenes Kategoriensystem: {{categories}}
 
-Example response: api, error_handling
+So ordnest du zu:
+1. Markiere einen Textabschnitt (von wo bis wo).
+2. Paraphrasieren — was sagt dieser Abschnitt im Kern, bezogen auf das Thema?
+3. Welche Kategorie(n) aus der Liste oben trifft INHALTLICH zu? Nur Stichwort-Match reicht nicht.
+
+Ein Textabschnitt kann mehrere Kategorien haben — aber WICHTIG: jede muss sich LOGISCH anhand des markierten Abschnitts nachvollziehen lassen. KEINE neuen Kategorien erfinden. Wenn keine passt oder der Text nichts zum Thema beiträgt: leere Antwort.
+
+Gib NUR Kategorienamen aus der Liste zurück, eine Zeile, komma-getrennt, nichts davor/danach.

--- a/prompts/mayring_hybrid.md
+++ b/prompts/mayring_hybrid.md
@@ -1,37 +1,19 @@
-Du analysierst Text- oder Code-Ausschnitte nach Mayrings Reduktions-Modell. Ziel ist nicht, den Inhalt zu erklären, sondern seine Funktion zu klassifizieren.
+Du bist ein qualitativer Inhaltsanalytiker (Mayring, hybride Kategorienbildung — Anker-Kategorien anlegen + wo nötig neue induktiv bilden).
 
-Anker-Kategorien (nutze wenn sie passen): {{categories}}
+Aus `{{task}}` bekommst du das Thema oder die Themen, auf die du den Text untersuchen sollst. (Steht da "(kein Task angegeben)" — leite das Thema aus dem Text selbst ab.)
 
-Arbeite in drei Schritten — aber gib nur den letzten als Antwort:
+Anker-Kategorien: {{categories}}
 
-1. Paraphrasieren: Übersetze Code in Sprache bzw. fasse den Textkern knapp in Worten — was tut dieser Block?
-2. Generalisieren: Welche Funktion/Rolle erfüllt er im System? Hebe weg von der konkreten Implementierung.
-3. Reduzieren: Verdichte die Funktion auf 2 bis 5 Schlagworte. Passt eine Ankerkategorie, nimm sie **ohne Prefix**. Neue Themen markierst du mit Prefix [neu].
+So findest du eine Kategorie:
+1. Markiere einen Textabschnitt (von wo bis wo).
+2. Paraphrasieren — was sagt dieser Abschnitt im Kern, bezogen auf das Thema?
+3. Generalisieren — heb das auf das Abstraktionsniveau, das das Thema verlangt.
+4. Reduzieren → zuordnen oder neu bilden:
+   - Passt eine Anker-Kategorie INHALTLICH → nimm sie OHNE Prefix. (`[neu]<x>` ist FALSCH wenn `<x>` schon im Anker steht.)
+   - Passt keine, aber ein neues Thema ist eindeutig → bilde es als `[neu]<label>` (sparsam, kein generischer Catch-All).
 
-REGELN:
-- Wenn eine Ankerkategorie inhaltlich passt: nimm sie **immer ohne [neu]-Prefix**. `[neu]api` ist FALSCH wenn `api` im Anker steht — schreib einfach `api`.
-- Wenn der Dateipfad `/tests/`, `test_`, `_test.`, `*.test.*` oder `conftest` enthält: `tests` MUSS unter den Labels sein (unabhängig davon, was der Code inhaltlich tut — Test-Code bleibt Test-Code).
-- `temp_dummy` NUR wenn der Code-Inhalt klar provisorisch/dummy/placeholder ist (TODO/FIXME-Stubs, Backup-Kopien, noch-nicht-implementiert). Nicht wegen Dateinamen, nicht für fertige Utility-Funktionen.
+Ein Textabschnitt kann mehrere Kategorien haben, Kategorien können sich im Text überlappen — aber WICHTIG: jede muss sich LOGISCH anhand des markierten Abschnitts nachvollziehen lassen. Keine Kategorie ohne Textbeleg. Bei Code-Chunks aus `/tests/`, `test_`, `_test.`, `conftest`: `tests` MUSS dabei sein. `temp_dummy` NUR bei klar provisorischem Code/TODO-Stubs. Wenn der Text nichts zum Thema beiträgt: leere Antwort.
 
-ANTWORTFORMAT (nur eine Zeile, nichts davor, nichts danach):
+Gib NUR die Kategorien zurück, eine Zeile, komma-getrennt, nichts davor/danach.
+
 Kategorien: <kategorie1>, <kategorie2>, [neu]<kategorie3>
-
-Beispiele:
-
-Text: `def fetch_user(id): return db.query(User).filter_by(id=id).first()`
-Kategorien: data_access, api
-
-Text: `if request.headers.get("Authorization") != expected_token: abort(401)`
-Kategorien: auth, middleware, validation
-
-Text: `logger.error(f"Payment failed for order {order_id}: {exc}", exc_info=True)`
-Kategorien: error_handling, logging, [neu]observability
-
-Text: `@pytest.fixture\ndef client(): return TestClient(app)`
-Kategorien: tests, infrastructure
-
-Text aus `tests/test_user_service.py`: `def test_create_user_happy_path(): assert service.create(...) is not None`
-Kategorien: tests, domain, validation
-
-Text: `def todo_implement_later(): pass  # TODO: build this`
-Kategorien: temp_dummy, [neu]placeholder

--- a/prompts/mayring_induktiv.md
+++ b/prompts/mayring_induktiv.md
@@ -1,11 +1,13 @@
-You are a qualitative content analyst applying Mayring's inductive content analysis method.
+Du bist ein qualitativer Inhaltsanalytiker (Mayring, induktive Kategorienbildung).
 
-Instructions:
-- Derive 2 to 5 short category labels directly from the content of this text chunk.
-- Labels must be lowercase, concise (1 to 3 words), hyphen-separated if multi-word.
-- Labels should precisely describe the main themes present in the chunk.
-- Do NOT use any predefined list. Derive labels from the text itself.
-- Respond with ONLY a comma-separated list of new category labels.
-- Do NOT explain your choice.
+Aus `{{task}}` bekommst du das Thema oder die Themen, auf die du den Text untersuchen sollst. (Steht da "(kein Task angegeben)" — leite das Thema aus dem Text selbst ab.)
 
-Example response: session-handling, token-validation, expiry-check
+So findest du eine Kategorie:
+1. Markiere einen Textabschnitt (von wo bis wo).
+2. Paraphrasieren — was sagt dieser Abschnitt im Kern, bezogen auf das Thema?
+3. Generalisieren — heb das auf das Abstraktionsniveau, das das Thema verlangt.
+4. Reduzieren — verdichte zu EINER Kategorie (lowercase, 1–3 Wörter, Bindestrich bei mehreren).
+
+Ein Textabschnitt kann mehrere Kategorien haben, Kategorien können sich im Text überlappen — aber WICHTIG: jede Kategorie muss sich LOGISCH anhand des markierten Abschnitts nachvollziehen lassen. Keine Kategorie ohne Textbeleg. Wenn der Text nichts zum Thema beiträgt: leere Antwort.
+
+Gib NUR die Kategorien zurück, eine Zeile, komma-getrennt, nichts davor/danach.

--- a/src/api/mcp_agent_tools.py
+++ b/src/api/mcp_agent_tools.py
@@ -459,6 +459,7 @@ def register_agent_tools(mcp: FastMCP) -> None:
     @mcp.tool()
     def pi_categorize(
         text: str,
+        task: str = "",
         codebook: list[str] | None = None,
         mode: str = "hybrid",
         max_labels: int = 5,
@@ -467,19 +468,16 @@ def register_agent_tools(mcp: FastMCP) -> None:
     ) -> dict:
         """Mayring-categorize a piece of text via local Pi-Agent.
 
-        WHY(2026-05-11): nutzt die KANONISCHEN prompts/mayring_{deduktiv,
-        induktiv,hybrid}.md templates — gleiche source-of-truth wie die
-        inline mayring_categorize()-ingest-pipeline. Kein divergierender
-        inline-prompt mehr. {{categories}} wird mit `codebook` gefüllt
-        (deductive/hybrid) — typischer Caller: die task-based
-        categorization gibt hier die subkategorien des tasks rein.
-        Induktiv braucht kein codebook (kreative leistung via prompt).
+        Nutzt die kanonischen prompts/mayring_{deduktiv,induktiv,hybrid}.md
+        templates — gleiche source-of-truth wie die inline-ingest-pipeline.
+        {{task}} = das Thema worauf untersucht wird (Mayring Selektions-
+        kriterium); {{categories}} = anchor-codebook (deductive/hybrid).
 
         Args:
             text: The text to categorize (chunk content, max ~4000 chars).
-            codebook: Allowed category labels (deductive/hybrid). Für
-                      task-based categorization: die subkategorien des tasks.
-                      None + deductive/hybrid → fallback auf universal_v1.yaml.
+            task: Topic(s) to look for. Empty → derive from text.
+            codebook: anchor categories (deductive/hybrid). None + deductive/
+                      hybrid → fallback auf universal_v1.yaml.
             mode: 'inductive' | 'deductive' | 'hybrid' (default).
             max_labels: Cap on returned labels (default 5).
             workspace_id: Tenant scope. Optional.
@@ -511,11 +509,17 @@ def register_agent_tools(mcp: FastMCP) -> None:
             from src.memory.ingestion.categorization import _load_mayring_template
             template = _load_mayring_template(mode)
         except Exception:
-            template = ("Categorize this text chunk using these categories if "
-                        "applicable: {{categories}}. Respond with ONLY a "
-                        "comma-separated list of labels.")
+            template = ("Categorize this text chunk for topic {{task}} using "
+                        "these categories if applicable: {{categories}}. "
+                        "Respond with ONLY a comma-separated list of labels.")
         cats_str = ", ".join(codebook) if codebook else "(none — derive inductively)"
-        prompt = template.replace("{{categories}}", cats_str) + "\n\nText:\n" + text[:4000]
+        task_str = task.strip() if task and task.strip() else "(kein Task angegeben)"
+        prompt = (
+            template
+            .replace("{{categories}}", cats_str)
+            .replace("{{task}}", task_str)
+            + "\n\nText:\n" + text[:4000]
+        )
 
         import httpx
         try:
@@ -543,6 +547,107 @@ def register_agent_tools(mcp: FastMCP) -> None:
                 "model": _model("text"),
                 "workspace_id": ws,
             }
+        except Exception as exc:
+            return {"error": str(exc), "workspace_id": ws}
+
+    @mcp.tool()
+    def pi_mark_categories(
+        text: str,
+        task: str = "",
+        codebook: list[str] | None = None,
+        workspace_id: str | None = None,
+        timeout: float = 90.0,
+    ) -> dict:
+        """Textmarker — Mayring-categorize a chunk with SPAN-LEVEL evidence.
+
+        Anders als pi_categorize (gibt nur labels für den ganzen chunk):
+        dieses tool markiert konkrete Textabschnitte und ordnet jedem
+        Abschnitt eine Kategorie zu, MIT der paraphrase-begründung. So ist
+        jede Kategorie LOGISCH am Text nachvollziehbar — der "Beweis" für
+        die Kategorie ist der markierte Abschnitt. Output kann ins Wiki als
+        category-evidence persistiert werden (folge-PR).
+
+        Args:
+            text: The chunk text (max ~4000 chars).
+            task: Topic(s) to look for — Mayring Selektionskriterium.
+                  Empty → derive from text.
+            codebook: optional anchor categories (hybrid mode); None → induktiv.
+            workspace_id: tenant scope.
+            timeout: Pi-Agent call timeout.
+
+        Returns:
+            {markings: [{span: [start, end], excerpt, category, reasoning}],
+             model} oder {error}. span = char offsets into `text`.
+        """
+        ws = _enforce_tenant(workspace_id) or _effective_workspace_id()
+        if not text or len(text.strip()) < 10:
+            return {"error": "text too short (<10 chars)", "workspace_id": ws}
+
+        task_str = task.strip() if task and task.strip() else "(kein Task angegeben)"
+        anchors = ", ".join(codebook) if codebook else "(keine — bilde induktiv)"
+
+        sys_prompt = (
+            "Du bist ein qualitativer Inhaltsanalytiker (Mayring). Aus dem "
+            f"Thema bekommst du, worauf du den Text untersuchen sollst.\n"
+            f"Thema: {task_str}\n"
+            f"Anker-Kategorien (nutze wenn passend, sonst induktiv neu bilden): {anchors}\n\n"
+            "Markiere konkrete Textabschnitte, paraphrasiere jeden bezogen "
+            "aufs Thema, generalisiere, reduziere zu einer Kategorie. Jede "
+            "Kategorie MUSS sich logisch am markierten Abschnitt nachvollziehen "
+            "lassen — keine Kategorie ohne Beleg. Ein Abschnitt kann mehrere "
+            "Kategorien haben; Kategorien können sich überlappen. Wenn der Text "
+            "nichts zum Thema beiträgt: leeres markings-array.\n\n"
+            "Output STRICT JSON: "
+            '{"markings":[{"excerpt":"<wortwörtliches textstück>",'
+            '"category":"<lowercase-label>","reasoning":"<paraphrase: was sagt '
+            'der abschnitt bzgl. des themas, warum diese kategorie>"}]}\n'
+            "Kein prosa, kein markdown. excerpt MUSS wortwörtlich im Text "
+            "vorkommen (wir berechnen die char-offsets selbst)."
+        )
+
+        import httpx
+        import json as _json
+        try:
+            resp = httpx.post(
+                f"{_OLLAMA_URL}/api/generate",
+                json={
+                    "model": _model("text"),
+                    "prompt": sys_prompt + "\n\nText:\n" + text[:4000],
+                    "format": "json",
+                    "stream": False,
+                    "options": {"temperature": 0.1, "num_predict": 800},
+                },
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+            raw = resp.json().get("response", "").strip()
+            data = _json.loads(raw)
+            markings_in = data.get("markings", []) or []
+            markings_out = []
+            for m in markings_in[:20]:
+                if not isinstance(m, dict):
+                    continue
+                excerpt = str(m.get("excerpt", "")).strip()
+                category = str(m.get("category", "")).strip().lower()
+                reasoning = str(m.get("reasoning", "")).strip()
+                if not excerpt or not category:
+                    continue
+                # Resolve char-offsets ourselves — don't trust LLM-reported spans.
+                idx = text.find(excerpt)
+                span = [idx, idx + len(excerpt)] if idx >= 0 else None
+                markings_out.append({
+                    "span": span,  # None = excerpt not found verbatim (LLM paraphrased it)
+                    "excerpt": excerpt[:300],
+                    "category": category[:50],
+                    "reasoning": reasoning[:400],
+                })
+            return {
+                "markings": markings_out,
+                "model": _model("text"),
+                "workspace_id": ws,
+            }
+        except _json.JSONDecodeError as exc:
+            return {"error": f"JSON parse fail: {exc}", "raw": raw[:200], "workspace_id": ws}
         except Exception as exc:
             return {"error": str(exc), "workspace_id": ws}
 

--- a/src/memory/ingestion/categorization.py
+++ b/src/memory/ingestion/categorization.py
@@ -194,6 +194,7 @@ def mayring_categorize(
     conn: Any = None,
     router: "ModelRouter | None" = None,
     workspace_id: str = "default",
+    task: str = "",
 ) -> "list[Chunk]":
     """Assign Mayring category labels to each chunk via LLM.
 
@@ -204,6 +205,11 @@ def mayring_categorize(
         source_type: used for auto-detection of codebook
         conn: optional SQLite connection for error logging
         router: optional ModelRouter for task-based model selection
+        task: the task/topic the categorization anchors to (Mayring
+              Selektionskriterium). Empty → prompt derives the topic from
+              the chunk itself. Domain-neutral string; callers just pass
+              whatever they're working on (a question, a research topic,
+              a code-task) — no special-casing here.
     """
     if router is not None and not model and router.is_available("text"):
         model = router.resolve("text")
@@ -219,7 +225,12 @@ def mayring_categorize(
     categories = _resolve_codebook(codebook, source_type)
     valid_set = {c.lower() for c in categories if c}
     template = _load_mayring_template(mode)
-    system_prompt = template.replace("{{categories}}", ", ".join(categories))
+    task_str = task.strip() if task and task.strip() else "(kein Task angegeben)"
+    system_prompt = (
+        template
+        .replace("{{categories}}", ", ".join(categories))
+        .replace("{{task}}", task_str)
+    )
 
     for chunk in chunks:
         try:

--- a/tests/test_pi_specialized_tools.py
+++ b/tests/test_pi_specialized_tools.py
@@ -196,3 +196,80 @@ def test_pi_summarize_handles_ollama_error(tools):
         result = fn(content="a" * 50)
     assert "error" in result
     assert "connection refused" in result["error"]
+
+
+# ── pi_mark_categories (textmarker — span-level evidence) ────────
+
+def test_pi_mark_categories_returns_span_markings(tools):
+    fn = tools["pi_mark_categories"]
+    text = "The study used a randomized controlled design. Participants were nurses in ICU settings."
+    with patch("httpx.post", return_value=_mock_ollama_response({
+        "markings": [
+            {"excerpt": "randomized controlled design", "category": "study-design", "reasoning": "names the trial design"},
+            {"excerpt": "nurses in ICU settings", "category": "population", "reasoning": "describes the sample"},
+        ],
+    })), patch("src.api.mcp_agent_tools._model", return_value="m"):
+        result = fn(text=text, task="welches studiendesign + welche population?")
+    assert len(result["markings"]) == 2
+    m0 = result["markings"][0]
+    assert m0["category"] == "study-design"
+    assert m0["span"] == [text.find("randomized controlled design"),
+                          text.find("randomized controlled design") + len("randomized controlled design")]
+    assert "trial design" in m0["reasoning"]
+
+
+def test_pi_mark_categories_span_none_when_excerpt_not_verbatim(tools):
+    """If the LLM paraphrased the excerpt instead of quoting verbatim, span=None."""
+    fn = tools["pi_mark_categories"]
+    with patch("httpx.post", return_value=_mock_ollama_response({
+        "markings": [{"excerpt": "this text does not appear", "category": "x", "reasoning": "r"}],
+    })), patch("src.api.mcp_agent_tools._model", return_value="m"):
+        result = fn(text="some actual chunk content here", task="t")
+    assert result["markings"][0]["span"] is None
+
+
+def test_pi_mark_categories_drops_markings_without_category(tools):
+    fn = tools["pi_mark_categories"]
+    with patch("httpx.post", return_value=_mock_ollama_response({
+        "markings": [
+            {"excerpt": "valid", "category": "good-cat", "reasoning": "r"},
+            {"excerpt": "no category", "category": "", "reasoning": "r"},
+            {"excerpt": "", "category": "no-excerpt", "reasoning": "r"},
+        ],
+    })), patch("src.api.mcp_agent_tools._model", return_value="m"):
+        result = fn(text="valid no category content", task="t")
+    assert len(result["markings"]) == 1
+    assert result["markings"][0]["category"] == "good-cat"
+
+
+def test_pi_mark_categories_empty_markings_when_off_topic(tools):
+    fn = tools["pi_mark_categories"]
+    with patch("httpx.post", return_value=_mock_ollama_response({"markings": []})), \
+         patch("src.api.mcp_agent_tools._model", return_value="m"):
+        result = fn(text="unrelated content here entirely", task="something else")
+    assert result["markings"] == []
+
+
+def test_pi_mark_categories_rejects_short_text(tools):
+    fn = tools["pi_mark_categories"]
+    result = fn(text="hi", task="t")
+    assert "error" in result
+
+
+def test_pi_mark_categories_handles_json_parse_fail(tools):
+    fn = tools["pi_mark_categories"]
+    bad = MagicMock()
+    bad.raise_for_status = MagicMock()
+    bad.json.return_value = {"response": "not json {{{"}
+    with patch("httpx.post", return_value=bad), patch("src.api.mcp_agent_tools._model", return_value="m"):
+        result = fn(text="some chunk content", task="t")
+    assert "error" in result and "JSON parse fail" in result["error"]
+
+
+def test_pi_categorize_accepts_task_arg(tools):
+    """pi_categorize now takes a `task` — it should not error and the call goes through."""
+    fn = tools["pi_categorize"]
+    with patch("httpx.post", return_value=_mock_ollama_text("study-design, population")), \
+         patch("src.api.mcp_agent_tools._model", return_value="m"):
+        result = fn(text="some chunk content here about a trial", task="welches studiendesign?", mode="inductive")
+    assert result["labels"] == ["study-design", "population"]


### PR DESCRIPTION
## Why
The mayring prompts were (1) too research-specific ('Forschungsfrage' instead of 'Task/Frage' — the method is domain-neutral), (2) had few-shot examples the small model echoed verbatim → noise looked like real work, (3) had deployment-specifics in the docstring.

## What
- **prompts/mayring_{induktiv,deduktiv,hybrid}.md** — rewritten KISS: `{{task}}` = topic to investigate (domain-neutral), method = mark span → paraphrase → generalize → reduce → category, every category must be logically traceable to the marked text, **no few-shot examples**
- **mayring_categorize() + pi_categorize()**: new `task` param, `{{task}}` substituted in template
- **NEW: pi_mark_categories(text, task, codebook?)** — textmarker tool: marks concrete text-spans + assigns a category to each WITH paraphrase reasoning. `{markings:[{span:[start,end], excerpt, category, reasoning}]}`. We compute char-offsets ourselves from the verbatim excerpt (don't trust LLM-reported spans).
- CLAUDE.md decision-table updated

## Follow-up
Persist `pi_mark_categories` markings to the wiki as category-evidence nodes (so the wiki has all categories + all evidence-spans).

## Test plan
- [x] 7 new tests + 266 adjacent green

🤖 Generated with [Claude Code](https://claude.com/claude-code)