### PR TITLE
feat(wiki): persist Mayring textmarker markings as category-evidence

### DIFF
--- a/codebooks/profiles/universal.yaml
+++ b/codebooks/profiles/universal.yaml
@@ -36,3 +36,23 @@ categories:
   - security
   - scheduling
   - temp_dummy
+  # Promoted 2026-05-11 from frequent [neu]X labels — diese sind
+  # organisch als nützliche kategorien entstanden, gehören als anker
+  # (kein [neu]-prefix mehr).
+  - observability
+  - monitoring
+  - analytics
+  - reporting
+  - search
+  - parsing
+  - filtering
+  - storage
+  - cli
+  - provider
+  # Domänen-inhalt (für non-code chunks: papers, konversationen)
+  - healthcare
+  - research
+  - machine_learning
+  - analysis
+  - evaluation
+  - processing

--- a/src/api/mcp_agent_tools.py
+++ b/src/api/mcp_agent_tools.py
@@ -555,6 +555,9 @@ def register_agent_tools(mcp: FastMCP) -> None:
         text: str,
         task: str = "",
         codebook: list[str] | None = None,
+        source_id: str | None = None,
+        chunk_id: str = "",
+        persist: bool = False,
         workspace_id: str | None = None,
         timeout: float = 90.0,
     ) -> dict:
@@ -564,20 +567,26 @@ def register_agent_tools(mcp: FastMCP) -> None:
         dieses tool markiert konkrete Textabschnitte und ordnet jedem
         Abschnitt eine Kategorie zu, MIT der paraphrase-begründung. So ist
         jede Kategorie LOGISCH am Text nachvollziehbar — der "Beweis" für
-        die Kategorie ist der markierte Abschnitt. Output kann ins Wiki als
-        category-evidence persistiert werden (folge-PR).
+        die Kategorie ist der markierte Abschnitt.
+
+        Wenn `persist=True` und `source_id` gesetzt: die markings landen in
+        wiki_category_evidence (vorhandene evidence für source_id wird
+        zuerst gelöscht — clean re-mark). Abrufbar via pi_category_evidence.
 
         Args:
             text: The chunk text (max ~4000 chars).
             task: Topic(s) to look for — Mayring Selektionskriterium.
                   Empty → derive from text.
             codebook: optional anchor categories (hybrid mode); None → induktiv.
