### PR TITLE
Tenancy Phase A: 3-Werte-Visibility + Owner-Fallback

### DIFF
--- a/src/api/admin_backfill_chroma_visibility.py
+++ b/src/api/admin_backfill_chroma_visibility.py
@@ -1,0 +1,30 @@
+"""One-time, idempotent backfill: stamp visibility/org_id/user_id into the Chroma
+metadata of every existing chunk (Phase A). Reads the authoritative values from
+SQLite `sources`. Safe to re-run."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def backfill_visibility_metadata(conn: Any, collection: Any, batch: int = 500) -> int:
+    rows = conn.execute(
+        "SELECT c.chunk_id, s.visibility, s.org_id, s.user_id "
+        "FROM chunks c JOIN sources s ON c.source_id = s.source_id"
+    ).fetchall()
+    by_id = {}
+    for r in rows:
+        cid = r["chunk_id"] if hasattr(r, "keys") else r[0]
+        by_id[cid] = {
+            "visibility": (r["visibility"] if hasattr(r, "keys") else r[1]) or "private",
+            "org_id": (r["org_id"] if hasattr(r, "keys") else r[2]) or "",
+            "user_id": (r["user_id"] if hasattr(r, "keys") else r[3]) or "",
+        }
+    if not by_id:
+        return 0
+    ids = list(by_id.keys())
+    updated = 0
+    for i in range(0, len(ids), batch):
+        chunk_ids = ids[i:i + batch]
+        collection.update(ids=chunk_ids, metadatas=[by_id[c] for c in chunk_ids])
+        updated += len(chunk_ids)
+    return updated

--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -486,14 +486,18 @@ async def memory_put(
             # DB-level default (NULL), which causes chunks to be invisible to
             # the scope_filter on reads.  personal → private (user_id-scoped),
             # org-artig → org (org_id=workspace_id).
-            from mayring_core.identity.workspace_resolver import workspace_kind
+            from mayring_core.identity.workspace_resolver import workspace_kind, workspace_owner
             _kind = workspace_kind(_get_conn(), workspace_id)
             if _kind in ("team", "project", "organization"):
                 source_dict["visibility"] = "org"
                 source_dict["org_id"] = workspace_id
             else:  # 'user' / 'system' / unknown → personal default
                 source_dict["visibility"] = "private"
-                source_dict["user_id"] = info.sub
+                # WHY(tenancy-T7, owner-fallback): user-agnostic service ingests
+                # (Service-Token, info.sub=None — repo-events, ambient, watcher)
+                # would write private+user_id=NULL → invisible to everyone.  Fall
+                # back to the workspace owner so the chunk is retrievable.
+                source_dict["user_id"] = info.sub or workspace_owner(_get_conn(), workspace_id)
         if request.visibility == "org":
             org_member_ids = set(info.org_ids)
             if request.org_id:

--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -498,6 +498,13 @@ async def memory_put(
                 # would write private+user_id=NULL → invisible to everyone.  Fall
                 # back to the workspace owner so the chunk is retrievable.
                 source_dict["user_id"] = info.sub or workspace_owner(_get_conn(), workspace_id)
+        if request.visibility == "private":
+            # WHY(tenancy phase A): explicit visibility='private' must stamp
+            # user_id so _scope_filter's `s.visibility='private' AND s.user_id=?`
+            # can match on cross-device reads.  Without this stamp the chunk is
+            # visible to nobody.  Fall back to workspace owner for service tokens.
+            from mayring_core.identity.workspace_resolver import workspace_owner
+            source_dict["user_id"] = info.sub or workspace_owner(_get_conn(), workspace_id)
         if request.visibility == "org":
             org_member_ids = set(info.org_ids)
             if request.org_id:

--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -459,7 +459,10 @@ async def memory_put(
         # knows private/org/public/user — silently dropped the chunk for EVERYONE
         # incl. the owner (a write-accepted, read-invisible black hole). Reject
         # unknown values loudly instead. Note: 'private' IS workspace-scoped.
-        _VALID_VISIBILITY = ("private", "org", "public", "user")
+        # WHY(tenancy phase A T6): 'user' was a legacy value — scope_filter only
+        # handles private/org/public so 'user' wrote-accepted but read-invisible.
+        # Shrink to the 3 canonical values so the allowlists on write and read match.
+        _VALID_VISIBILITY = ("private", "org", "public")
         if request.visibility is not None and request.visibility not in _VALID_VISIBILITY:
             raise HTTPException(
                 status_code=422,
@@ -477,6 +480,20 @@ async def memory_put(
             source_dict["scope_key"] = scope
         if request.visibility:
             source_dict["visibility"] = request.visibility
+        else:
+            # WHY(tenancy phase A): when caller omits visibility, derive the
+            # sensible default from workspace kind rather than relying on the
+            # DB-level default (NULL), which causes chunks to be invisible to
+            # the scope_filter on reads.  personal → private (user_id-scoped),
+            # org-artig → org (org_id=workspace_id).
+            from mayring_core.identity.workspace_resolver import workspace_kind
+            _kind = workspace_kind(_get_conn(), workspace_id)
+            if _kind in ("team", "project", "organization"):
+                source_dict["visibility"] = "org"
+                source_dict["org_id"] = workspace_id
+            else:  # 'user' / 'system' / unknown → personal default
+                source_dict["visibility"] = "private"
+                source_dict["user_id"] = info.sub
         if request.visibility == "org":
             org_member_ids = set(info.org_ids)
             if request.org_id:
@@ -501,14 +518,6 @@ async def memory_put(
                     first_org, info.sub,
                 )
                 source_dict["org_id"] = first_org
-        elif request.visibility == "user":
-            # WHY(fix-user-visibility-rest): _scope_filter matches
-            # `s.visibility='user' AND s.user_id=?` — without stamping
-            # user_id here the column stays NULL and the filter never
-            # matches, so 'user' cross-device visibility is fully broken
-            # for REST callers. MCP path handles this via
-            # resolve_write_visibility; mirror it here.
-            source_dict["user_id"] = info.sub
         elif request.org_id:
             # Honor explicit org_id even outside visibility=org (e.g. when
             # caller wants to stamp the source for later promotion).
@@ -961,12 +970,14 @@ async def patch_source_visibility(
     WHY(L8, v2-workspaces): without ownership-check this endpoint allowed
     cross-tenant vandalism — any authed caller could flip visibility on
     another user's sources. V2 enforces: owner (same workspace OR same sub)
-    or admin (scope * / admin). 'user' added to the visibility whitelist.
+    or admin (scope * / admin).
+    WHY(tenancy phase A T6): allowlist shrunk to 3 canonical values matching
+    what scope_filter reads — 'user' was write-accepted but read-invisible.
     """
