### PR TITLE
feat(#252): scope_key — typed logical sub-bucket within a workspace

### DIFF
--- a/src/api/memory_service.py
+++ b/src/api/memory_service.py
@@ -160,6 +160,7 @@ def run_ingest(
         visibility=source_dict.get("visibility") or "private",
         org_id=source_dict.get("org_id"),
         user_id=source_dict.get("user_id"),
+        scope_key=source_dict.get("scope_key"),  # #252
     )
     return ingest(
         source=src,

--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -110,6 +110,10 @@ async def memory_search(
             opts["repo"] = request.repo
         if request.source_type:
             opts["source_type"] = request.source_type
+        if request.scope:
+            # #252: restrict to one logical sub-bucket (e.g. "project:<id>") —
+            # a Recherche search stays inside that project's papers.
+            opts["scope_key"] = request.scope.strip()
         if request.task_context:
             opts["task_context"] = request.task_context
         if request.llm_prefilter is not None:
@@ -272,12 +276,32 @@ async def memory_put(
     (else 403); if they didn't, default to their first org-membership.
     """
     try:
+        # #252: scope_key — typed sub-bucket within the workspace. REQUIRED
+        # for paper/agent_result (so a Recherche search can stay inside one
+        # project), optional otherwise. FAIL-loud — no silent default.
+        from src.memory.schema import is_valid_scope_key
+        scope = (request.scope or "").strip() or None
+        if scope is not None and not is_valid_scope_key(scope):
+            raise HTTPException(
+                status_code=422,
+                detail=f"scope must be type-prefixed (e.g. 'project:<id>', 'repo:<url>') — got {scope!r}",
+            )
+        if request.source_type in ("paper", "agent_result") and scope is None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"scope is required for source_type={request.source_type!r} "
+                       "(e.g. 'project:<projekt_id>') — refusing to ingest unscoped "
+                       "research content into a workspace-global bucket",
+            )
+
         source_dict: dict[str, Any] = {
             "source_id": request.source_id,
             "source_type": request.source_type,
             "repo": request.repo,
             "path": request.path,
         }
+        if scope is not None:
+            source_dict["scope_key"] = scope
         if request.visibility:
             source_dict["visibility"] = request.visibility
         if request.visibility == "org":

--- a/src/api/routes/models.py
+++ b/src/api/routes/models.py
@@ -74,6 +74,11 @@ class MemorySearchRequest(BaseModel):
     # variable RERANKER_VERSION decides; default is v1 so behaviour
     # never changes silently.
     reranker_version: str | None = None
+    # WHY(#252): restrict the search to one logical sub-bucket of the
+    # workspace — e.g. "project:<uuid>" so a Recherche search only sees that
+    # project's papers, never another project's (same workspace). Always
+    # type-prefixed; None = search the whole workspace.
+    scope: str | None = None
     # WHY(2026-05-10 multi-cat prompt-decomp): wenn der hook prompt-
     # kategorien via mistral:7b-instruct extrahiert hat, kann er sie als
     # hint mitsenden. Chunks deren category_labels mit diesen kategorien
@@ -99,6 +104,12 @@ class MemoryPutRequest(BaseModel):
     # 'org' requires membership in org_id (or first org_id if not given).
     visibility: str | None = None
     org_id: str | None = None
+    # WHY(#252): typed logical sub-bucket within the workspace — e.g.
+    # "project:<uuid>" for a Recherche project's papers. REQUIRED when
+    # source_type in (paper, agent_result) — memory_put returns 422 without
+    # it (no silent default). Optional/None for other source_types
+    # (= workspace-global). Always type-prefixed: "<type>:<id>".
+    scope: str | None = None
 
 
 class LogEvent(BaseModel):

--- a/src/memory/retrieval.py
+++ b/src/memory/retrieval.py
@@ -72,6 +72,7 @@ def _scope_filter(
     org_id: str | None = None,
     org_ids: tuple[str, ...] | list[str] | None = None,
     user_id: str | None = None,
+    scope_key: str | None = None,
 ) -> list[str]:
     """Return chunk_ids of active chunks matching hard scope filters.
 
@@ -125,6 +126,12 @@ def _scope_filter(
     if source_type:
         query += " AND s.source_type = ?"
         params.append(source_type)
+    if scope_key:
+        # #252: restrict to one logical sub-bucket of the workspace (e.g.
+        # "project:<id>") — a Recherche search only sees that project's
+        # papers, never another project's chunks in the same workspace.
+        query += " AND s.scope_key = ?"
+        params.append(scope_key)
 
     rows = conn.execute(query, params).fetchall()
 
@@ -672,6 +679,7 @@ def search(
     else:
         org_ids = None
     user_id: str | None = opts.get("user_id")
+    scope_key: str | None = opts.get("scope_key")  # #252: e.g. "project:<id>"
 
     # Query-Cache check — hit: clone records, repopulate text on demand.
     # Bug history: cache used to store only (chunk_id, score_final), so
@@ -699,7 +707,7 @@ def search(
     candidate_ids = _scope_filter(
         conn, repo=repo, categories=categories, source_type=source_type,
         workspace_id=workspace_id, org_id=org_id, org_ids=org_ids,
-        user_id=user_id,
+        user_id=user_id, scope_key=scope_key,
     )
     if not candidate_ids:
         # Tell callers WHY the result is empty: scope filter excluded

--- a/src/memory/schema.py
+++ b/src/memory/schema.py
@@ -10,9 +10,22 @@ Example:     memory:repo:auth:owner-name-src-user_service.py:9f3a1b2c
 from __future__ import annotations
 
 import hashlib
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from urllib.parse import urlparse
+
+# WHY(#252): scope_key is ALWAYS type-prefixed. Allowed types — extend
+# deliberately, never accept a bare/untyped value (that's how `repo` got
+# overloaded). `project:` = a Recherche project's papers; `repo:` = a code
+# repo; `campaign:` reserved (gaming layer maps 1:1 to project for now, so
+# unused — listed so the validator doesn't need touching later).
+SCOPE_KEY_RE = re.compile(r"^(repo|project|campaign):.+$")
+
+
+def is_valid_scope_key(value: str | None) -> bool:
+    """True iff value is None (workspace-global) or a typed `<type>:<id>` key."""
+    return value is None or bool(value and SCOPE_KEY_RE.match(value))
 
 
 def canonicalize_url(url: str) -> str:
@@ -69,6 +82,12 @@ class Source:
                                   # UUID. Same value across all workspaces of
                                   # the same human user; required when
                                   # visibility="user".
+    # WHY(#252): typed logical sub-bucket WITHIN a workspace — e.g.
+    # "project:<uuid>" for a Recherche project's papers, "repo:<url>" for a
+    # code repo. NULL = workspace-global. Required for source_type in
+    # (paper, agent_result) — enforced at the /ingest boundary. Never store
+    # an untyped value here; see SCOPE_KEY_RE.
+    scope_key: str | None = None
 
     @staticmethod
     def make_id(repo: str, path: str) -> str:
@@ -93,6 +112,7 @@ class Source:
             "visibility": self.visibility,
             "org_id": self.org_id,
             "user_id": self.user_id,
+            "scope_key": self.scope_key,
         }
 
     @classmethod
@@ -100,6 +120,7 @@ class Source:
         data = {k: d.get(k, "") for k in cls.__dataclass_fields__}
         data["org_id"] = d.get("org_id")  # None when absent or NULL
         data["user_id"] = d.get("user_id")
+        data["scope_key"] = d.get("scope_key")  # None when absent or NULL
         return cls(**data)
 
 

--- a/src/memory/store.py
+++ b/src/memory/store.py
@@ -77,7 +77,9 @@ def kv_invalidate_by_ids(chunk_ids: list[str]) -> None:
 # DB init
 # ---------------------------------------------------------------------------
 
-CURRENT_SCHEMA_VERSION = 1
+# Bump when _init_schema gains new DDL/migrations so existing DBs re-run it.
+#   v2 (#252): sources.scope_key column + index.
+CURRENT_SCHEMA_VERSION = 2
 
 
 def _now_iso() -> str:
@@ -132,6 +134,10 @@ def _migrate_schema(conn: DBAdapter) -> None:
             # so all sessions of the same user can see each other's memory
             # without falling back to 'public'.
             ("user_id", "TEXT DEFAULT NULL"),
+            # scope_key (#252): typed logical sub-bucket within a workspace —
+            # "project:<uuid>" / "repo:<url>" / NULL=workspace-global. Existing
+            # rows get NULL (they were workspace-global before this concept).
+            ("scope_key", "TEXT DEFAULT NULL"),
         ],
         "chunks": [
             ("workspace_id", "TEXT NOT NULL DEFAULT 'default'"),
@@ -240,7 +246,8 @@ def _migrate_visibility_check(conn: DBAdapter) -> None:
                 workspace_id    TEXT NOT NULL DEFAULT 'default',
                 visibility      TEXT NOT NULL DEFAULT 'private' CHECK(visibility IN ('private', 'org', 'public', 'user')),
                 org_id          TEXT DEFAULT NULL,
-                user_id         TEXT DEFAULT NULL
+                user_id         TEXT DEFAULT NULL,
+                scope_key       TEXT DEFAULT NULL
             );
         """)
         legacy_cols = conn.get_columns("sources_legacy_visibility")
@@ -289,7 +296,8 @@ def _init_schema(conn: DBAdapter) -> None:
             captured_at     TEXT NOT NULL,
             visibility      TEXT NOT NULL DEFAULT 'private' CHECK(visibility IN ('private', 'org', 'public', 'user')),
             org_id          TEXT DEFAULT NULL,
-            user_id         TEXT DEFAULT NULL
+            user_id         TEXT DEFAULT NULL,
+            scope_key       TEXT DEFAULT NULL
         );
 
         CREATE TABLE IF NOT EXISTS chunks (
@@ -517,6 +525,9 @@ def _init_schema(conn: DBAdapter) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_sources_workspace_id ON sources(workspace_id)"
     )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sources_scope_key ON sources(scope_key)"
+    )
 
     # System-Workspace seedet sich beim DB-init. Verwendet von Service-
     # Tokens (src/api/auth.py:37), post-deploy-ingest, conversation_watcher,
@@ -545,23 +556,24 @@ def _init_schema(conn: DBAdapter) -> None:
 def upsert_source(
     conn: DBAdapter, source: Source, workspace_id: str = "default",
     visibility: str | None = None, org_id: str | None = None,
-    user_id: str | None = None,
+    user_id: str | None = None, scope_key: str | None = None,
 ) -> None:
     """Insert/update a source row.
 
-    visibility/org_id/user_id default to the values on the Source dataclass
-    when not explicitly passed; this lets callers attach them at Source
-    construction time and have them flow all the way to the DB.
+    visibility/org_id/user_id/scope_key default to the values on the Source
+    dataclass when not explicitly passed; this lets callers attach them at
+    Source construction time and have them flow all the way to the DB.
     """
     eff_visibility = visibility if visibility is not None else source.visibility
     eff_org_id = org_id if org_id is not None else source.org_id
     eff_user_id = user_id if user_id is not None else source.user_id
+    eff_scope_key = scope_key if scope_key is not None else source.scope_key
     conn.execute(
         """
         INSERT INTO sources
             (source_id, source_type, repo, path, branch, "commit", content_hash,
-             captured_at, workspace_id, visibility, org_id, user_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             captured_at, workspace_id, visibility, org_id, user_id, scope_key)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(source_id) DO UPDATE SET
             source_type  = excluded.source_type,
             repo         = excluded.repo,
@@ -573,12 +585,13 @@ def upsert_source(
             workspace_id = excluded.workspace_id,
             visibility   = excluded.visibility,
             org_id       = excluded.org_id,
-            user_id      = excluded.user_id
+            user_id      = excluded.user_id,
+            scope_key    = excluded.scope_key
         """,
         (
             source.source_id, source.source_type, source.repo, source.path,
             source.branch, source.commit, source.content_hash, source.captured_at,
-            workspace_id, eff_visibility, eff_org_id, eff_user_id,
+            workspace_id, eff_visibility, eff_org_id, eff_user_id, eff_scope_key,
         ),
     )
     _maybe_commit(conn)

--- a/tests/test_scope_key.py
+++ b/tests/test_scope_key.py
@@ -1,0 +1,147 @@
+"""#252 — scope_key: typed logical sub-bucket within a workspace.
+
+A Recherche search scoped to project A must never see project B's papers
+(same workspace). Paper/agent_result ingests REQUIRE a scope (FAIL-loud,
+422 — no silent workspace-global default).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.memory.schema import Source, is_valid_scope_key
+from src.memory.store import (
+    CURRENT_SCHEMA_VERSION,
+    init_memory_db,
+    insert_chunk,
+    upsert_source,
+)
+from src.memory.retrieval import _scope_filter
+
+
+# ---------------------------------------------------------------------------
+# schema / validator
+# ---------------------------------------------------------------------------
+
+def test_schema_version_bumped_and_column_present(tmp_path: Path):
+    c = init_memory_db(tmp_path / "m.db")
+    assert CURRENT_SCHEMA_VERSION >= 2
+    assert "scope_key" in c.get_columns("sources")
+    assert c.execute("PRAGMA user_version").fetchone()[0] == CURRENT_SCHEMA_VERSION
+    c.close()
+
+
+@pytest.mark.parametrize("val,ok", [
+    ("project:abc-123", True),
+    ("repo:https://github.com/x/y", True),
+    ("campaign:42", True),
+    (None, True),                # None = workspace-global
+    ("abc", False),              # untyped
+    ("", False),
+    ("project:", False),         # type but no id
+    ("weird:thing", False),      # unknown type
+])
+def test_is_valid_scope_key(val, ok):
+    assert is_valid_scope_key(val) is ok
+
+
+def test_upsert_source_roundtrips_scope_key(tmp_path: Path):
+    c = init_memory_db(tmp_path / "m.db")
+    upsert_source(c, Source(source_id="paper:r1", source_type="agent_result",
+                            repo="", path="", scope_key="project:p1"),
+                  workspace_id="bene")
+    row = c.execute("SELECT scope_key FROM sources WHERE source_id='paper:r1'").fetchone()
+    assert row[0] == "project:p1"
+    c.close()
+
+
+# ---------------------------------------------------------------------------
+# retrieval isolation
+# ---------------------------------------------------------------------------
+
+def _seed_paper(conn, *, source_id, scope_key, chunk_id, text, ws="bene"):
+    upsert_source(conn, Source(source_id=source_id, source_type="agent_result",
+                               repo="", path="", scope_key=scope_key,
+                               content_hash="h:" + chunk_id), workspace_id=ws)
+    from src.memory.schema import Chunk
+    insert_chunk(conn, Chunk(chunk_id=chunk_id, source_id=source_id, text=text,
+                             text_hash="th:" + chunk_id), workspace_id=ws)
+
+
+def test_scope_filter_isolates_projects(tmp_path: Path):
+    c = init_memory_db(tmp_path / "m.db")
+    _seed_paper(c, source_id="paper:a", scope_key="project:p1", chunk_id="ck_a", text="alpha")
+    _seed_paper(c, source_id="paper:b", scope_key="project:p2", chunk_id="ck_b", text="beta")
+    _seed_paper(c, source_id="conv:x", scope_key=None,           chunk_id="ck_x", text="global")  # workspace-global
+    # ↑ conv:x is agent_result here for brevity but scope_key=None — fine for the filter test
+    c.commit()
+
+    only_p1 = set(_scope_filter(c, workspace_id="bene", user_id=None, scope_key="project:p1"))
+    assert only_p1 == {"ck_a"}, only_p1
+
+    only_p2 = set(_scope_filter(c, workspace_id="bene", user_id=None, scope_key="project:p2"))
+    assert only_p2 == {"ck_b"}, only_p2
+
+    # no scope_key → whole workspace
+    all_ws = set(_scope_filter(c, workspace_id="bene", user_id=None))
+    assert all_ws == {"ck_a", "ck_b", "ck_x"}, all_ws
+    c.close()
+
+
+# ---------------------------------------------------------------------------
+# /memory/put FAIL-loud
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+
+    from src.api import auth as auth_module
+    from src.api import server as srv
+
+    async def _fake_ws():
+        return "bene"
+
+    class _FakeInfo:
+        org_ids: list = []
+        sub = "1"
+
+    async def _fake_info():
+        return _FakeInfo()
+
+    srv.app.dependency_overrides[auth_module.get_workspace] = _fake_ws
+    srv.app.dependency_overrides[auth_module.get_token_info] = _fake_info
+    yield TestClient(srv.app)
+    srv.app.dependency_overrides.clear()
+
+
+def _put(client, **kw):
+    return client.post("/memory/put", json=kw, headers={"Authorization": "Bearer tst"})
+
+
+def test_memory_put_rejects_paper_without_scope(client):
+    r = _put(client, source_id="paper:x", source_type="paper", content="some text")
+    assert r.status_code == 422
+    assert "scope is required" in r.json()["detail"]
+
+
+def test_memory_put_rejects_untyped_scope(client):
+    r = _put(client, source_id="paper:x", source_type="agent_result", content="t", scope="not-prefixed")
+    assert r.status_code == 422
+    assert "type-prefixed" in r.json()["detail"]
+
+
+def test_memory_put_accepts_paper_with_scope(client):
+    with patch("src.api.routes.memory._run_ingest", return_value={"source_id": "paper:x", "state": "new",
+                                                                  "chunk_ids": [], "indexed": 0}):
+        r = _put(client, source_id="paper:x", source_type="agent_result", content="t", scope="project:p1")
+    assert r.status_code == 200, r.text
+
+
+def test_memory_put_repo_file_does_not_need_scope(client):
+    with patch("src.api.routes.memory._run_ingest", return_value={"source_id": "repo:x", "state": "new",
+                                                                  "chunk_ids": [], "indexed": 0}):
+        r = _put(client, source_id="repo:x:f.py", source_type="repo_file", content="code", repo="https://github.com/x/y", path="f.py")
+    assert r.status_code == 200, r.text


### PR DESCRIPTION
Part 1 of #252 (MayringCoder side). Part 2 = app.linn.games (`MayringSearchClient` sends `scope="project:{id}"` + `mayring:reingest-papers` backfill) — separate PR.

## Was

`sources.scope_key` (nullable, typed: `project:<uuid>` / `repo:<url>` / NULL=workspace-global) → eine Recherche-search kann auf ein Projekt scopen, sieht nie ein anderes Projekt im selben workspace.

- Schema-version 1→2 (existierende DBs re-runnen `_init_schema` → `ALTER TABLE sources ADD COLUMN scope_key` + index). `_migrate_visibility_check`-rebuild trägt's auch.
- `Source.scope_key` + `SCOPE_KEY_RE` + `is_valid_scope_key()`. Immer typ-präfixiert.
- `upsert_source` / `memory_service.run_ingest` reichen's durch.
- `MemoryPutRequest.scope` + `MemorySearchRequest.scope`.
- `memory_put`: validate format; **422 FAIL-loud** wenn `source_type in (paper, agent_result)` und kein scope (kein silent workspace-global default für research-content).
- `memory_search` → `retrieval.search` → `_scope_filter`: `AND s.scope_key = ?` wenn gegeben. Ohne scope: unverändert.

## Tests

15 in `tests/test_scope_key.py` (version-bump, validator, upsert-roundtrip, retrieval-isolation projekt A ⊅ projekt B, 422 für unscoped papers, repo_file braucht kein scope). 429/430 in den verwandten suites grün; die 1 failure (`test_v2_silent_fail_audit::test_no_silent_pass_in_api_pipeline` — flaggt ein bestehendes `except Exception: pass` in `mcp_memory_tools.py`) ist **pre-existing** (stash-and-rerun bestätigt) — separater bug, nicht von dieser PR.

## Deploy-koordination

Diese PR mergen+deployen → dann app.linn.games-PR (sonst werfen paper-ingests von app.linn.games 422 bis sie `scope` schicken — `DownloadPaperJob::mayringIngest` fängt das best-effort, kein job-crash, self-recovering beim re-ingest-command). Dann `mayring:reingest-papers --all` (Variante-2-backfill für die ~947 alt-papers ohne scope).

Closes #252 (zusammen mit der app.linn.games-PR-B).