+            source_id: which source/chunk this came from (für persist).
+            chunk_id: optional chunk-id (für persist).
+            persist: True + source_id → schreibt markings ins wiki.
             workspace_id: tenant scope.
             timeout: Pi-Agent call timeout.
 
         Returns:
             {markings: [{span: [start, end], excerpt, category, reasoning}],
-             model} oder {error}. span = char offsets into `text`.
+             model, persisted: int} oder {error}. span = char offsets into `text`.
         """
         ws = _enforce_tenant(workspace_id) or _effective_workspace_id()
         if not text or len(text.strip()) < 10:
@@ -641,13 +650,70 @@ def register_agent_tools(mcp: FastMCP) -> None:
                     "category": category[:50],
                     "reasoning": reasoning[:400],
                 })
+            persisted = 0
+            if persist and source_id and markings_out:
+                try:
+                    from src.wiki_v2.store import init_wiki_db, persist_category_evidence, delete_category_evidence
+                    from src.memory.store import MEMORY_DB_PATH
+                    wdb = init_wiki_db(MEMORY_DB_PATH.parent / "wiki_v2.db")
+                    try:
+                        delete_category_evidence(wdb, ws, source_id)
+                        persisted = persist_category_evidence(
+                            wdb, ws, source_id, markings_out,
+                            task=task_str if task_str != "(kein Task angegeben)" else "",
+                            chunk_id=chunk_id,
+                        )
+                    finally:
+                        wdb.close()
+                except Exception as exc:
+                    import logging as _logging
+                    _logging.getLogger(__name__).warning("category-evidence persist failed: %s", exc)
+
             return {
                 "markings": markings_out,
                 "model": _model("text"),
+                "persisted": persisted,
                 "workspace_id": ws,
             }
         except _json.JSONDecodeError as exc:
             return {"error": f"JSON parse fail: {exc}", "raw": raw[:200], "workspace_id": ws}
+        except Exception as exc:
+            return {"error": str(exc), "workspace_id": ws}
+
+    @mcp.tool()
+    def pi_category_evidence(
+        category: str | None = None,
+        source_id: str | None = None,
+        limit: int = 100,
+        workspace_id: str | None = None,
+    ) -> dict:
+        """Read Mayring category-evidence (from pi_mark_categories persist).
+
+        Beantwortet "zeig mir alle Belege für Kategorie X" oder "welche
+        Kategorien wurden in Source Y gefunden, mit welchem Beleg".
+
+        Args:
+            category: filter by category label (lowercase). None = all.
+            source_id: filter by source. None = all.
+            limit: max rows.
+            workspace_id: tenant scope.
+
+        Returns:
+            {evidence: [{source_id, chunk_id, category, span, excerpt,
+             reasoning, task, created_at}], count} oder {error}.
+        """
+        ws = _enforce_tenant(workspace_id) or _effective_workspace_id()
+        try:
+            from src.wiki_v2.store import init_wiki_db, get_category_evidence
+            from src.memory.store import MEMORY_DB_PATH
+            wdb = init_wiki_db(MEMORY_DB_PATH.parent / "wiki_v2.db")
+            try:
+                rows = get_category_evidence(
+                    wdb, ws, category=category, source_id=source_id, limit=limit,
+                )
+            finally:
+                wdb.close()
+            return {"evidence": rows, "count": len(rows), "workspace_id": ws}
         except Exception as exc:
             return {"error": str(exc), "workspace_id": ws}
 

--- a/src/wiki_v2/store.py
+++ b/src/wiki_v2/store.py
@@ -77,6 +77,29 @@ def _init_schema(conn: DBAdapter) -> None:
         target_node TEXT NOT NULL,
         timestamp TEXT DEFAULT (datetime('now'))
     );
+
+    -- WHY(2026-05-11): Mayring-Textmarkierungen. pi_mark_categories
+    -- markiert konkrete Textabschnitte und ordnet jedem eine Kategorie zu
+    -- MIT paraphrase-begründung. Hier persistiert: jede Kategorie hängt
+    -- nachvollziehbar am Text — der "Beweis" ist excerpt + span + reasoning.
+    -- Das Wiki kann daraus aggregieren: "Kategorie X, gefunden in N Stellen,
+    -- hier die Belege". span = char-offsets in den chunk-text (-1 wenn der
+    -- excerpt nicht wortwörtlich gefunden wurde, LLM hat paraphrasiert).
+    CREATE TABLE IF NOT EXISTS wiki_category_evidence (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        workspace_id TEXT NOT NULL,
+        source_id TEXT NOT NULL,
+        chunk_id TEXT NOT NULL DEFAULT '',
+        category TEXT NOT NULL,
+        span_start INTEGER NOT NULL DEFAULT -1,
+        span_end INTEGER NOT NULL DEFAULT -1,
+        excerpt TEXT NOT NULL DEFAULT '',
+        reasoning TEXT NOT NULL DEFAULT '',
+        task TEXT NOT NULL DEFAULT '',
+        created_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_wce_category ON wiki_category_evidence(workspace_id, category);
+    CREATE INDEX IF NOT EXISTS idx_wce_source ON wiki_category_evidence(source_id);
     """)
     conn.commit()
     _ensure_rationale_column(conn)
@@ -365,3 +388,113 @@ def get_task_feedback_matrix(
             "created_at": r[4] if isinstance(r, tuple) else r["created_at"],
         })
     return list(tasks.values())
