### PR TITLE
feat(categories): promote frequent [neu]X to codebook + --promote-known cleanup

### DIFF
--- a/codebooks/profiles/universal.yaml
+++ b/codebooks/profiles/universal.yaml
@@ -36,3 +36,23 @@ categories:
   - security
   - scheduling
   - temp_dummy
+  # Promoted 2026-05-11 from frequent [neu]X labels — diese sind
+  # organisch als nützliche kategorien entstanden, gehören als anker
+  # (kein [neu]-prefix mehr).
+  - observability
+  - monitoring
+  - analytics
+  - reporting
+  - search
+  - parsing
+  - filtering
+  - storage
+  - cli
+  - provider
+  # Domänen-inhalt (für non-code chunks: papers, konversationen)
+  - healthcare
+  - research
+  - machine_learning
+  - analysis
+  - evaluation
+  - processing

--- a/tests/test_cleanup_categories.py
+++ b/tests/test_cleanup_categories.py
@@ -1,0 +1,86 @@
+"""Tests for tools/cleanup_hallucinated_categories — _process_labels + promote-known."""
+
+from __future__ import annotations
+
+from tools.cleanup_hallucinated_categories import (
+    _process_labels, is_valid_neu_label, strip_neu_labels,
+)
+
+
+def test_strip_strict_removes_all_neu():
+    out, removed = strip_neu_labels("api, [neu]observability, data_access, [neu]gibberish", strict=True)
+    assert out == "api,data_access"
+    assert removed == 2
+
+
+def test_strip_non_strict_keeps_valid_neu_drops_invalid():
+    # [neu]ai is valid (2 chars, alphanumeric); [neu]zzzzz fails the vowel/repeat heuristic
+    out, removed = strip_neu_labels("[neu]ai, [neu]zzzzzzz, api", strict=False)
+    assert "[neu]ai" in out
+    assert "[neu]zzzzzzz" not in out
+    assert "api" in out
+    assert removed == 1
+
+
+def test_promote_known_rewrites_neu_to_plain():
+    out, removed = _process_labels(
+        "api, [neu]observability, data_access",
+        strict=False, promote_known={"observability", "monitoring"},
+    )
+    assert out == "api,observability,data_access"
+    assert removed == 0  # promotion is a rewrite, not a removal
+
+
+def test_promote_known_plus_strict_drops_unknown_neu():
+    out, removed = _process_labels(
+        "[neu]observability, [neu]customthing, api",
+        strict=True, promote_known={"observability"},
+    )
+    assert out == "observability,api"  # [neu]customthing dropped (strict, not in codebook)
+    assert removed == 1
+
+
+def test_promote_known_dedups_against_existing_plain():
+    # If chunk already has 'observability' AND '[neu]observability' → only one kept
+    out, _ = _process_labels(
+        "observability, [neu]observability, api",
+        strict=False, promote_known={"observability"},
+    )
+    assert out == "observability,api"
+
+
+def test_promote_known_only_no_strict_keeps_valid_neu():
+    out, removed = _process_labels(
+        "[neu]observability, [neu]customvalid, api",
+        strict=False, promote_known={"observability"},
+    )
+    assert out == "observability,[neu]customvalid,api"
+    assert removed == 0
+
+
+def test_no_promote_no_strict_is_passthrough_for_valid():
+    out, removed = _process_labels("api, [neu]ai, data_access", strict=False, promote_known=None)
+    assert out == "api,[neu]ai,data_access"
+    assert removed == 0
+
+
+def test_is_valid_neu_label():
+    assert is_valid_neu_label("observability")
+    assert is_valid_neu_label("ai")
+    assert is_valid_neu_label("machine_learning")
+    assert not is_valid_neu_label("x")  # too short
+    assert not is_valid_neu_label("")  # empty
+    assert not is_valid_neu_label("a!b@c")  # bad chars
+    assert not is_valid_neu_label("aaaaaaaaa")  # repeat heuristic
+
+
+def test_load_universal_categories_includes_promoted():
+    from tools.cleanup_hallucinated_categories import _load_universal_categories
+    cats = _load_universal_categories()
+    # promoted in PR — these should now be anchors
+    assert "observability" in cats
+    assert "healthcare" in cats
+    assert "research" in cats
+    # original ones still there
+    assert "api" in cats
+    assert "data_access" in cats

