### PR TITLE
feat(ingest): /memory/ingest accepts task param

### DIFF
--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -310,7 +310,8 @@ async def memory_put(
             source_dict["org_id"] = request.org_id
 
         result = _run_ingest(source_dict, request.content, _get_conn(), _get_chroma(),
-                             _OLLAMA_URL, _model("text"), {"categorize": request.categorize},
+                             _OLLAMA_URL, _model("text"),
+                             {"categorize": request.categorize, "task": request.task},
                              workspace_id)
         if source_dict.get("source_type") == "paper":
             _threading.Thread(

--- a/src/api/routes/models.py
+++ b/src/api/routes/models.py
@@ -90,6 +90,11 @@ class MemoryPutRequest(BaseModel):
     path: str = ""
     content: str
     categorize: bool = False
+    # WHY(2026-05-11): Mayring Selektionskriterium — das Thema worauf
+    # kategorisiert wird (z.B. die forschungsfrage bei paper-ingest aus
+    # app.linn.games). Empty → die prompts leiten das Thema aus dem
+    # chunk selbst ab.
+    task: str = ""
     # V2 visibility — optional; defaults to 'private' downstream.
     # 'org' requires membership in org_id (or first org_id if not given).
     visibility: str | None = None

--- a/src/memory/ingestion/core.py
+++ b/src/memory/ingestion/core.py
@@ -144,6 +144,11 @@ def ingest(
     do_force:      bool = bool(effective.get("force", False))
     mode:          str  = effective.get("mode", "hybrid")
     codebook_choice: str = effective.get("codebook", "auto")
+    # WHY(2026-05-11): Mayring Selektionskriterium — das Thema worauf
+    # kategorisiert wird. Callers (app.linn.games paper-ingest: die
+    # forschungsfrage; memory-hook: der derived task) geben das mit.
+    # Empty → die prompts leiten das Thema aus dem chunk selbst ab.
+    categorize_task: str = str(effective.get("task", "") or "")
 
     from src.analysis.context import _embed_texts
 
@@ -197,6 +202,7 @@ def ingest(
                 conn=conn,
                 router=router,
                 workspace_id=workspace_id,
+                task=categorize_task,
             )
 
         new_chunk_ids: list[str] = []


### PR DESCRIPTION
Follow-up to task-anchored prompts (#237): the ingest pipeline can now thread the Mayring Selektionskriterium. `MemoryPutRequest.task` → `memory_put` opts → `core.ingest` → `mayring_categorize(task=...)`. Lets app.linn.games pass the forschungsfrage at paper-ingest (follow-up PR there). Empty → prompts derive topic from chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)