+
+
+# --- Mayring Textmarkierungen / Category-Evidence (#textmarker) ---
+
+def persist_category_evidence(
+    conn: DBAdapter,
+    workspace_id: str,
+    source_id: str,
+    markings: list[dict],
+    task: str = "",
+    chunk_id: str = "",
+) -> int:
+    """Persist pi_mark_categories markings into wiki_category_evidence.
+
+    Args:
+        markings: [{span: [start,end]|None, excerpt, category, reasoning}, ...]
+        task:     what the categorization was anchored to (Mayring Selektionskriterium).
+        chunk_id: optional — which chunk the markings came from.
+
+    Returns: number of rows written. Idempotent-ish: dedups within this call
+    on (category, excerpt) so a re-run with the same markings doesn't double up
+    — but does NOT delete prior evidence for the source. Callers that want a
+    clean re-mark should delete_category_evidence(source_id) first.
+    """
+    if not markings:
+        return 0
+    seen: set[tuple[str, str]] = set()
+    written = 0
+    for m in markings:
+        if not isinstance(m, dict):
+            continue
+        cat = str(m.get("category", "")).strip().lower()
+        excerpt = str(m.get("excerpt", "")).strip()
+        if not cat or not excerpt:
+            continue
+        key = (cat, excerpt[:200])
+        if key in seen:
+            continue
+        seen.add(key)
+        span = m.get("span")
+        if isinstance(span, (list, tuple)) and len(span) == 2:
+            start, end = int(span[0]), int(span[1])
+        else:
+            start, end = -1, -1
+        conn.execute(
+            """INSERT INTO wiki_category_evidence
+               (workspace_id, source_id, chunk_id, category, span_start, span_end,
+                excerpt, reasoning, task)
+               VALUES (?,?,?,?,?,?,?,?,?)""",
+            (workspace_id, source_id, chunk_id, cat, start, end,
+             excerpt[:500], str(m.get("reasoning", "")).strip()[:1000], task[:300]),
+        )
+        written += 1
+    if written:
+        conn.commit()
+    return written
+
+
+def delete_category_evidence(conn: DBAdapter, workspace_id: str, source_id: str) -> int:
+    """Remove all category-evidence for a source (use before re-marking)."""
+    cur = conn.execute(
+        "DELETE FROM wiki_category_evidence WHERE workspace_id = ? AND source_id = ?",
+        (workspace_id, source_id),
+    )
+    conn.commit()
+    return getattr(cur, "rowcount", 0) or 0
+
+
+def get_category_evidence(
+    conn: DBAdapter,
+    workspace_id: str,
+    category: str | None = None,
+    source_id: str | None = None,
+    limit: int = 200,
+) -> list[dict]:
+    """Return evidence rows, optionally filtered by category or source.
+
+    Use to answer "show me all Belege for category X" (wiki view) or
+    "what categories were found in source Y, with which evidence".
+    """
+    where = ["workspace_id = ?"]
+    params: list = [workspace_id]
+    if category:
+        where.append("category = ?")
+        params.append(category.lower())
+    if source_id:
+        where.append("source_id = ?")
+        params.append(source_id)
+    rows = conn.execute(
+        f"""SELECT source_id, chunk_id, category, span_start, span_end, excerpt,
+                   reasoning, task, created_at
+            FROM wiki_category_evidence
+            WHERE {' AND '.join(where)}
+            ORDER BY created_at DESC LIMIT ?""",
+        params + [limit],
+    ).fetchall()
+    out = []
+    for r in rows:
+        d = r if isinstance(r, dict) else {
+            "source_id": r[0], "chunk_id": r[1], "category": r[2],
+            "span_start": r[3], "span_end": r[4], "excerpt": r[5],
+            "reasoning": r[6], "task": r[7], "created_at": r[8],
+        }
+        span = [d["span_start"], d["span_end"]] if d["span_start"] >= 0 else None
+        out.append({
+            "source_id": d["source_id"], "chunk_id": d["chunk_id"],
+            "category": d["category"], "span": span, "excerpt": d["excerpt"],
+            "reasoning": d["reasoning"], "task": d["task"], "created_at": d["created_at"],
+        })
+    return out