--- a/tools/cleanup_hallucinated_categories.py
+++ b/tools/cleanup_hallucinated_categories.py
@@ -53,18 +53,58 @@ def strip_neu_labels(label_csv: str, strict: bool) -> tuple[str, int]:
 
     Returns (cleaned_csv, removed_count).
     """
+    return _process_labels(label_csv, strict=strict, promote_known=None)
+
+
+def _process_labels(
+    label_csv: str, *, strict: bool, promote_known: set[str] | None,
+) -> tuple[str, int]:
+    """Process a comma-separated label string.
+
+    For each `[neu]X` label:
+      - if `promote_known` is given and `X.lower()` is in it → rewrite to `X`
+        (drop the prefix — the category is now a real anchor). Counts as 0 removed.
+      - else if `strict` OR not a plausible label → drop it. Counts as removed.
+      - else → keep `[neu]X` as-is.
+
+    Returns (cleaned_csv, removed_count). Promotions are NOT counted as removed
+    (they're rewrites, not deletions), but they DO change the string.
+    """
     labels = [l.strip() for l in label_csv.split(",") if l.strip()]
-    kept = []
+    kept: list[str] = []
     removed = 0
+    seen_lower: set[str] = set()
     for lbl in labels:
         low = lbl.lower()
         if low.startswith("[neu]"):
-            inner = lbl[len("[neu]"):]
+            inner = lbl[len("[neu]"):].strip()
+            inner_low = inner.lower()
+            if promote_known is not None and inner_low in promote_known:
+                # Promote: [neu]X → X (dedup against an existing plain X)
+                if inner_low not in seen_lower:
+                    kept.append(inner_low)
+                    seen_lower.add(inner_low)
+                continue
             if strict or not is_valid_neu_label(inner):
                 removed += 1
                 continue
+        else:
+            if low in seen_lower:
+                continue
+            seen_lower.add(low)
         kept.append(lbl)
     return ",".join(kept), removed
+
+
+def _load_universal_categories() -> set[str]:
+    """Return the lowercased category set from codebooks/profiles/universal.yaml."""
+    try:
+        import yaml
+        path = Path(__file__).parent.parent / "codebooks" / "profiles" / "universal.yaml"
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return {str(c).lower().strip() for c in (data or {}).get("categories", [])}
+    except Exception:
+        return set()
 
 
 def main() -> None:
@@ -72,9 +112,16 @@ def main() -> None:
     parser.add_argument("--workspace-id", default=None, help="Limit to one workspace")
     parser.add_argument("--dry-run", action="store_true", help="Preview only, no DB writes")
     parser.add_argument("--strict", action="store_true", help="Remove ALL [neu]X labels regardless of validity")
+    parser.add_argument("--promote-known", action="store_true",
+                        help="Rewrite [neu]X → X when X is now in codebooks/profiles/universal.yaml "
+                             "(promoted categories). Combine with --strict to also drop the rest.")
     args = parser.parse_args()
 
     conn = init_memory_db()
+    promote_set = _load_universal_categories() if args.promote_known else None
+    if args.promote_known:
+        print(f"Promote-known: {len(promote_set or [])} codebook categories — "
+              f"[neu]X → X for those, {'strip rest' if args.strict else 'keep valid [neu]X'}")
 
     sql = "SELECT chunk_id, category_labels, workspace_id FROM chunks WHERE category_labels LIKE '%[neu]%' AND is_active = 1"
     params: list = []
@@ -87,25 +134,33 @@ def main() -> None:
     total_chunks = len(rows)
     affected = 0
     total_removed = 0
+    total_promoted = 0
     pending_recategorize = 0
 
     print(f"Scanning {total_chunks} chunks with [neu] labels"
           f"{f' in workspace {args.workspace_id}' if args.workspace_id else ''}"
-          f" (strict={args.strict}, dry_run={args.dry_run})\n")
+          f" (strict={args.strict}, promote_known={args.promote_known}, dry_run={args.dry_run})\n")
 
     for chunk_id, label_csv, ws in rows:
-        cleaned, removed = strip_neu_labels(label_csv or "", args.strict)
-        if removed == 0:
-            continue
+        original = label_csv or ""
+        cleaned, removed = _process_labels(original, strict=args.strict, promote_known=promote_set)
+        if cleaned == original:
+            continue  # no change (e.g. only valid [neu]X kept, no strict, no promote)
         affected += 1
         total_removed += removed
+        # promoted = [neu]X labels that became X (delta between original [neu]-count
+        # and removed); rough estimate for the summary.
+        orig_neu = sum(1 for l in original.split(",") if l.strip().lower().startswith("[neu]"))
+        new_neu = sum(1 for l in cleaned.split(",") if l.strip().lower().startswith("[neu]"))
+        promoted_here = max(0, orig_neu - new_neu - removed)
+        total_promoted += promoted_here
         recategorize = not cleaned.strip()
         if recategorize:
             pending_recategorize += 1
 
         print(f"  {chunk_id[:12]} ws={ws or '-':<24} "
-              f"removed={removed} pending={recategorize} "
-              f"before={(label_csv or '')[:60]!r} after={cleaned[:60]!r}")
+              f"removed={removed} promoted={promoted_here} pending={recategorize} "
+              f"before={original[:60]!r} after={cleaned[:60]!r}")
 
         if args.dry_run:
             continue
@@ -127,7 +182,8 @@ def main() -> None:
 
     print()
     print(f"Summary: scanned={total_chunks} affected={affected} "
-          f"labels_removed={total_removed} marked_for_recategorize={pending_recategorize}")
+          f"labels_removed={total_removed} labels_promoted={total_promoted} "
+          f"marked_for_recategorize={pending_recategorize}")
     if args.dry_run:
         print("(dry-run — no DB writes)")
 


### PR DESCRIPTION
## Why
634 distinct [neu]X labels across 4882 chunks (1807 occurrences). Some useful (observability ×178, healthcare ×112, research ×108), most noise. The garbage poisons retrieval.

## What
1. **codebooks/profiles/universal.yaml**: promoted 16 frequent [neu]X labels to real anchor categories — code-side (observability, monitoring, analytics, reporting, search, parsing, filtering, storage, cli, provider) + domain-content (healthcare, research, machine_learning, analysis, evaluation, processing). Future categorization uses them as anchors WITHOUT [neu].
2. **tools/cleanup_hallucinated_categories.py**: new `--promote-known` mode — `[neu]X → X` when X is now in the codebook (rewrite). Combine with `--strict` to also drop the rest. `_process_labels()` is the new core (with dedup against existing plain labels).

## Prod-cleanup workflow (separate, dry-run first)
`python tools/cleanup_hallucinated_categories.py --promote-known --strict --dry-run` then without --dry-run. Chunks left with no labels → `category_source='cleanup-pending'` for re-categorization with the new task-anchored prompts.

## Test plan
- [x] 9 new tests + 150 adjacent green

🤖 Generated with [Claude Code](https://claude.com/claude-code)