-    if request.visibility not in ("private", "org", "public", "user"):
+    if request.visibility not in ("private", "org", "public"):
         raise HTTPException(
             status_code=400,
-            detail="visibility must be private|org|public|user",
+            detail="visibility must be private|org|public",
         )
     conn = _get_conn()
     row = conn.execute(
@@ -994,6 +1005,28 @@ async def patch_source_visibility(
         (request.visibility, request.org_id, source_id),
     )
     conn.commit()
+
+    # WHY(tenancy phase A): SQLite is SoT for visibility, but vector search
+    # filters in Chroma — without this sync a freshly patched source stays
+    # invisible on the vector path until the next full reindex.
+    try:
+        _cids = [
+            (rr["chunk_id"] if hasattr(rr, "keys") else rr[0])
+            for rr in conn.execute(
+                "SELECT chunk_id FROM chunks WHERE source_id = ?", (source_id,)
+            ).fetchall()
+        ]
+        if _cids:
+            _get_chroma().update(
+                ids=_cids,
+                metadatas=[
+                    {"visibility": request.visibility, "org_id": request.org_id or ""}
+                    for _ in _cids
+                ],
+            )
+    except Exception as _e:
+        _log.warning("chroma visibility-sync failed for %s: %s", source_id, _e)
+
     return {"source_id": source_id, "visibility": request.visibility, "org_id": request.org_id}
 
 
@@ -1045,6 +1078,27 @@ async def share_source(
         (new_vis, new_org, source_id),
     )
     conn.commit()
+
+    # WHY(tenancy phase A): keep Chroma metadata in sync so vector searches
+    # immediately reflect the new visibility without a full reindex.
+    try:
+        _cids = [
+            (rr["chunk_id"] if hasattr(rr, "keys") else rr[0])
+            for rr in conn.execute(
+                "SELECT chunk_id FROM chunks WHERE source_id = ?", (source_id,)
+            ).fetchall()
+        ]
+        if _cids:
+            _get_chroma().update(
+                ids=_cids,
+                metadatas=[
+                    {"visibility": new_vis, "org_id": new_org or ""}
+                    for _ in _cids
+                ],
+            )
+    except Exception as _e:
+        _log.warning("chroma visibility-sync failed for %s: %s", source_id, _e)
+
     return {"source_id": source_id, "visibility": new_vis, "org_id": new_org, "shared": True}
 
 

--- a/src/api/routes/sync.py
+++ b/src/api/routes/sync.py
@@ -63,11 +63,12 @@ def get_changes(
 ) -> MemorySyncResponse:
     """Stream chunks created after `since`, scoped by V2 visibility rules.
 
-    WHY(L6, v2-workspaces): the previous query dropped 'org' and 'user'
+    WHY(L6, v2-workspaces): the previous query dropped 'org' and 'private'
     visibility silently — Laravel + Hook clients re-syncing missed every
     chunk shared cross-workspace via membership or same-user. The filter
-    must mirror retrieval._scope_filter: public + own private + own user
-    + chunks of orgs the caller is a member of.
+    mirrors retrieval._scope_filter: public + private (user_id-scoped, any
+    workspace) + chunks of orgs the caller is a member of.
+    'user' (old name) is gone; 'private' is the canonical 3-value model value.
     """
     db = _get_conn()
     _ensure_visibility_column(db)
@@ -92,14 +93,13 @@ def get_changes(
         WHERE c.created_at > ?
           AND (
               s.visibility = 'public'
-              OR (s.visibility = 'private' AND c.workspace_id = ?)
-              OR (s.visibility = 'user' AND s.user_id = ?)
+              OR (s.visibility = 'private' AND s.user_id = ?)
               {org_clause}
           )
         ORDER BY c.created_at ASC
         LIMIT ?
     """
-    params = [since, workspace_id, info.sub, *org_params, limit]
+    params = [since, info.sub, *org_params, limit]
 
     try:
         rows = db.execute(sql, tuple(params)).fetchall()

--- a/tests/test_backfill_chroma_visibility.py
+++ b/tests/test_backfill_chroma_visibility.py
@@ -1,0 +1,122 @@
+"""Idempotenter Backfill: visibility/org_id/user_id in Chroma-Metadata stempeln.
+
+Tenancy Phase A — Task 2.
+"""
+from __future__ import annotations
+
+import pathlib
+import tempfile
+
+import pytest
+
+from mayring_core.memory import store
+from mayring_core.memory.schema import Chunk, Source
+from src.api.admin_backfill_chroma_visibility import backfill_visibility_metadata
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.meta: dict[str, dict] = {}
+
+    def update(self, ids: list[str], metadatas: list[dict]) -> None:
+        for cid, m in zip(ids, metadatas):
+            self.meta.setdefault(cid, {}).update(m)
+
+    def get(self, ids=None, **kwargs):
+        if ids is None:
+            ids = list(self.meta.keys())
+        return {"ids": ids, "metadatas": [self.meta.get(i, {}) for i in ids]}
+
+    def count(self) -> int:
+        return len(self.meta)
+
+
+@pytest.fixture()
+def db_with_chunk(tmp_path):
+    db_path = tmp_path / "memory.db"
+    conn = store.init_memory_db(db_path)
+    s = Source(
+        source_id="s:1",
+        source_type="doc",
+        repo="",
+        path="p",
+        visibility="org",
+        org_id="org-x",
+    )
+    store.upsert_source(conn, s, workspace_id="ws-1")
+    ch = Chunk(chunk_id="c1", source_id="s:1", text="t", text_hash="h1")
+    store.insert_chunk(conn, ch, workspace_id="ws-1")
+    return conn
+
+
+def test_backfill_stamps_visibility(db_with_chunk):
+    coll = _FakeCollection()
+    coll.meta["c1"] = {"workspace_id": "ws-1", "source_id": "s:1"}
+
+    updated = backfill_visibility_metadata(db_with_chunk, coll, batch=100)
+
+    assert updated == 1
+    assert coll.meta["c1"]["visibility"] == "org"
+    assert coll.meta["c1"]["org_id"] == "org-x"
+
+
+def test_backfill_idempotent(db_with_chunk):
+    """Re-running backfill must not raise and must return same count."""
+    coll = _FakeCollection()
+    coll.meta["c1"] = {"workspace_id": "ws-1", "source_id": "s:1"}
+
+    first = backfill_visibility_metadata(db_with_chunk, coll, batch=100)
+    second = backfill_visibility_metadata(db_with_chunk, coll, batch=100)
+
+    assert first == second == 1
+    assert coll.meta["c1"]["visibility"] == "org"
+
+
+def test_backfill_empty_db(tmp_path):
+    db_path = tmp_path / "empty.db"
+    conn = store.init_memory_db(db_path)
+    coll = _FakeCollection()
+
+    updated = backfill_visibility_metadata(conn, coll)
+
+    assert updated == 0
+
+
+def test_backfill_batching(tmp_path):
+    """Batch splitting: 3 chunks mit batch=2 → 2 update-Aufrufe, alle gestempelt."""
+    db_path = tmp_path / "batch.db"
+    conn = store.init_memory_db(db_path)
+    s = Source(
+        source_id="s:1",
+        source_type="doc",
+        repo="",
+        path="p",
+        visibility="public",
+        org_id=None,
+    )
+    store.upsert_source(conn, s, workspace_id="ws-1")
+    for i in range(3):
+        ch = Chunk(chunk_id=f"c{i}", source_id="s:1", text=f"t{i}", text_hash=f"h{i}")
+        store.insert_chunk(conn, ch, workspace_id="ws-1")
+
+    update_calls: list[list[str]] = []
+    original_update = _FakeCollection.update
+
+    coll = _FakeCollection()
+    for i in range(3):
+        coll.meta[f"c{i}"] = {"workspace_id": "ws-1"}
+
+    def _tracking_update(self, ids, metadatas):
+        update_calls.append(list(ids))
+        original_update(self, ids, metadatas)
+
+    _FakeCollection.update = _tracking_update  # type: ignore[method-assign]
+    try:
+        updated = backfill_visibility_metadata(conn, coll, batch=2)
+    finally:
+        _FakeCollection.update = original_update  # type: ignore[method-assign]
+
+    assert updated == 3
+    assert len(update_calls) == 2
+    for i in range(3):
+        assert coll.meta[f"c{i}"]["visibility"] == "public"

--- a/tests/test_dashboard_endpoints.py
+++ b/tests/test_dashboard_endpoints.py
@@ -51,9 +51,9 @@ def seeded_db(tmp_path, monkeypatch) -> sqlite3.Connection:
     )
     conn.execute(
         "INSERT INTO sources (source_id, source_type, repo, path, captured_at, "
-        "                     workspace_id, visibility) "
-        "VALUES (?,?,?,?,?,?,?)",
-        ("repo:x:foo.py", "repo_file", "x", "foo.py", now, "user-2", "user"),
+        "                     workspace_id, visibility, user_id) "
+        "VALUES (?,?,?,?,?,?,?,?)",
+        ("repo:x:foo.py", "repo_file", "x", "foo.py", now, "user-2", "private", "user-2"),
     )
     conn.execute(
         "INSERT INTO chunks (chunk_id, source_id, text, text_hash, created_at, "

--- a/tests/test_ingest_default_visibility.py
+++ b/tests/test_ingest_default_visibility.py
@@ -1,0 +1,166 @@
+"""Task 9 — Ingest-Default nach Workspace-Typ.
+
+When visibility is omitted on /memory/put, the route must derive it from the
+workspace kind: personal (kind='user') → private + user_id stamp,
+org-artig (kind IN ('team','project','organization')) → org + org_id stamp.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — mirror pattern from test_scope_key.py
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def client_personal_ws():
+    """Personal (kind='user') workspace — expects visibility='private' default."""
+    from fastapi.testclient import TestClient
+    from src.api import auth as auth_module
+    from src.api import server as srv
+
+    async def _fake_ws():
+        return "bene"
+
+    class _FakeInfo:
+        org_ids: list = []
+        sub = "1"
+        scopes: list = []
+        workspace_id = "bene"
+
+        def membership_name(self, _org_id):  # noqa: D102
+            return ""
+
+    async def _fake_info():
+        return _FakeInfo()
+
+    srv.app.dependency_overrides[auth_module.get_workspace] = _fake_ws
+    srv.app.dependency_overrides[auth_module.get_token_info] = _fake_info
+    yield TestClient(srv.app)
+    srv.app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client_team_ws():
+    """Org-artig (kind='team') workspace — expects visibility='org' default."""
+    from fastapi.testclient import TestClient
+    from src.api import auth as auth_module
+    from src.api import server as srv
+
+    _ORG_ID = "org-team-001"
+
+    async def _fake_ws():
+        return _ORG_ID
+
+    class _FakeInfo:
+        org_ids: list = [_ORG_ID]
+        sub = "2"
+        scopes: list = []
+        workspace_id = _ORG_ID
+
+        def membership_name(self, _org_id):  # noqa: D102
+            return ""
+
+    async def _fake_info():
+        return _FakeInfo()
+
+    srv.app.dependency_overrides[auth_module.get_workspace] = _fake_ws
+    srv.app.dependency_overrides[auth_module.get_token_info] = _fake_info
+    yield TestClient(srv.app)
+    srv.app.dependency_overrides.clear()
+
+
+_INGEST_OK = {"source_id": "note:x", "state": "new", "chunk_ids": [], "indexed": 0}
+
+
+# ---------------------------------------------------------------------------
+# Task 9: personal workspace → private
+# ---------------------------------------------------------------------------
+
+def test_personal_ws_defaults_to_private(client_personal_ws):
+    """No visibility in body → route stamps 'private' + user_id for personal WS."""
+    captured: dict = {}
+
+    def _fake_ingest(source_dict, *args, **kwargs):
+        captured.update(source_dict)
+        return _INGEST_OK
+
+    with (
+        patch("src.api.routes.memory._run_ingest", side_effect=_fake_ingest),
+        patch(
+            "mayring_core.identity.workspace_resolver.workspace_kind",
+            return_value="user",
+        ),
+    ):
+        r = client_personal_ws.post(
+            "/memory/put",
+            json={"source_id": "note:x", "source_type": "note", "content": "hello"},
+            headers={"Authorization": "Bearer tst"},
+        )
+
+    assert r.status_code == 200, r.text
+    assert captured.get("visibility") == "private", captured
+    assert captured.get("user_id") == "1", captured
+
+
+# ---------------------------------------------------------------------------
+# Task 9: team workspace → org
+# ---------------------------------------------------------------------------
+
+def test_team_ws_defaults_to_org(client_team_ws):
+    """No visibility in body → route stamps 'org' + org_id=workspace_id for team WS."""
+    captured: dict = {}
+
+    def _fake_ingest(source_dict, *args, **kwargs):
+        captured.update(source_dict)
+        return _INGEST_OK
+
+    with (
+        patch("src.api.routes.memory._run_ingest", side_effect=_fake_ingest),
+        patch(
+            "mayring_core.identity.workspace_resolver.workspace_kind",
+            return_value="team",
+        ),
+    ):
+        r = client_team_ws.post(
+            "/memory/put",
+            json={"source_id": "note:y", "source_type": "note", "content": "team note"},
+            headers={"Authorization": "Bearer tst"},
+        )
+
+    assert r.status_code == 200, r.text
+    assert captured.get("visibility") == "org", captured
+    assert captured.get("org_id") == "org-team-001", captured
+
+
+# ---------------------------------------------------------------------------
+# Task 9: explicit visibility is preserved, not overwritten
+# ---------------------------------------------------------------------------
+
+def test_explicit_visibility_not_overwritten(client_personal_ws):
+    """Explicit visibility='public' must pass through unchanged."""
+    captured: dict = {}
+
+    def _fake_ingest(source_dict, *args, **kwargs):
+        captured.update(source_dict)
+        return _INGEST_OK
+
+    with (
+        patch("src.api.routes.memory._run_ingest", side_effect=_fake_ingest),
+        patch(
+            "mayring_core.identity.workspace_resolver.workspace_kind",
+            return_value="user",
+        ),
+    ):
+        r = client_personal_ws.post(
+            "/memory/put",
+            json={"source_id": "note:z", "source_type": "note", "content": "t",
+                  "visibility": "public"},
+            headers={"Authorization": "Bearer tst"},
+        )
+
+    assert r.status_code == 200, r.text
+    assert captured.get("visibility") == "public", captured

--- a/tests/test_ingest_default_visibility.py
+++ b/tests/test_ingest_default_visibility.py
@@ -137,6 +137,97 @@ def test_team_ws_defaults_to_org(client_team_ws):
 
 
 # ---------------------------------------------------------------------------
+# Task 7: owner-fallback when info.sub is None (Service-Token ingests)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def client_service_token_personal_ws():
+    """Personal (kind='user') workspace, but info.sub=None (Service-Token caller)."""
+    from fastapi.testclient import TestClient
+    from src.api import auth as auth_module
+    from src.api import server as srv
+
+    async def _fake_ws():
+        return "bene"
+
+    class _FakeInfoNoSub:
+        org_ids: list = []
+        sub = None  # Service-Token: no user subject
+        scopes: list = ["*"]
+        workspace_id = "bene"
+
+        def membership_name(self, _org_id):  # noqa: D102
+            return ""
+
+    async def _fake_info():
+        return _FakeInfoNoSub()
+
+    srv.app.dependency_overrides[auth_module.get_workspace] = _fake_ws
+    srv.app.dependency_overrides[auth_module.get_token_info] = _fake_info
+    yield TestClient(srv.app)
+    srv.app.dependency_overrides.clear()
+
+
+def test_service_token_personal_ws_uses_owner_fallback(client_service_token_personal_ws, monkeypatch):
+    """No sub on Service-Token + personal-WS → user_id falls back to workspace owner.
+
+    MAYRING_PERSONAL_OWNERS='{"bene":"owner-1"}' → user_id must be "owner-1".
+    """
+    captured: dict = {}
+
+    def _fake_ingest(source_dict, *args, **kwargs):
+        captured.update(source_dict)
+        return _INGEST_OK
+
+    monkeypatch.setenv("MAYRING_PERSONAL_OWNERS", '{"bene":"owner-1"}')
+
+    with (
+        patch("src.api.routes.memory._run_ingest", side_effect=_fake_ingest),
+        patch(
+            "mayring_core.identity.workspace_resolver.workspace_kind",
+            return_value="user",
+        ),
+    ):
+        r = client_service_token_personal_ws.post(
+            "/memory/put",
+            json={"source_id": "note:svc", "source_type": "note", "content": "ambient capture"},
+            headers={"Authorization": "Bearer svc-token"},
+        )
+
+    assert r.status_code == 200, r.text
+    assert captured.get("visibility") == "private", captured
+    assert captured.get("user_id") == "owner-1", f"expected owner-1, got {captured.get('user_id')!r}"
+
+
+def test_service_token_no_owner_map_user_id_is_none(client_service_token_personal_ws, monkeypatch):
+    """Service-Token + personal-WS + no MAYRING_PERSONAL_OWNERS → user_id=None (best-effort)."""
+    captured: dict = {}
+
+    def _fake_ingest(source_dict, *args, **kwargs):
+        captured.update(source_dict)
+        return _INGEST_OK
+
+    monkeypatch.delenv("MAYRING_PERSONAL_OWNERS", raising=False)
+
+    with (
+        patch("src.api.routes.memory._run_ingest", side_effect=_fake_ingest),
+        patch(
+            "mayring_core.identity.workspace_resolver.workspace_kind",
+            return_value="user",
+        ),
+    ):
+        r = client_service_token_personal_ws.post(
+            "/memory/put",
+            json={"source_id": "note:svc2", "source_type": "note", "content": "ambient capture"},
+            headers={"Authorization": "Bearer svc-token"},
+        )
+
+    assert r.status_code == 200, r.text
+    assert captured.get("visibility") == "private", captured
+    assert captured.get("user_id") is None, captured
+
+
+# ---------------------------------------------------------------------------
 # Task 9: explicit visibility is preserved, not overwritten
 # ---------------------------------------------------------------------------
 

--- a/tests/test_memory_sync_endpoint.py
+++ b/tests/test_memory_sync_endpoint.py
@@ -52,8 +52,12 @@ def _seed_chunk(conn, chunk_id: str, source_id: str, workspace_id: str,
                 is_active: int = 1) -> None:
     from mayring_core.memory.store import upsert_source, insert_chunk
     from mayring_core.memory.schema import Source, Chunk
+    # WHY(tenancy phase A): visibility='private' is now user_id-scoped (not
+    # workspace-scoped). The /memory/changes caller stub has sub="0", so seed the
+    # source with user_id="0" — otherwise the private arm (s.user_id = caller_sub)
+    # never matches and the cross-device sync test sees nothing.
     upsert_source(conn, Source(source_id=source_id, source_type="note", repo="r", path="p"),
-                  workspace_id=workspace_id, visibility=visibility)
+                  workspace_id=workspace_id, visibility=visibility, user_id="0")
     conn.execute(
         """INSERT OR IGNORE INTO chunks
            (chunk_id, source_id, text, workspace_id, created_at, is_active, text_hash, dedup_key)

--- a/tests/test_multi_tenancy.py
+++ b/tests/test_multi_tenancy.py
@@ -151,12 +151,21 @@ class TestWorkspaceScopedDedup:
 # ---------------------------------------------------------------------------
 
 class TestScopeFilterWorkspaceIsolation:
+    # WHY(tenancy-T7 migration): 3-value visibility model — isolation is
+    # user_id-scoped for private chunks.  Each workspace-owner gets a distinct
+    # user_id so _scope_filter isolates correctly.  The isolation assertion is
+    # unchanged: user A cannot see user B's private chunks.
+    _USER_A = "u-ws-a"
+    _USER_B = "u-ws-b"
+
     def _setup_two_workspaces(self, conn):
-        """Insert one chunk in ws_a and one in ws_b, same repo."""
+        """Insert one private chunk per workspace, each owned by a distinct user."""
         src_a = _make_source("repo:owner/shared:a.py", repo="owner/shared")
         src_b = _make_source("repo:owner/shared:b.py", repo="owner/shared")
-        upsert_source(conn, src_a, workspace_id="ws_a")
-        upsert_source(conn, src_b, workspace_id="ws_b")
+        upsert_source(conn, src_a, workspace_id="ws_a",
+                      visibility="private", user_id=self._USER_A)
+        upsert_source(conn, src_b, workspace_id="ws_b",
+                      visibility="private", user_id=self._USER_B)
         insert_chunk(conn, _make_chunk(src_a.source_id, 0, text="workspace a content"), workspace_id="ws_a")
         insert_chunk(conn, _make_chunk(src_b.source_id, 0, text="workspace b content"), workspace_id="ws_b")
         return src_a, src_b
@@ -165,7 +174,7 @@ class TestScopeFilterWorkspaceIsolation:
         conn = init_memory_db(tmp_path / "m.db")
         src_a, src_b = self._setup_two_workspaces(conn)
 
-        ids_a = _scope_filter(conn, workspace_id="ws_a")
+        ids_a = _scope_filter(conn, workspace_id="ws_a", user_id=self._USER_A)
         chunk_a = Chunk.make_id(src_a.source_id, 0, "function")
         chunk_b = Chunk.make_id(src_b.source_id, 0, "function")
 
@@ -176,7 +185,7 @@ class TestScopeFilterWorkspaceIsolation:
         conn = init_memory_db(tmp_path / "m.db")
         src_a, src_b = self._setup_two_workspaces(conn)
 
-        ids_b = _scope_filter(conn, workspace_id="ws_b")
+        ids_b = _scope_filter(conn, workspace_id="ws_b", user_id=self._USER_B)
         chunk_a = Chunk.make_id(src_a.source_id, 0, "function")
         chunk_b = Chunk.make_id(src_b.source_id, 0, "function")
 
@@ -187,13 +196,14 @@ class TestScopeFilterWorkspaceIsolation:
         conn = init_memory_db(tmp_path / "m.db")
         self._setup_two_workspaces(conn)
 
-        all_ids = _scope_filter(conn)  # no workspace_id
+        all_ids = _scope_filter(conn)  # no workspace_id → no visibility filter
         assert len(all_ids) == 2
 
     def test_unknown_workspace_returns_empty(self, tmp_path: Path) -> None:
         conn = init_memory_db(tmp_path / "m.db")
         self._setup_two_workspaces(conn)
 
+        # workspace_id="ws_unknown" with no matching user_id → nothing visible
         ids = _scope_filter(conn, workspace_id="ws_unknown")
         assert ids == []
 

--- a/tests/test_pi_jobs.py
+++ b/tests/test_pi_jobs.py
@@ -274,11 +274,11 @@ def test_local_claim_ignores_cloud_jobs(db: Path) -> None:
 
 def test_claim_cloud_next_requires_capability(db: Path) -> None:
     pi_jobs.insert_cloud_job(
-        "needs-gpu", capability_required="local-gpu", db_path=db,
+        "needs-gpu", capability_required="local-gpu", workspace_id="ws-test", db_path=db,
     )
-    no_gpu = pi_jobs.claim_cloud_next("wkr_no", capabilities=["cpu"], db_path=db)
+    no_gpu = pi_jobs.claim_cloud_next("wkr_no", capabilities=["cpu"], workspace_id="ws-test", db_path=db)
     assert no_gpu is None
-    gpu = pi_jobs.claim_cloud_next("wkr_yes", capabilities=["local-gpu"], db_path=db)
+    gpu = pi_jobs.claim_cloud_next("wkr_yes", capabilities=["local-gpu"], workspace_id="ws-test", db_path=db)
     assert gpu is not None
     assert gpu.claimed_by == "wkr_yes"
     assert gpu.scope == "cloud"
@@ -286,18 +286,18 @@ def test_claim_cloud_next_requires_capability(db: Path) -> None:
 
 
 def test_claim_cloud_next_no_required_matches_any_worker(db: Path) -> None:
-    pi_jobs.insert_cloud_job("any", db_path=db)
-    j = pi_jobs.claim_cloud_next("wkr_any", capabilities=[], db_path=db)
+    pi_jobs.insert_cloud_job("any", workspace_id="ws-test", db_path=db)
+    j = pi_jobs.claim_cloud_next("wkr_any", capabilities=[], workspace_id="ws-test", db_path=db)
     assert j is not None and j.claimed_by == "wkr_any"
 
 
 def test_claim_cloud_next_returns_none_when_empty(db: Path) -> None:
-    assert pi_jobs.claim_cloud_next("wkr", db_path=db) is None
+    assert pi_jobs.claim_cloud_next("wkr", workspace_id="ws-test", db_path=db) is None
 
 
 def test_claim_cloud_next_atomic_under_concurrency(db: Path) -> None:
     pi_jobs.insert_cloud_job(
-        "only-one", capability_required="local-gpu", db_path=db,
+        "only-one", capability_required="local-gpu", workspace_id="ws-test", db_path=db,
     )
 
     import threading
@@ -307,7 +307,7 @@ def test_claim_cloud_next_atomic_under_concurrency(db: Path) -> None:
     def worker(wid: str) -> None:
         barrier.wait()
         results.append(
-            pi_jobs.claim_cloud_next(wid, capabilities=["local-gpu"], db_path=db)
+            pi_jobs.claim_cloud_next(wid, capabilities=["local-gpu"], workspace_id="ws-test", db_path=db)
         )
 
     threads = [

--- a/tests/test_scope_key.py
+++ b/tests/test_scope_key.py
@@ -61,9 +61,15 @@ def test_upsert_source_roundtrips_scope_key(tmp_path: Path):
 # retrieval isolation
 # ---------------------------------------------------------------------------
 
-def _seed_paper(conn, *, source_id, scope_key, chunk_id, text, ws="bene"):
+def _seed_paper(conn, *, source_id, scope_key, chunk_id, text, ws="bene",
+               user_id: str | None = None):
+    # WHY(tenancy-T7 migration): 3-value visibility model — seeds use 'private'
+    # with an explicit user_id so scope_filter can match them.  'public' is used
+    # when user_id is absent (scope_key-isolation test; no visibility assertion).
+    vis = "private" if user_id else "public"
     upsert_source(conn, Source(source_id=source_id, source_type="agent_result",
                                repo="", path="", scope_key=scope_key,
+                               visibility=vis, user_id=user_id,
                                content_hash="h:" + chunk_id), workspace_id=ws)
     from mayring_core.memory.schema import Chunk
     insert_chunk(conn, Chunk(chunk_id=chunk_id, source_id=source_id, text=text,
@@ -71,20 +77,26 @@ def _seed_paper(conn, *, source_id, scope_key, chunk_id, text, ws="bene"):
 
 
 def test_scope_filter_isolates_projects(tmp_path: Path):
+    """scope_key restricts results to the matching logical sub-bucket.
+
+    Chunks are seeded as public (no user_id needed) so _scope_filter returns them
+    regardless of caller identity — the assertion under test is scope_key isolation,
+    not visibility isolation (which is covered by test_scope_filter_visibility.py).
+    """
     c = init_memory_db(tmp_path / "m.db")
     _seed_paper(c, source_id="paper:a", scope_key="project:p1", chunk_id="ck_a", text="alpha")
     _seed_paper(c, source_id="paper:b", scope_key="project:p2", chunk_id="ck_b", text="beta")
-    _seed_paper(c, source_id="conv:x", scope_key=None,           chunk_id="ck_x", text="global")  # workspace-global
-    # ↑ conv:x is agent_result here for brevity but scope_key=None — fine for the filter test
+    _seed_paper(c, source_id="conv:x", scope_key=None,           chunk_id="ck_x", text="global")
     c.commit()
 
+    # scope_key="project:p1" → only ck_a; user_id=None is fine for public chunks
     only_p1 = set(_scope_filter(c, workspace_id="bene", user_id=None, scope_key="project:p1"))
     assert only_p1 == {"ck_a"}, only_p1
 
     only_p2 = set(_scope_filter(c, workspace_id="bene", user_id=None, scope_key="project:p2"))
     assert only_p2 == {"ck_b"}, only_p2
 
-    # no scope_key → whole workspace
+    # no scope_key → all public chunks in workspace
     all_ws = set(_scope_filter(c, workspace_id="bene", user_id=None))
     assert all_ws == {"ck_a", "ck_b", "ck_x"}, all_ws
     c.close()

--- a/tests/test_share_patch_chroma_sync.py
+++ b/tests/test_share_patch_chroma_sync.py
@@ -1,0 +1,178 @@
+"""Task 6 — Allowlist 3 Werte + share/PATCH syncen Chroma-Metadata.
+
+Allowlist: /memory/put AND PATCH /sources/{id}/visibility AND
+POST /sources/{id}/share must all reject visibility values outside
+{'private', 'org', 'public'}.  'user' and 'workspace' are legacy values
+that must produce 422/400.
+
+Chroma-Sync: after a PATCH or share, the chunk metadata in Chroma must be
+updated.  We verify that _get_chroma().update() is called with the correct
+new visibility — a lightweight mock instead of spinning up an actual Chroma
+instance.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    from src.api import auth as auth_module
+    from src.api import server as srv
+
+    async def _fake_ws():
+        return "bene"
+
+    class _FakeInfo:
+        org_ids: list = []
+        sub = "1"
+        scopes: list = []
+        workspace_id = "bene"
+
+        def membership_name(self, _org_id):
+            return ""
+
+    async def _fake_info():
+        return _FakeInfo()
+
+    srv.app.dependency_overrides[auth_module.get_workspace] = _fake_ws
+    srv.app.dependency_overrides[auth_module.get_token_info] = _fake_info
+    yield TestClient(srv.app)
+    srv.app.dependency_overrides.clear()
+
+
+def _put(client, **kw):
+    return client.post("/memory/put", json=kw, headers={"Authorization": "Bearer tst"})
+
+
+# ---------------------------------------------------------------------------
+# Task 6a: Allowlist on /memory/put — 'user' and 'workspace' must be 422
+# ---------------------------------------------------------------------------
+
+def test_put_rejects_user_visibility(client):
+    r = _put(client, source_id="note:a", source_type="note", content="t", visibility="user")
+    assert r.status_code == 422, r.text
+    assert "visibility must be one of" in r.json()["detail"]
+
+
+def test_put_rejects_workspace_visibility(client):
+    r = _put(client, source_id="note:b", source_type="note", content="t", visibility="workspace")
+    assert r.status_code == 422, r.text
+    assert "visibility must be one of" in r.json()["detail"]
+
+
+def test_put_accepts_private(client):
+    """'private' must still be accepted (personal default after T9)."""
+    with (
+        patch("src.api.routes.memory._run_ingest",
+              return_value={"source_id": "note:c", "state": "new",
+                            "chunk_ids": [], "indexed": 0}),
+        patch("mayring_core.identity.workspace_resolver.workspace_kind",
+              return_value="user"),
+    ):
+        r = _put(client, source_id="note:c", source_type="note", content="t",
+                 visibility="private")
+    assert r.status_code == 200, r.text
+
+
+def test_put_accepts_public(client):
+    with (
+        patch("src.api.routes.memory._run_ingest",
+              return_value={"source_id": "note:d", "state": "new",
+                            "chunk_ids": [], "indexed": 0}),
+        patch("mayring_core.identity.workspace_resolver.workspace_kind",
+              return_value="user"),
+    ):
+        r = _put(client, source_id="note:d", source_type="note", content="t",
+                 visibility="public")
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Task 6b: PATCH /sources/{id}/visibility — 'user' must be 400
+# ---------------------------------------------------------------------------
+
+def test_patch_rejects_user_visibility(client):
+    r = client.patch(
+        "/sources/note:x/visibility",
+        json={"visibility": "user"},
+        headers={"Authorization": "Bearer tst"},
+    )
+    assert r.status_code == 400, r.text
+    assert "visibility must be" in r.json()["detail"]
+
+
+def test_patch_rejects_workspace_visibility(client):
+    r = client.patch(
+        "/sources/note:x/visibility",
+        json={"visibility": "workspace"},
+        headers={"Authorization": "Bearer tst"},
+    )
+    assert r.status_code == 400, r.text
+
+
+# ---------------------------------------------------------------------------
+# Task 6c: PATCH syncs Chroma metadata (mocked Chroma + DB row)
+# ---------------------------------------------------------------------------
+
+def _make_mock_conn(*, src_ws="bene", src_user="1", chunk_ids=("ck_1", "ck_2")):
+    """Build a minimal mock DB connection for the PATCH path."""
+    conn = MagicMock()
+
+    def _execute(sql, params=()):
+        result = MagicMock()
+        if "SELECT workspace_id" in sql:
+            row = MagicMock()
+            row.__iter__ = lambda self: iter([src_ws, src_user])
+            row.keys = lambda: ["workspace_id", "user_id"]
+            row.__getitem__ = lambda self, k: (src_ws if k in (0, "workspace_id") else src_user)
+            result.fetchone.return_value = row
+        elif "SELECT chunk_id FROM chunks" in sql:
+            rows = []
+            for cid in chunk_ids:
+                r = MagicMock()
+                r.__getitem__ = lambda self, k, _cid=cid: _cid
+                r.keys = lambda: ["chunk_id"]
+                rows.append(r)
+            result.fetchall.return_value = rows
+        else:
+            result.fetchone.return_value = None
+            result.fetchall.return_value = []
+        return result
+
+    conn.execute.side_effect = _execute
+    return conn
+
+
+def test_patch_syncs_chroma_metadata(client):
+    """After PATCH, Chroma.update() must be called with the new visibility."""
+    mock_conn = _make_mock_conn()
+    mock_chroma = MagicMock()
+
+    with (
+        patch("src.api.routes.memory._get_conn", return_value=mock_conn),
+        patch("src.api.routes.memory._get_chroma", return_value=mock_chroma),
+    ):
+        r = client.patch(
+            "/sources/note:x/visibility",
+            json={"visibility": "public"},
+            headers={"Authorization": "Bearer tst"},
+        )
+
+    assert r.status_code == 200, r.text
+    mock_chroma.update.assert_called_once()
+    call_kwargs = mock_chroma.update.call_args
+    ids_arg = call_kwargs.kwargs.get("ids") or call_kwargs.args[0] if call_kwargs.args else None
+    metadatas_arg = (
+        call_kwargs.kwargs.get("metadatas")
+        or (call_kwargs.args[1] if len(call_kwargs.args or []) > 1 else None)
+    )
+    assert metadatas_arg is not None, "chroma.update must pass metadatas"
+    assert all(m["visibility"] == "public" for m in metadatas_arg)

--- a/tests/test_shared_memory.py
+++ b/tests/test_shared_memory.py
@@ -75,10 +75,11 @@ def test_token_info_org_id_defaults_to_none():
 # ---------------------------------------------------------------------------
 
 def _insert_chunk(db: DBAdapter, source_id: str, workspace_id: str,
-                  visibility: str = "private", org_id: str | None = None) -> str:
+                  visibility: str = "private", org_id: str | None = None,
+                  user_id: str | None = None) -> str:
     src = Source(source_id=source_id, source_type="note", repo="r", path="p")
     upsert_source(db, src, workspace_id=workspace_id,
-                  visibility=visibility, org_id=org_id)
+                  visibility=visibility, org_id=org_id, user_id=user_id)
     chunk_id = f"chk-{source_id}"
     now = datetime.datetime.utcnow().isoformat()
     chunk = Chunk(
@@ -114,13 +115,16 @@ def test_org_chunk_hidden_when_org_differs():
     assert cid not in results
 
 
-def test_private_chunk_workspace_isolated():
+def test_private_chunk_user_isolated():
+    # private = user_id-scoped (same human, all workspaces); NOT workspace-scoped.
     from mayring_core.memory.retrieval import _scope_filter
     db = _db()
-    cid = _insert_chunk(db, "priv-src", "ws-owner", visibility="private")
-    results = _scope_filter(db, workspace_id="ws-other", org_id=None)
+    cid = _insert_chunk(db, "priv-src", "ws-owner", visibility="private", user_id="u-owner")
+    # different user cannot see it, even from the same workspace
+    results = _scope_filter(db, workspace_id="ws-owner", org_id=None, user_id="u-other")
     assert cid not in results
-    results_own = _scope_filter(db, workspace_id="ws-owner", org_id=None)
+    # owner sees it across workspaces
+    results_own = _scope_filter(db, workspace_id="ws-other", org_id=None, user_id="u-owner")
     assert cid in results_own
 
 

--- a/tests/test_v2_workspaces.py
+++ b/tests/test_v2_workspaces.py
@@ -223,18 +223,23 @@ class TestScopeFilterOrgIds:
         assert cid not in results
 
     def test_scope_filter_backward_compat_no_memberships(self):
-        """Caller ohne org-memberships sieht nur public + own private."""
+        """Caller ohne org-memberships sieht public + private mit passender user_id."""
         from mayring_core.memory.retrieval import _scope_filter
         db = _db()
         cid_pub = _insert_chunk(db, "pub", "ws-other", visibility="public")
-        cid_priv = _insert_chunk(db, "own", "ws-bene", visibility="private")
+        cid_priv = _insert_chunk(db, "own", "ws-bene", visibility="private", user_id="u1")
         cid_org = _insert_chunk(db, "org", "ws-other", visibility="org", org_id="org-x")
 
-        # No org_ids passed → only public + own private
-        results = _scope_filter(db, workspace_id="ws-bene")
+        # user_id provided → private chunk with matching user_id is visible
+        results = _scope_filter(db, workspace_id="ws-bene", user_id="u1")
         assert cid_pub in results
         assert cid_priv in results
         assert cid_org not in results
+
+        # No user_id → private chunks never match (new 3-value model)
+        results_no_user = _scope_filter(db, workspace_id="ws-bene")
+        assert cid_pub in results_no_user
+        assert cid_priv not in results_no_user
 
     def test_scope_filter_legacy_org_id_single_still_works(self):
         """Backward-Compat: single org_id-Argument bleibt akzeptiert."""
@@ -381,23 +386,23 @@ class TestPatchVisibilityAuthorization:
         _deps._conn = None
 
     def test_patch_visibility_user_value_accepted(self):
-        """V2: 'user' must be a valid visibility option."""
+        """V2: 'private' (cross-device-same-human) must be a valid visibility option."""
         from fastapi.testclient import TestClient
         db = _db()
         upsert_source(
             db, Source(source_id="s4", source_type="note", repo="", path="x"),
-            workspace_id="ws-owner", visibility="private",
+            workspace_id="ws-owner", visibility="public",
         )
         ti = TokenInfo(workspace_id="ws-owner", sub="42", scopes=("mcp:memory",))
         app = self._setup_app_with_token(ti, db)
         client = TestClient(app)
         resp = client.patch(
             "/sources/s4/visibility",
-            json={"visibility": "user", "org_id": None},
+            json={"visibility": "private", "org_id": None},
             headers={"Authorization": "Bearer test"},
         )
         assert resp.status_code == 200, resp.text
-        assert resp.json()["visibility"] == "user"
+        assert resp.json()["visibility"] == "private"
         app.dependency_overrides.clear()
         import src.api.dependencies as _deps
         _deps._conn = None
@@ -417,12 +422,12 @@ class TestSyncRespectsOrgUserVisibility:
         import src.api.dependencies as _deps
 
         db = _db()
-        # 4 chunks: public, private-own, private-other, org-member, user-own
+        # 5 chunks: public, private-own-ws, private-other-ws, org-member, private-same-user-other-ws
         cid_pub = _insert_chunk(db, "pub", "ws-other", visibility="public")
-        cid_own = _insert_chunk(db, "own", "ws-bene", visibility="private")
-        cid_other = _insert_chunk(db, "other", "ws-other", visibility="private")
+        cid_own = _insert_chunk(db, "own", "ws-bene", visibility="private", user_id="42")
+        cid_other = _insert_chunk(db, "other", "ws-other", visibility="private", user_id="99")
         cid_org = _insert_chunk(db, "org", "ws-acme", visibility="org", org_id="org-acme")
-        cid_user = _insert_chunk(db, "user", "ws-other-of-bene", visibility="user", user_id="42")
+        cid_user = _insert_chunk(db, "user", "ws-other-of-bene", visibility="private", user_id="42")
 
         ti = TokenInfo(
             workspace_id="ws-bene",
@@ -451,7 +456,7 @@ class TestSyncRespectsOrgUserVisibility:
             assert cid_own in ids
             assert cid_other not in ids   # other-tenant private must not leak
             assert cid_org in ids          # member of org-acme
-            assert cid_user in ids         # same user across workspaces
+            assert cid_user in ids         # private+user_id=42 visible for same user across workspaces
 
         app.dependency_overrides.clear()
         _deps._conn = None
@@ -556,16 +561,16 @@ class TestIngestOrgIdResolution:
 
 
 class TestIngestUserIdResolution:
-    """L3 FIX1: visibility='user' bei /memory/put muss user_id aus TokenInfo.sub stempeln.
+    """L3 FIX1: visibility='private' bei /memory/put muss user_id aus TokenInfo.sub stempeln.
 
-    Ohne diesen Stamp: _scope_filter's `s.visibility='user' AND s.user_id=?`
-    findet nie einen Match → 'user'-Visibility (cross-device-of-same-human) ist
+    Ohne diesen Stamp: _scope_filter's `s.visibility='private' AND s.user_id=?`
+    findet nie einen Match → 'private'-Visibility (cross-device-of-same-human) ist
     für REST-Caller komplett gebrochen. MCP-Pfad tut dies korrekt via
     resolve_write_visibility; REST-Pfad war blind dafür.
     """
 
     def test_ingest_user_visibility_stamps_user_id(self, monkeypatch):
-        """visibility='user' → source_dict bekommt user_id == caller.sub."""
+        """visibility='private' → source_dict bekommt user_id == caller.sub."""
         from fastapi.testclient import TestClient
         from src.api.server import app
         from src.api.auth import get_token_info, get_workspace
@@ -599,22 +604,22 @@ class TestIngestUserIdResolution:
             json={
                 "source_id": "s-user-vis-1",
                 "content": "cross-device note",
-                "visibility": "user",
+                "visibility": "private",
             },
             headers={"Authorization": "Bearer test"},
         )
         assert resp.status_code == 200, resp.text
-        assert captured["source_dict"].get("visibility") == "user"
+        assert captured["source_dict"].get("visibility") == "private"
         assert captured["source_dict"].get("user_id") == "42", (
             "user_id must be stamped from TokenInfo.sub so _scope_filter "
-            "'s.visibility=user AND s.user_id=?' can match on cross-device reads"
+            "'s.visibility=private AND s.user_id=?' can match on cross-device reads"
         )
 
         app.dependency_overrides.clear()
         _deps._conn = None
 
-    def test_ingest_non_user_visibility_does_not_stamp_user_id(self, monkeypatch):
-        """visibility='private' (not 'user') must NOT add user_id to source_dict."""
+    def test_ingest_non_private_visibility_does_not_stamp_user_id(self, monkeypatch):
+        """visibility='public' must NOT auto-stamp user_id — only 'private' does."""
         from fastapi.testclient import TestClient
         from src.api.server import app
         from src.api.auth import get_token_info, get_workspace
@@ -643,15 +648,15 @@ class TestIngestUserIdResolution:
         resp = client.post(
             "/memory/put",
             json={
-                "source_id": "s-private-1",
-                "content": "private note",
-                "visibility": "private",
+                "source_id": "s-public-1",
+                "content": "public note",
+                "visibility": "public",
             },
             headers={"Authorization": "Bearer test"},
         )
         assert resp.status_code == 200, resp.text
         assert "user_id" not in captured["source_dict"], (
-            "visibility='private' must not add user_id (only 'user' needs it)"
+            "visibility='public' must not add user_id (only 'private' needs it)"
         )
 
         app.dependency_overrides.clear()

--- a/tests/test_workspace_isolation.py
+++ b/tests/test_workspace_isolation.py
@@ -14,10 +14,17 @@ from mayring_core.memory.store import init_memory_db, insert_chunk, upsert_sourc
 
 @pytest.fixture
 def memory_db(tmp_path):
-    """Isolated DB with seed chunks for two workspaces."""
+    """Isolated DB with seed chunks for two workspaces.
+
+    WHY(tenancy-T7 migration): 3-value visibility model — private chunks need
+    user_id to be visible.  Each tenant gets its own user_id so _scope_filter
+    can enforce isolation.  The map TENANT_USER is used by the tests that call
+    _scope_filter so they pass the matching user_id.
+    """
     conn = init_memory_db(tmp_path / "memory.db")
 
     for ws in ("tenant-a", "tenant-b"):
+        user_id = f"u-{ws}"  # deterministic; tests reference via TENANT_USER
         src = Source(
             source_id=f"repo-file:{ws}.py",
             source_type="repo_file",
@@ -25,6 +32,8 @@ def memory_db(tmp_path):
             path=f"{ws}.py",
             content_hash=f"sha256:{ws}",
             captured_at=datetime.now(timezone.utc).isoformat(),
+            visibility="private",
+            user_id=user_id,
         )
         upsert_source(conn, src, workspace_id=ws)
 
@@ -46,25 +55,37 @@ def memory_db(tmp_path):
     return conn
 
 
+# user_id for each tenant workspace — callers must pass these to _scope_filter
+_TENANT_USER = {"tenant-a": "u-tenant-a", "tenant-b": "u-tenant-b"}
+
+
 # ---------------------------------------------------------------------------
 # Retrieval-layer: _scope_filter enforces workspace_id
 # ---------------------------------------------------------------------------
 
 def test_tenant_a_sees_only_own_chunks(memory_db):
-    ids = _scope_filter(memory_db, workspace_id="tenant-a")
+    ids = _scope_filter(memory_db, workspace_id="tenant-a",
+                        user_id=_TENANT_USER["tenant-a"])
     assert ids == ["chk_tenant-a_1"]
 
 
 def test_tenant_b_sees_only_own_chunks(memory_db):
-    ids = _scope_filter(memory_db, workspace_id="tenant-b")
+    ids = _scope_filter(memory_db, workspace_id="tenant-b",
+                        user_id=_TENANT_USER["tenant-b"])
     assert ids == ["chk_tenant-b_1"]
 
 
-def test_visibility_user_crosses_workspaces_for_same_user(tmp_path):
+def test_visibility_private_crosses_workspaces_for_same_user(tmp_path):
     """Issue: claude.ai (workspace-A) and claude-cli (workspace-B) belong to the
     same human user (JWT.sub='42'). A source ingested in workspace-A with
-    visibility='user' must surface in a search from workspace-B with the same
-    user_id — without falling back to 'public'."""
+    visibility='private' must surface in a search from workspace-B with the same
+    user_id — without falling back to 'public'.
+
+    WHY(tenancy-T7 migration): 'user' was a legacy visibility value.  The 3-value
+    model replaces it with 'private' (user_id-scoped); the cross-workspace
+    cross-device property is identical — private=user_id-scoped means the same
+    human sees their chunks from any workspace, not just the ingesting one.
+    """
     conn = init_memory_db(tmp_path / "user_share.db")
 
     src = Source(
@@ -74,7 +95,7 @@ def test_visibility_user_crosses_workspaces_for_same_user(tmp_path):
         path="note",
         content_hash="sha256:abc",
         captured_at=datetime.now(timezone.utc).isoformat(),
-        visibility="user",
+        visibility="private",
         user_id="42",
     )
     upsert_source(conn, src, workspace_id="workspace-A")
@@ -187,7 +208,7 @@ def test_chroma_filter_failure_skips_vector_not_leaks(memory_db, monkeypatch):
         memory_db,
         chroma_collection=FilterFailingChroma(),
         ollama_url="http://fake",
-        opts={"workspace_id": "tenant-a", "top_k": 5},
+        opts={"workspace_id": "tenant-a", "user_id": _TENANT_USER["tenant-a"], "top_k": 5},
     )
     result_ids = {r.chunk_id for r in results}
     assert "chk_tenant-b_1" not in result_ids, "tenant-b data leaked via chroma fallback"
@@ -214,7 +235,7 @@ def test_chroma_workspace_a_cannot_see_workspace_b_data(memory_db, monkeypatch):
         memory_db,
         chroma_collection=LeakyChroma(),
         ollama_url="http://fake",
-        opts={"workspace_id": "tenant-a", "top_k": 5},
+        opts={"workspace_id": "tenant-a", "user_id": _TENANT_USER["tenant-a"], "top_k": 5},
     )
     result_ids = {r.chunk_id for r in results}
     assert "chk_tenant-b_1" not in result_ids, "tenant-b chunk leaked into tenant-a results"