--- a/tests/test_cleanup_categories.py
+++ b/tests/test_cleanup_categories.py
@@ -1,0 +1,86 @@
+"""Tests for tools/cleanup_hallucinated_categories — _process_labels + promote-known."""
+
+from __future__ import annotations
+
+from tools.cleanup_hallucinated_categories import (
+    _process_labels, is_valid_neu_label, strip_neu_labels,
+)
+
+
+def test_strip_strict_removes_all_neu():
+    out, removed = strip_neu_labels("api, [neu]observability, data_access, [neu]gibberish", strict=True)
+    assert out == "api,data_access"
+    assert removed == 2
+
+
+def test_strip_non_strict_keeps_valid_neu_drops_invalid():
+    # [neu]ai is valid (2 chars, alphanumeric); [neu]zzzzz fails the vowel/repeat heuristic
+    out, removed = strip_neu_labels("[neu]ai, [neu]zzzzzzz, api", strict=False)
+    assert "[neu]ai" in out
+    assert "[neu]zzzzzzz" not in out
+    assert "api" in out
+    assert removed == 1
+
+
+def test_promote_known_rewrites_neu_to_plain():
+    out, removed = _process_labels(
+        "api, [neu]observability, data_access",
+        strict=False, promote_known={"observability", "monitoring"},
+    )
+    assert out == "api,observability,data_access"
+    assert removed == 0  # promotion is a rewrite, not a removal
+
+
+def test_promote_known_plus_strict_drops_unknown_neu():
+    out, removed = _process_labels(
+        "[neu]observability, [neu]customthing, api",
+        strict=True, promote_known={"observability"},
+    )
+    assert out == "observability,api"  # [neu]customthing dropped (strict, not in codebook)
+    assert removed == 1
+
+
+def test_promote_known_dedups_against_existing_plain():
+    # If chunk already has 'observability' AND '[neu]observability' → only one kept
+    out, _ = _process_labels(
+        "observability, [neu]observability, api",
+        strict=False, promote_known={"observability"},
+    )
+    assert out == "observability,api"
+
+
+def test_promote_known_only_no_strict_keeps_valid_neu():
+    out, removed = _process_labels(
+        "[neu]observability, [neu]customvalid, api",
+        strict=False, promote_known={"observability"},
+    )
+    assert out == "observability,[neu]customvalid,api"
+    assert removed == 0
+
+
+def test_no_promote_no_strict_is_passthrough_for_valid():
+    out, removed = _process_labels("api, [neu]ai, data_access", strict=False, promote_known=None)
+    assert out == "api,[neu]ai,data_access"
+    assert removed == 0
+
+
+def test_is_valid_neu_label():
+    assert is_valid_neu_label("observability")
+    assert is_valid_neu_label("ai")
+    assert is_valid_neu_label("machine_learning")
+    assert not is_valid_neu_label("x")  # too short
+    assert not is_valid_neu_label("")  # empty
+    assert not is_valid_neu_label("a!b@c")  # bad chars
+    assert not is_valid_neu_label("aaaaaaaaa")  # repeat heuristic
+
+
+def test_load_universal_categories_includes_promoted():
+    from tools.cleanup_hallucinated_categories import _load_universal_categories
+    cats = _load_universal_categories()
+    # promoted in PR — these should now be anchors
+    assert "observability" in cats
+    assert "healthcare" in cats
+    assert "research" in cats
+    # original ones still there
+    assert "api" in cats
+    assert "data_access" in cats

--- a/tests/test_pi_specialized_tools.py
+++ b/tests/test_pi_specialized_tools.py
@@ -273,3 +273,60 @@ def test_pi_categorize_accepts_task_arg(tools):
          patch("src.api.mcp_agent_tools._model", return_value="m"):
         result = fn(text="some chunk content here about a trial", task="welches studiendesign?", mode="inductive")
     assert result["labels"] == ["study-design", "population"]
+
+
+def test_pi_mark_categories_persists_to_wiki(tools, tmp_path, monkeypatch):
+    """persist=True + source_id → markings land in wiki_category_evidence."""
+    # Point MEMORY_DB_PATH to a tmp dir so wiki_v2.db is created there.
+    import src.memory.store as _store
+    monkeypatch.setattr(_store, "MEMORY_DB_PATH", tmp_path / "memory.db")
+
+    fn = tools["pi_mark_categories"]
+    text = "def validate_jwt(token): return decode(token)"
+    with patch("httpx.post", return_value=_mock_ollama_response({
+        "markings": [{"excerpt": "def validate_jwt", "category": "auth", "reasoning": "validates a jwt"}],
+    })), patch("src.api.mcp_agent_tools._model", return_value="m"):
+        result = fn(text=text, task="wie wird auth gemacht?", source_id="src:foo.py",
+                    chunk_id="chk_1", persist=True)
+    assert result["persisted"] == 1
+
+    # Read it back via get_category_evidence
+    from src.wiki_v2.store import init_wiki_db, get_category_evidence
+    wdb = init_wiki_db(tmp_path / "wiki_v2.db")
+    try:
+        ev = get_category_evidence(wdb, result["workspace_id"], category="auth")
+        assert len(ev) == 1
+        assert ev[0]["source_id"] == "src:foo.py"
+        assert ev[0]["task"] == "wie wird auth gemacht?"
+    finally:
+        wdb.close()
+
+
+def test_pi_mark_categories_no_persist_when_persist_false(tools, tmp_path, monkeypatch):
+    import src.memory.store as _store
+    monkeypatch.setattr(_store, "MEMORY_DB_PATH", tmp_path / "memory.db")
+    fn = tools["pi_mark_categories"]
+    with patch("httpx.post", return_value=_mock_ollama_response({
+        "markings": [{"excerpt": "abc", "category": "x", "reasoning": "r"}],
+    })), patch("src.api.mcp_agent_tools._model", return_value="m"):
+        result = fn(text="abc content here", task="t", source_id="src:y", persist=False)
+    assert result["persisted"] == 0
+
+
+def test_pi_category_evidence_reads_persisted(tools, tmp_path, monkeypatch):
+    import src.memory.store as _store
+    monkeypatch.setattr(_store, "MEMORY_DB_PATH", tmp_path / "memory.db")
+    from src.wiki_v2.store import init_wiki_db, persist_category_evidence
+    wdb = init_wiki_db(tmp_path / "wiki_v2.db")
+    persist_category_evidence(wdb, "bene", "src:z", [
+        {"span": [0, 3], "excerpt": "abc", "category": "demo-cat", "reasoning": "r"},
+    ], task="demo task")
+    wdb.close()
+
+    fn = tools["pi_category_evidence"]
+    with patch("src.api.mcp_agent_tools._enforce_tenant", return_value="bene"), \
+         patch("src.api.mcp_agent_tools._effective_workspace_id", return_value="bene"):
+        result = fn(category="demo-cat")
+    assert result["count"] == 1
+    assert result["evidence"][0]["category"] == "demo-cat"
+    assert result["evidence"][0]["task"] == "demo task"