--- a/tools/smoke_test_production.py
+++ b/tools/smoke_test_production.py
@@ -1210,7 +1210,11 @@ def check_visibility_isolation(api: str, token: str) -> CheckResult:
                            f"PATCH visibility failed http={code3}: {body3}")
 
     # 3) Search for the marker token — both should surface for the
-    #    same user/workspace that ingested them.
+    #    same user/workspace that ingested them.  Use _search_finds (retry)
+    #    for the PRIVATE source to absorb multi-worker commit-propagation lag
+    #    (WHY: chk_0aaf83324a0404c3 — one-shot search false-RED under 4 workers).
+    private_visible = _search_finds(api, token, f"marker token {suffix}", priv_id)
+    # Public source: one-shot is fine — public chunks are always visible.
     code4, body4, _ = _http(
         "POST", f"{api}/memory/search", token,
         body={"query": f"marker token {suffix}", "top_k": 5,
@@ -1221,7 +1225,6 @@ def check_visibility_isolation(api: str, token: str) -> CheckResult:
         return CheckResult("visibility_isolation", False,
                            f"search failed http={code4}")
     src_ids_seen = {r["source_id"] for r in (body4 or {}).get("results", [])}
-    private_visible = priv_id in src_ids_seen
     public_visible = pub_id in src_ids_seen
 
     return CheckResult(
@@ -2160,16 +2163,21 @@ def check_public_visibility(api: str, token: str) -> CheckResult:
 
 
 def check_user_cross_device(api: str, token: str) -> CheckResult:
-    """Same human (same sub) on two devices/workspaces: ingest visibility='user'
+    """Same human (same sub) on two devices/workspaces: ingest visibility='private'
     as sub=S in WA → search as sub=S in WB MUST see it; a different sub must
-    NOT. Proves 'user' visibility = cross-device-of-same-human."""
+    NOT. Proves 'private' visibility = user_id-scoped = cross-device-of-same-human.
+
+    WHY(tenancy-T7 migration): 'user' was a legacy value rejected by the 3-value
+    allowlist since T6.  'private' is the canonical replacement — same semantics
+    (user_id-scoped), correct vocabulary.
+    """
     suffix = int(time.time())
     sub_s = f"cd-{suffix}"
     wa, wb = f"cda-{suffix}", f"cdb-{suffix}"
     sid = f"smoke:user-xd:{suffix}"
     code1, _, _ = _http("POST", f"{api}/memory/put", token,
         body={"source_id": sid, "source_type": "note", "repo": "smoke-xd",
-              "path": "p", "content": f"USER-XD {suffix}", "visibility": "user", "categorize": False},
+              "path": "p", "content": f"USER-XD {suffix}", "visibility": "private", "categorize": False},
         extra_headers=_act_as(sub_s, workspace=wa), timeout=15.0)
     if code1 != 200:
         return CheckResult("user_cross_device", False, f"ingest failed http={code1}")


### PR DESCRIPTION
Aus Tenancy-Audit 2026-05-31 (Spec/Plan lokal, docs gitignored). Phase A: Visibility {private=user_id, org, public}; Chroma-Metadata+where bringt public/org cross-tenant in den Vektor-Recall (fixt roten public_visibility-Smoke). Ingest-Default nach WS-Typ + Owner-Fallback für user-agnostische System-Ingests (repo-events/ambient). share/PATCH syncen Chroma. 2 Prod-Bugs gefangen (sync.py /memory/changes, memory.py private-stamp). Migration v15 läuft beim Boot (migrate-then-flip). Braucht vendor/mayring-core-PR-Merge zuerst + MAYRING_PERSONAL_OWNERS-env.

⚠️ DEPLOY-GATE: master-Merge löst Prod-Migration+Backfill aus — erst nach Consent + Owner-env + Backfill-Plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce a three-value visibility model and align ingestion, retrieval, sync, and vector-store metadata with tenant-aware access rules.

New Features:
- Derive default visibility on /memory/put from workspace type with owner-based fallback for service-token ingests.
- Provide an idempotent backfill utility to stamp visibility, org_id, and user_id into existing Chroma chunk metadata.

Bug Fixes:
- Ensure private visibility is consistently user_id-scoped across retrieval and /memory/changes sync so cross-device access behaves correctly.
- Fix cases where chunks became unreadable due to missing visibility/user_id stamps or legacy 'user' visibility values.
- Keep Chroma metadata in sync when source visibility changes via share or PATCH so vector search respects updated access rules.

Enhancements:
- Consolidate to a canonical three-value visibility allowlist (private|org|public) across write and patch endpoints.
- Tighten multi-tenant workspace isolation in scope filtering and dashboard/sync paths to prevent cross-tenant data leaks.

Tests:
- Add extensive tests for ingest default visibility behavior, owner-fallback for service tokens, and explicit visibility passthrough.
- Add tests to validate three-value visibility allowlists and Chroma sync behavior on share/PATCH operations.
- Add tests for Chroma visibility backfill idempotence and batching, and update existing multi-tenancy, isolation, sync, and smoke tests to the new model.