--- a/tests/test_wiki_category_evidence.py
+++ b/tests/test_wiki_category_evidence.py
@@ -1,0 +1,109 @@
+"""Tests for wiki_v2 category-evidence (Mayring textmarker persistence)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.wiki_v2.store import (
+    init_wiki_db, persist_category_evidence, get_category_evidence,
+    delete_category_evidence,
+)
+
+
+@pytest.fixture
+def wdb(tmp_path):
+    db = init_wiki_db(tmp_path / "wiki_v2.db")
+    yield db
+    db.close()
+
+
+def test_persist_and_read_by_category(wdb):
+    n = persist_category_evidence(wdb, "bene", "src:foo.py", [
+        {"span": [10, 25], "excerpt": "def validate_jwt", "category": "auth", "reasoning": "validates a JWT"},
+    ], task="wie wird auth gemacht?", chunk_id="chk_1")
+    assert n == 1
+    ev = get_category_evidence(wdb, "bene", category="auth")
+    assert len(ev) == 1
+    assert ev[0]["category"] == "auth"
+    assert ev[0]["span"] == [10, 25]
+    assert ev[0]["excerpt"] == "def validate_jwt"
+    assert ev[0]["task"] == "wie wird auth gemacht?"
+    assert ev[0]["chunk_id"] == "chk_1"
+
+
+def test_span_none_persisted_as_minus_one(wdb):
+    persist_category_evidence(wdb, "bene", "src:x", [
+        {"span": None, "excerpt": "paraphrased text not in chunk", "category": "validation", "reasoning": "r"},
+    ])
+    ev = get_category_evidence(wdb, "bene", category="validation")
+    assert ev[0]["span"] is None  # -1 sentinel → None on read
+
+
+def test_dedup_within_call(wdb):
+    n = persist_category_evidence(wdb, "bene", "src:y", [
+        {"span": [0, 5], "excerpt": "hello", "category": "greeting", "reasoning": "r"},
+        {"span": [10, 15], "excerpt": "hello", "category": "greeting", "reasoning": "r2"},  # same (cat, excerpt)
+        {"span": [0, 5], "excerpt": "hello", "category": "other", "reasoning": "r"},  # different cat → kept
+    ])
+    assert n == 2
+
+
+def test_skips_markings_without_category_or_excerpt(wdb):
+    n = persist_category_evidence(wdb, "bene", "src:z", [
+        {"span": [0, 5], "excerpt": "valid", "category": "good", "reasoning": "r"},
+        {"span": [0, 5], "excerpt": "", "category": "no-excerpt", "reasoning": "r"},
+        {"span": [0, 5], "excerpt": "no-cat", "category": "", "reasoning": "r"},
+        {"not": "a dict"},
+    ])
+    assert n == 1
+
+
+def test_read_by_source(wdb):
+    persist_category_evidence(wdb, "bene", "src:a", [
+        {"span": [0, 3], "excerpt": "abc", "category": "c1", "reasoning": "r"},
+        {"span": [4, 7], "excerpt": "def", "category": "c2", "reasoning": "r"},
+    ])
+    persist_category_evidence(wdb, "bene", "src:b", [
+        {"span": [0, 3], "excerpt": "xyz", "category": "c1", "reasoning": "r"},
+    ])
+    ev_a = get_category_evidence(wdb, "bene", source_id="src:a")
+    assert len(ev_a) == 2
+    ev_c1 = get_category_evidence(wdb, "bene", category="c1")
+    assert len(ev_c1) == 2  # one from each source
+
+
+def test_workspace_isolation(wdb):
+    persist_category_evidence(wdb, "alice", "src:a", [{"span": [0, 3], "excerpt": "abc", "category": "c1", "reasoning": "r"}])
+    persist_category_evidence(wdb, "bob", "src:a", [{"span": [0, 3], "excerpt": "abc", "category": "c1", "reasoning": "r"}])
+    assert len(get_category_evidence(wdb, "alice")) == 1
+    assert len(get_category_evidence(wdb, "bob")) == 1
+
+
+def test_delete_then_re_mark(wdb):
+    persist_category_evidence(wdb, "bene", "src:remark", [
+        {"span": [0, 3], "excerpt": "old", "category": "stale-cat", "reasoning": "r"},
+    ])
+    deleted = delete_category_evidence(wdb, "bene", "src:remark")
+    assert deleted == 1
+    assert get_category_evidence(wdb, "bene", source_id="src:remark") == []
+    # re-mark
+    persist_category_evidence(wdb, "bene", "src:remark", [
+        {"span": [5, 8], "excerpt": "new", "category": "fresh-cat", "reasoning": "r"},
+    ])
+    ev = get_category_evidence(wdb, "bene", source_id="src:remark")
+    assert len(ev) == 1 and ev[0]["category"] == "fresh-cat"
+
+
+def test_empty_markings_returns_zero(wdb):
+    assert persist_category_evidence(wdb, "bene", "src:empty", []) == 0
+
+
+def test_category_lowercased_on_query(wdb):
+    persist_category_evidence(wdb, "bene", "src:c", [
+        {"span": [0, 3], "excerpt": "abc", "category": "MixedCase", "reasoning": "r"},
+    ])
+    # stored lowercased; query with any case works
+    assert len(get_category_evidence(wdb, "bene", category="mixedcase")) == 1
+    assert len(get_category_evidence(wdb, "bene", category="MIXEDCASE")) == 1

--- a/tools/cleanup_hallucinated_categories.py
+++ b/tools/cleanup_hallucinated_categories.py
@@ -53,18 +53,58 @@ def strip_neu_labels(label_csv: str, strict: bool) -> tuple[str, int]:
 
     Returns (cleaned_csv, removed_count).
     """
+    return _process_labels(label_csv, strict=strict, promote_known=None)
+
+
+def _process_labels(
+    label_csv: str, *, strict: bool, promote_known: set[str] | None,
+) -> tuple[str, int]:
+    """Process a comma-separated label string.
+
+    For each `[neu]X` label:
+      - if `promote_known` is given and `X.lower()` is in it → rewrite to `X`
+        (drop the prefix — the category is now a real anchor). Counts as 0 removed.
+      - else if `strict` OR not a plausible label → drop it. Counts as removed.
+      - else → keep `[neu]X` as-is.
+
+    Returns (cleaned_csv, removed_count). Promotions are NOT counted as removed
+    (they're rewrites, not deletions), but they DO change the string.
+    """
     labels = [l.strip() for l in label_csv.split(",") if l.strip()]
-    kept = []
+    kept: list[str] = []
     removed = 0
+    seen_lower: set[str] = set()
     for lbl in labels:
         low = lbl.lower()
         if low.startswith("[neu]"):
-            inner = lbl[len("[neu]"):]
+            inner = lbl[len("[neu]"):].strip()
+            inner_low = inner.lower()
+            if promote_known is not None and inner_low in promote_known:
+                # Promote: [neu]X → X (dedup against an existing plain X)
+                if inner_low not in seen_lower:
+                    kept.append(inner_low)
+                    seen_lower.add(inner_low)
+                continue
             if strict or not is_valid_neu_label(inner):
                 removed += 1
                 continue
+        else:
+            if low in seen_lower:
+                continue
+            seen_lower.add(low)
         kept.append(lbl)
     return ",".join(kept), removed
+
+
+def _load_universal_categories() -> set[str]:
+    """Return the lowercased category set from codebooks/profiles/universal.yaml."""
+    try:
+        import yaml
+        path = Path(__file__).parent.parent / "codebooks" / "profiles" / "universal.yaml"
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return {str(c).lower().strip() for c in (data or {}).get("categories", [])}
+    except Exception:
+        return set()
 
 
 def main() -> None:
@@ -72,9 +112,16 @@ def main() -> None:
     parser.add_argument("--workspace-id", default=None, help="Limit to one workspace")
     parser.add_argument("--dry-run", action="store_true", help="Preview only, no DB writes")
     parser.add_argument("--strict", action="store_true", help="Remove ALL [neu]X labels regardless of validity")
+    parser.add_argument("--promote-known", action="store_true",
+                        help="Rewrite [neu]X → X when X is now in codebooks/profiles/universal.yaml "
+                             "(promoted categories). Combine with --strict to also drop the rest.")
     args = parser.parse_args()
 
     conn = init_memory_db()
+    promote_set = _load_universal_categories() if args.promote_known else None
+    if args.promote_known:
+        print(f"Promote-known: {len(promote_set or [])} codebook categories — "
+              f"[neu]X → X for those, {'strip rest' if args.strict else 'keep valid [neu]X'}")
 
     sql = "SELECT chunk_id, category_labels, workspace_id FROM chunks WHERE category_labels LIKE '%[neu]%' AND is_active = 1"
     params: list = []
@@ -87,25 +134,33 @@ def main() -> None:
     total_chunks = len(rows)
     affected = 0
     total_removed = 0
+    total_promoted = 0
     pending_recategorize = 0
 
     print(f"Scanning {total_chunks} chunks with [neu] labels"
           f"{f' in workspace {args.workspace_id}' if args.workspace_id else ''}"
-          f" (strict={args.strict}, dry_run={args.dry_run})\n")
+          f" (strict={args.strict}, promote_known={args.promote_known}, dry_run={args.dry_run})\n")
 
     for chunk_id, label_csv, ws in rows:
-        cleaned, removed = strip_neu_labels(label_csv or "", args.strict)
-        if removed == 0:
-            continue
+        original = label_csv or ""
+        cleaned, removed = _process_labels(original, strict=args.strict, promote_known=promote_set)
+        if cleaned == original:
+            continue  # no change (e.g. only valid [neu]X kept, no strict, no promote)
         affected += 1
         total_removed += removed
+        # promoted = [neu]X labels that became X (delta between original [neu]-count
+        # and removed); rough estimate for the summary.
+        orig_neu = sum(1 for l in original.split(",") if l.strip().lower().startswith("[neu]"))
+        new_neu = sum(1 for l in cleaned.split(",") if l.strip().lower().startswith("[neu]"))
+        promoted_here = max(0, orig_neu - new_neu - removed)
+        total_promoted += promoted_here
         recategorize = not cleaned.strip()
         if recategorize:
             pending_recategorize += 1
 
         print(f"  {chunk_id[:12]} ws={ws or '-':<24} "
-              f"removed={removed} pending={recategorize} "
-              f"before={(label_csv or '')[:60]!r} after={cleaned[:60]!r}")
+              f"removed={removed} promoted={promoted_here} pending={recategorize} "
+              f"before={original[:60]!r} after={cleaned[:60]!r}")
 
         if args.dry_run:
             continue
@@ -127,7 +182,8 @@ def main() -> None:
 
     print()
     print(f"Summary: scanned={total_chunks} affected={affected} "
-          f"labels_removed={total_removed} marked_for_recategorize={pending_recategorize}")
+          f"labels_removed={total_removed} labels_promoted={total_promoted} "
+          f"marked_for_recategorize={pending_recategorize}")
     if args.dry_run:
         print("(dry-run — no DB writes)")
 


### PR DESCRIPTION
## Why
pi_mark_categories produced markings that went nowhere — without wiki-persistence the whole thing is useless (user's words).

## What
1. **wiki_v2/store.py**: new `wiki_category_evidence` table (source_id, chunk_id, category, span_start/end, excerpt, reasoning, task) + `persist_category_evidence` / `delete_category_evidence` / `get_category_evidence`. Persist dedups within-call on (category, excerpt); span=None → -1 sentinel.
2. **pi_mark_categories**: new params source_id/chunk_id/persist. persist=True + source_id → delete + persist (clean re-mark). Returns persisted-count. Fail-soft.
3. **NEW pi_category_evidence(category?, source_id?)** MCP tool — reads the evidence back. The wiki now has all categories AND all evidence (excerpt + span + paraphrase-reasoning) per category.

## Test plan
- [x] 9 wiki-evidence tests + 3 pi_mark-persist tests + 289 adjacent green

## Follow-up
- re-cat batch job for the 145 cleanup-pending chunks (pi_mark_categories+persist)
- app.linn.games template: pass forschungsfrage as task in paper-ingest

🤖 Generated with [Claude Code](https://claude.com/claude-code)