### PR TITLE
Tenancy Phase B: Role-Enforcement (user/editor/admin + can() + policy matrix)

### DIFF
--- a/src/api/authz_helpers.py
+++ b/src/api/authz_helpers.py
@@ -1,0 +1,49 @@
+"""Bridge the JWT TokenInfo to the core authz model (tenancy Phase B)."""
+from __future__ import annotations
+
+import os
+
+import mayring_core.identity.workspace_resolver as _wr
+from mayring_core.identity import authz
+from src.api.jwt_auth import TokenInfo
+
+
+def _get_db_conn():
+    from src.api.dependencies import get_conn
+    return get_conn()
+
+
+def _public_ws_id() -> str:
+    return os.getenv("MAYRING_PUBLIC_WORKSPACE_ID", "")
+
+
+def caller_role(info: TokenInfo, workspace_id: str) -> str:
+    """Normalized role of the caller IN workspace_id.
+
+    Resolution order:
+      1. Workspace OWNER is always admin (even without a memberships entry).
+      2. JWT memberships entry for workspace_id → normalize_role(m.role).
+      3. No match → 'user' (least privilege).
+    """
+    if info.sub:
+        try:
+            conn = _get_db_conn()
+            if _wr.workspace_owner(conn, workspace_id) == info.sub:
+                return "admin"
+        except Exception:
+            pass
+    for m in info.memberships:
+        if m.id == workspace_id:
+            return authz.normalize_role(m.role)
+    return "user"
+
+
+def caller_can(info: TokenInfo, workspace_id: str, permission: str, *,
+               overrides: dict | None = None) -> bool:
+    return authz.can(
+        caller_role(info, workspace_id),
+        permission,
+        is_super_admin=bool(info.is_admin),
+        is_public_ws=bool(_public_ws_id()) and workspace_id == _public_ws_id(),
+        overrides=overrides,
+    )

--- a/src/api/jwt_auth.py
+++ b/src/api/jwt_auth.py
@@ -64,7 +64,11 @@ class TokenInfo:
 
     @property
     def is_admin(self) -> bool:
-        return "admin" in self.scopes
+        # WHY(tenancy phase B): super-admin is the JWT 'admin' scope OR the
+        # wildcard '*' that the MCP_SERVICE_TOKEN path stamps (auth.py). Without
+        # '*' the role gate (caller_can → is_super_admin) would 403 every system
+        # ingest (repo-events/ambient/watcher) that the service token drives.
+        return "admin" in self.scopes or "*" in self.scopes
 
     @property
     def uses_custom_provider(self) -> bool:

--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -1026,16 +1026,22 @@ async def patch_source_visibility(
     src_ws = row["workspace_id"] if hasattr(row, "keys") else row[0]
     src_user = row["user_id"] if hasattr(row, "keys") else row[1]
 
-    is_admin = "*" in info.scopes or "admin" in info.scopes
+    # WHY(tenancy phase B): super-admin (scope=admin) is honored implicitly by
+    # caller_can(is_super_admin); only the workspace/sub owner skips manage_foreign.
     is_owner = (
         src_ws == workspace_id
         or (src_user is not None and info.sub is not None and src_user == info.sub)
     )
-    if not (is_admin or is_owner):
-        raise HTTPException(
-            status_code=403,
-            detail="not authorized to change visibility of this source",
-        )
+    from src.api.authz_helpers import caller_can
+    from mayring_core.memory.store import get_role_permissions
+    _ov = get_role_permissions(conn, workspace_id)
+    if not is_owner and not caller_can(info, workspace_id, "manage_foreign", overrides=_ov):
+        raise HTTPException(status_code=403, detail="manage_foreign permission required")
+    _target_vis = request.visibility
+    if _target_vis == "org" and not caller_can(info, workspace_id, "share_org", overrides=_ov):
+        raise HTTPException(status_code=403, detail="share_org permission required")
+    if _target_vis == "public" and not caller_can(info, workspace_id, "share_public", overrides=_ov):
+        raise HTTPException(status_code=403, detail="share_public permission required")
 
     conn.execute(
         "UPDATE sources SET visibility = ?, org_id = ? WHERE source_id = ?",
@@ -1092,13 +1098,22 @@ async def share_source(
     src_ws = row["workspace_id"] if hasattr(row, "keys") else row[0]
     src_user = row["user_id"] if hasattr(row, "keys") else row[1]
 
-    is_admin = "*" in info.scopes or "admin" in info.scopes
+    # WHY(tenancy phase B): super-admin (scope=admin) is honored implicitly by
+    # caller_can(is_super_admin); only the workspace/sub owner skips manage_foreign.
     is_owner = (
         src_ws == workspace_id
         or (src_user is not None and info.sub is not None and src_user == info.sub)
     )
-    if not (is_admin or is_owner):
-        raise HTTPException(status_code=403, detail="not authorized to share this source")
+    from src.api.authz_helpers import caller_can
+    from mayring_core.memory.store import get_role_permissions
+    _ov = get_role_permissions(conn, workspace_id)
+    if not is_owner and not caller_can(info, workspace_id, "manage_foreign", overrides=_ov):
+        raise HTTPException(status_code=403, detail="manage_foreign permission required")
+    _target_vis = "org" if req.org_id else "public"
+    if _target_vis == "org" and not caller_can(info, workspace_id, "share_org", overrides=_ov):
+        raise HTTPException(status_code=403, detail="share_org permission required")
+    if _target_vis == "public" and not caller_can(info, workspace_id, "share_public", overrides=_ov):
+        raise HTTPException(status_code=403, detail="share_public permission required")
 
     if req.org_id:
         if req.org_id not in set(info.org_ids):

--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -544,6 +544,19 @@ async def memory_put(
                 display_name=info.membership_name(source_dict["org_id"]),
             )
 
+        # WHY(tenancy phase B): enforce the role→permission policy. 'write' gates
+        # any ingest; promoting to org/public additionally needs share_org/share_public.
+        from src.api.authz_helpers import caller_can
+        from mayring_core.memory.store import get_role_permissions
+        _ov = get_role_permissions(_get_conn(), workspace_id)
+        if not caller_can(info, workspace_id, "write", overrides=_ov):
+            raise HTTPException(status_code=403, detail="write permission required")
+        _eff_vis = source_dict.get("visibility")
+        if _eff_vis == "org" and not caller_can(info, workspace_id, "share_org", overrides=_ov):
+            raise HTTPException(status_code=403, detail="share_org permission required")
+        if _eff_vis == "public" and not caller_can(info, workspace_id, "share_public", overrides=_ov):
+            raise HTTPException(status_code=403, detail="share_public permission required")
+
         result = _run_ingest(source_dict, request.content, _get_conn(), _get_chroma(),
                              _OLLAMA_URL, _model("text"),
                              {"categorize": request.categorize, "task": request.task},

--- a/src/api/routes/role_permissions.py
+++ b/src/api/routes/role_permissions.py
@@ -1,0 +1,51 @@
+"""Per-workspace role→permission matrix (tenancy Phase B). Read+edit, gated by
+the manage_members permission (super-admin only on the public workspace)."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from mayring_core.identity import authz
+from mayring_core.memory.store import get_role_permissions, set_role_permission
+from src.api.auth import get_token_info, get_workspace
+from src.api.authz_helpers import caller_can
+from src.api.dependencies import get_conn as _get_conn
+from src.api.jwt_auth import TokenInfo
+
+router = APIRouter()
+
+
+class RolePermissionUpdate(BaseModel):
+    role: str
+    permission: str
+    allowed: bool
+
+
+def _effective_matrix(overrides: dict[tuple[str, str], bool]) -> dict[str, dict[str, bool]]:
+    out: dict[str, dict[str, bool]] = {}
+    for role in authz.ROLES:
+        out[role] = {perm: authz.can(role, perm, overrides=overrides) for perm in authz.PERMISSIONS}
+    return out
+
+
+@router.get("/stats/workspaces/{ws}/role-permissions")
+async def get_role_permissions_endpoint(ws: str, workspace_id: str = Depends(get_workspace), info: TokenInfo = Depends(get_token_info)) -> dict:
+    overrides = get_role_permissions(_get_conn(), ws)
+    if not caller_can(info, ws, "manage_members", overrides=overrides):
+        raise HTTPException(status_code=403, detail="manage_members required")
+    return {"workspace_id": ws, "matrix": _effective_matrix(overrides), "locked": {"admin": list(authz.ADMIN_LOCKED_PERMISSIONS)}}
+
+
+@router.put("/stats/workspaces/{ws}/role-permissions")
+async def put_role_permission_endpoint(ws: str, body: RolePermissionUpdate, workspace_id: str = Depends(get_workspace), info: TokenInfo = Depends(get_token_info)) -> dict:
+    overrides = get_role_permissions(_get_conn(), ws)
+    if not caller_can(info, ws, "manage_members", overrides=overrides):
+        raise HTTPException(status_code=403, detail="manage_members required")
+    if body.role not in authz.ROLES:
+        raise HTTPException(status_code=422, detail=f"role must be one of {authz.ROLES}")
+    if body.permission not in authz.PERMISSIONS:
+        raise HTTPException(status_code=422, detail=f"permission must be one of {authz.PERMISSIONS}")
+    if body.role == "admin" and body.permission in authz.ADMIN_LOCKED_PERMISSIONS and not body.allowed:
+        raise HTTPException(status_code=422, detail=f"admin.{body.permission} cannot be disabled (anti-lockout)")
+    set_role_permission(_get_conn(), ws, body.role, body.permission, body.allowed)
+    return {"workspace_id": ws, "role": body.role, "permission": body.permission, "allowed": body.allowed}

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -102,6 +102,8 @@ from src.api.routes import ambient_admin as _ambient_admin  # ambient snapshot r
 app.include_router(_ambient_admin.router)
 from src.api.routes import backfill_admin as _backfill_admin  # tenancy phase A: chroma visibility backfill
 app.include_router(_backfill_admin.router)
+from src.api.routes import role_permissions as _role_permissions  # tenancy phase B
+app.include_router(_role_permissions.router)
 from src.api.routes import watch_repos as _watch_repos  # dashboard-managed repo-watch list
 app.include_router(_watch_repos.router)
 from src.api.routes import agent_keys as _agent_keys  # per-agent A2A API keys (X-API-Key)

--- a/tests/test_caller_role.py
+++ b/tests/test_caller_role.py
@@ -1,0 +1,32 @@
+"""Tests for the JWT→authz bridge (tenancy Phase B, Task 4)."""
+from src.api.authz_helpers import caller_role, caller_can
+from src.api.jwt_auth import TokenInfo, Membership
+
+
+def test_caller_role_from_membership():
+    info = TokenInfo(workspace_id="ws-1", scopes=(), memberships=(
+        Membership(id="ws-1", type="organization", role="owner", name="Acme"),))
+    assert caller_role(info, "ws-1") == "admin"
+    assert caller_role(info, "ws-other") == "user"
+
+
+def test_caller_can_uses_default_matrix():
+    info = TokenInfo(workspace_id="ws-1", scopes=(), memberships=(
+        Membership(id="ws-1", type="organization", role="editor", name="Acme"),))
+    assert caller_can(info, "ws-1", "share_org", overrides={}) is True
+    assert caller_can(info, "ws-1", "manage_members", overrides={}) is False
+
+
+def test_caller_can_super_admin():
+    info = TokenInfo(workspace_id="ws-1", scopes=("admin",), memberships=())
+    assert caller_can(info, "ws-1", "manage_foreign", overrides={}) is True
+
+
+def test_workspace_owner_is_admin(monkeypatch):
+    import src.api.authz_helpers as ah
+    import mayring_core.identity.workspace_resolver as wr
+    monkeypatch.setattr(wr, "workspace_owner", lambda conn, ws: "owner-sub")
+    # also patch _get_db_conn so no real DB is needed
+    monkeypatch.setattr(ah, "_get_db_conn", lambda: None)
+    info = TokenInfo(workspace_id="ws-1", scopes=(), sub="owner-sub", memberships=())
+    assert ah.caller_role(info, "ws-1") == "admin"

--- a/tests/test_ingest_default_visibility.py
+++ b/tests/test_ingest_default_visibility.py
@@ -10,6 +10,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+from src.api.jwt_auth import TokenInfo
+
 
 # ---------------------------------------------------------------------------
 # Fixtures — mirror pattern from test_scope_key.py
@@ -25,17 +27,12 @@ def client_personal_ws():
     async def _fake_ws():
         return "bene"
 
-    class _FakeInfo:
-        org_ids: list = []
-        sub = "1"
-        scopes: list = []
-        workspace_id = "bene"
-
-        def membership_name(self, _org_id):  # noqa: D102
-            return ""
+    # WHY(tenancy phase B): exercises the visibility-default mechanism, not the
+    # role gate → run as super-admin so caller_can() never blocks the ingest.
+    info = TokenInfo(workspace_id="bene", scopes=("admin",), sub="1")
 
     async def _fake_info():
-        return _FakeInfo()
+        return info
 
     srv.app.dependency_overrides[auth_module.get_workspace] = _fake_ws
     srv.app.dependency_overrides[auth_module.get_token_info] = _fake_info
@@ -55,17 +52,16 @@ def client_team_ws():
     async def _fake_ws():
         return _ORG_ID
 
-    class _FakeInfo:
-        org_ids: list = [_ORG_ID]
-        sub = "2"
-        scopes: list = []
-        workspace_id = _ORG_ID
-
-        def membership_name(self, _org_id):  # noqa: D102
-            return ""
+    from src.api.jwt_auth import Membership
+    # WHY(tenancy phase B): super-admin so caller_can(write/share_org) never
+    # blocks; the membership carries the org_id used by the org-default branch.
+    info = TokenInfo(
+        workspace_id=_ORG_ID, scopes=("admin",), sub="2",
+        memberships=(Membership(id=_ORG_ID, type="organization", role="owner"),),
+    )
 
     async def _fake_info():
-        return _FakeInfo()
+        return info
 
     srv.app.dependency_overrides[auth_module.get_workspace] = _fake_ws
     srv.app.dependency_overrides[auth_module.get_token_info] = _fake_info
@@ -150,17 +146,11 @@ def client_service_token_personal_ws():
     async def _fake_ws():
         return "bene"
 
-    class _FakeInfoNoSub:
-        org_ids: list = []
-        sub = None  # Service-Token: no user subject
-        scopes: list = ["*"]
-        workspace_id = "bene"
-
-        def membership_name(self, _org_id):  # noqa: D102
-            return ""
+    # Service-Token: no user subject, super-admin scope (info.is_admin → bypass).
+    info = TokenInfo(workspace_id="bene", scopes=("admin",), sub=None)
 
     async def _fake_info():
-        return _FakeInfoNoSub()
+        return info
 
     srv.app.dependency_overrides[auth_module.get_workspace] = _fake_ws
     srv.app.dependency_overrides[auth_module.get_token_info] = _fake_info

--- a/tests/test_memory_put_authz.py
+++ b/tests/test_memory_put_authz.py
@@ -1,0 +1,99 @@
+"""Task 6 (tenancy phase B) — role→permission capping in POST /memory/put.
+
+The 'write' permission gates any ingest; promoting a source to org/public
+additionally requires share_org / share_public. A plain 'user' role (per
+DEFAULT_MATRIX) has search+write but NOT share_* — so it may ingest a
+private source but must be 403'd when it tries to write a public one.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.api.jwt_auth import Membership, TokenInfo
+
+
+@pytest.fixture
+def client_user():
+    """Caller with a plain 'user' membership in workspace 'bene'."""
+    from fastapi.testclient import TestClient
+    from src.api import auth as auth_module
+    from src.api import server as srv
+
+    async def _fake_ws():
+        return "bene"
+
+    info = TokenInfo(
+        workspace_id="bene",
+        scopes=("mcp:memory",),
+        sub="1",
+        memberships=(Membership(id="bene", type="personal", role="viewer"),),
+    )
+
+    async def _fake_info():
+        return info
+
+    srv.app.dependency_overrides[auth_module.get_workspace] = _fake_ws
+    srv.app.dependency_overrides[auth_module.get_token_info] = _fake_info
+    yield TestClient(srv.app)
+    srv.app.dependency_overrides.clear()
+
+
+def _put(client, **kw):
+    return client.post("/memory/put", json=kw, headers={"Authorization": "Bearer tst"})
+
+
+def test_user_cannot_write_public(client_user):
+    """A 'user' role lacks share_public → visibility='public' must be 403."""
+    with patch(
+        "src.api.routes.memory._run_ingest",
+        return_value={"source_id": "note:p", "state": "new", "chunk_ids": [], "indexed": 0},
+    ):
+        r = _put(client_user, source_id="note:p", source_type="note",
+                 content="t", visibility="public")
+    assert r.status_code == 403, r.text
+    assert "share_public" in r.json()["detail"]
+
+
+def test_service_token_wildcard_can_write_public():
+    """Self-lockout guard: the MCP_SERVICE_TOKEN scope='*' must bypass the role
+    gate (info.is_admin) so system ingests (repo-events/ambient) keep working."""
+    from fastapi.testclient import TestClient
+    from src.api import auth as auth_module
+    from src.api import server as srv
+
+    info = TokenInfo(workspace_id="system", scopes=("*",), sub=None)
+
+    async def _fake_ws():
+        return "system"
+
+    async def _fake_info():
+        return info
+
+    srv.app.dependency_overrides[auth_module.get_workspace] = _fake_ws
+    srv.app.dependency_overrides[auth_module.get_token_info] = _fake_info
+    try:
+        with patch(
+            "src.api.routes.memory._run_ingest",
+            return_value={"source_id": "note:s", "state": "new", "chunk_ids": [], "indexed": 0},
+        ):
+            r = _put(TestClient(srv.app), source_id="note:s", source_type="note",
+                     content="t", visibility="public")
+        assert r.status_code == 200, r.text
+    finally:
+        srv.app.dependency_overrides.clear()
+
+
+def test_user_can_write_private(client_user):
+    """A 'user' role HAS write → visibility='private' must succeed (200)."""
+    with (
+        patch(
+            "src.api.routes.memory._run_ingest",
+            return_value={"source_id": "note:q", "state": "new", "chunk_ids": [], "indexed": 0},
+        ),
+        patch("mayring_core.identity.workspace_resolver.workspace_kind", return_value="user"),
+    ):
+        r = _put(client_user, source_id="note:q", source_type="note",
+                 content="t", visibility="private")
+    assert r.status_code == 200, r.text

--- a/tests/test_role_permissions_endpoint.py
+++ b/tests/test_role_permissions_endpoint.py
@@ -1,0 +1,45 @@
+import asyncio
+from src.api.routes import role_permissions as rp
+from src.api.jwt_auth import TokenInfo, Membership
+
+
+def _admin_info(ws):
+    return TokenInfo(workspace_id=ws, scopes=(), memberships=(
+        Membership(id=ws, type="organization", role="owner", name="Acme"),))
+
+
+def test_get_returns_effective_matrix(tmp_path, monkeypatch):
+    from mayring_core.memory import store
+    conn = store.init_memory_db(tmp_path / "m.db")
+    monkeypatch.setattr(rp, "_get_conn", lambda: conn)
+    res = asyncio.run(rp.get_role_permissions_endpoint("ws-1", workspace_id="ws-1", info=_admin_info("ws-1")))
+    assert res["matrix"]["editor"]["share_org"] is True
+
+
+def test_put_sets_override_and_blocks_lockout(tmp_path, monkeypatch):
+    from mayring_core.memory import store
+    conn = store.init_memory_db(tmp_path / "m.db")
+    monkeypatch.setattr(rp, "_get_conn", lambda: conn)
+    asyncio.run(rp.put_role_permission_endpoint("ws-1", rp.RolePermissionUpdate(role="editor", permission="share_public", allowed=False), workspace_id="ws-1", info=_admin_info("ws-1")))
+    res = asyncio.run(rp.get_role_permissions_endpoint("ws-1", workspace_id="ws-1", info=_admin_info("ws-1")))
+    assert res["matrix"]["editor"]["share_public"] is False
+    import fastapi
+    try:
+        asyncio.run(rp.put_role_permission_endpoint("ws-1", rp.RolePermissionUpdate(role="admin", permission="manage_members", allowed=False), workspace_id="ws-1", info=_admin_info("ws-1")))
+        assert False, "expected HTTPException"
+    except fastapi.HTTPException as e:
+        assert e.status_code == 422
+
+
+def test_put_denied_for_non_manage_member_caller(tmp_path, monkeypatch):
+    from mayring_core.memory import store
+    conn = store.init_memory_db(tmp_path / "m.db")
+    monkeypatch.setattr(rp, "_get_conn", lambda: conn)
+    user_info = TokenInfo(workspace_id="ws-1", scopes=(), memberships=(
+        Membership(id="ws-1", type="organization", role="user", name="Acme"),))
+    import fastapi
+    try:
+        asyncio.run(rp.put_role_permission_endpoint("ws-1", rp.RolePermissionUpdate(role="editor", permission="write", allowed=False), workspace_id="ws-1", info=user_info))
+        assert False
+    except fastapi.HTTPException as e:
+        assert e.status_code == 403

--- a/tests/test_scope_key.py
+++ b/tests/test_scope_key.py
@@ -116,12 +116,13 @@ def client():
     async def _fake_ws():
         return "bene"
 
-    class _FakeInfo:
-        org_ids: list = []
-        sub = "1"
+    # WHY(tenancy phase B): these tests exercise scope_key validation, not the
+    # role gate → run as super-admin so caller_can() never blocks the ingest.
+    from src.api.jwt_auth import TokenInfo
+    info = TokenInfo(workspace_id="bene", scopes=("admin",), sub="1")
 
     async def _fake_info():
-        return _FakeInfo()
+        return info
 
     srv.app.dependency_overrides[auth_module.get_workspace] = _fake_ws
     srv.app.dependency_overrides[auth_module.get_token_info] = _fake_info

--- a/tests/test_share_authz.py
+++ b/tests/test_share_authz.py
@@ -1,0 +1,84 @@
+"""Task 7 (tenancy phase B) — manage_foreign + share_* in share/patch.
+
+Mutating the visibility of a FOREIGN source (not owned by the caller, neither
+by same-workspace nor same-sub) requires the manage_foreign permission. A
+plain 'editor' (search/write/share_org/share_public, but NOT manage_foreign)
+must therefore be 403'd when it patches someone else's source.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mayring_core.memory.schema import Source
+from mayring_core.memory.store import init_memory_db, upsert_source
+from src.api.jwt_auth import Membership, TokenInfo
+
+
+@pytest.fixture
+def seeded_conn(tmp_path: Path):
+    """Test DB seeded with a source owned by a FOREIGN user/workspace."""
+    conn = init_memory_db(tmp_path / "m.db")
+    upsert_source(
+        conn,
+        Source(source_id="note:foreign", source_type="note", repo="", path="",
+               visibility="private", user_id="999", content_hash="h:foreign"),
+        workspace_id="other-ws",
+    )
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def client_editor(seeded_conn):
+    """Caller = 'editor' in workspace 'bene', sub='1' (does NOT own the source)."""
+    from fastapi.testclient import TestClient
+    from src.api import auth as auth_module
+    from src.api import server as srv
+
+    async def _fake_ws():
+        return "bene"
+
+    info = TokenInfo(
+        workspace_id="bene",
+        scopes=("mcp:memory",),
+        sub="1",
+        memberships=(Membership(id="bene", type="organization", role="editor"),),
+    )
+
+    async def _fake_info():
+        return info
+
+    srv.app.dependency_overrides[auth_module.get_workspace] = _fake_ws
+    srv.app.dependency_overrides[auth_module.get_token_info] = _fake_info
+    with (
+        patch("src.api.routes.memory._get_conn", return_value=seeded_conn),
+        patch("src.api.routes.memory._get_chroma"),
+    ):
+        yield TestClient(srv.app)
+    srv.app.dependency_overrides.clear()
+
+
+def test_editor_cannot_patch_foreign_visibility(client_editor):
+    """editor lacks manage_foreign → patching a foreign source must be 403."""
+    r = client_editor.patch(
+        "/sources/note:foreign/visibility",
+        json={"visibility": "public"},
+        headers={"Authorization": "Bearer tst"},
+    )
+    assert r.status_code == 403, r.text
+    assert "manage_foreign" in r.json()["detail"]
+
+
+def test_editor_cannot_share_foreign(client_editor):
+    """Same gate on POST /sources/{id}/share."""
+    r = client_editor.post(
+        "/sources/note:foreign/share",
+        json={},
+        headers={"Authorization": "Bearer tst"},
+    )
+    assert r.status_code == 403, r.text
+    assert "manage_foreign" in r.json()["detail"]

--- a/tests/test_share_patch_chroma_sync.py
+++ b/tests/test_share_patch_chroma_sync.py
@@ -30,17 +30,14 @@ def client():
     async def _fake_ws():
         return "bene"
 
-    class _FakeInfo:
-        org_ids: list = []
-        sub = "1"
-        scopes: list = []
-        workspace_id = "bene"
-
-        def membership_name(self, _org_id):
-            return ""
+    # WHY(tenancy phase B): exercises allowlist + chroma-sync, not the role gate
+    # → super-admin so caller_can() never blocks. sub="1" also owns the patched
+    # source (src_user="1") so the manage_foreign branch is skipped anyway.
+    from src.api.jwt_auth import TokenInfo
+    info = TokenInfo(workspace_id="bene", scopes=("admin",), sub="1")
 
     async def _fake_info():
-        return _FakeInfo()
+        return info
 
     srv.app.dependency_overrides[auth_module.get_workspace] = _fake_ws
     srv.app.dependency_overrides[auth_module.get_token_info] = _fake_info

--- a/tests/test_shared_memory.py
+++ b/tests/test_shared_memory.py
@@ -175,7 +175,13 @@ def test_share_source_makes_public():
     from src.api.jwt_auth import TokenInfo
     import src.api.dependencies as _deps
 
-    owner_info = TokenInfo(workspace_id="ws-share", sub="7", scopes=())
+    # WHY(tenancy phase B): sharing public additionally requires share_public —
+    # the owning user carries the 'owner' (→admin) role in the membership.
+    from src.api.jwt_auth import Membership
+    owner_info = TokenInfo(
+        workspace_id="ws-share", sub="7", scopes=("mcp:memory",),
+        memberships=(Membership(id="ws-share", type="personal", role="owner"),),
+    )
     app.dependency_overrides[get_workspace] = lambda: "ws-share"
     app.dependency_overrides[get_token_info] = lambda: owner_info
     db = _db()

--- a/tests/test_v2_workspaces.py
+++ b/tests/test_v2_workspaces.py
@@ -323,7 +323,12 @@ class TestPatchVisibilityAuthorization:
 
     def test_patch_visibility_owner_ok(self):
         from fastapi.testclient import TestClient
-        ti = TokenInfo(workspace_id="ws-owner", sub="42", scopes=("mcp:memory",))
+        # WHY(tenancy phase B): owner-of-workspace carries the admin role in the
+        # membership → caller_can(share_public) for the promotion to public.
+        ti = TokenInfo(
+            workspace_id="ws-owner", sub="42", scopes=("mcp:memory",),
+            memberships=(Membership(id="ws-owner", type="personal", role="owner"),),
+        )
         db = _db()
         upsert_source(
             db, Source(source_id="s1", source_type="note", repo="", path="x"),
@@ -372,6 +377,8 @@ class TestPatchVisibilityAuthorization:
             db, Source(source_id="s3", source_type="note", repo="", path="x"),
             workspace_id="ws-someone", visibility="private",
         )
+        # WHY(tenancy phase B): the wildcard '*' scope (MCP_SERVICE_TOKEN) must
+        # still bypass the role gate via info.is_admin → caller_can(is_super_admin).
         ti = TokenInfo(workspace_id="system", sub="0", scopes=("*",))
         app = self._setup_app_with_token(ti, db)
         client = TestClient(app)
@@ -627,10 +634,12 @@ class TestIngestUserIdResolution:
         import src.api.routes.memory as _mod
 
         db = _db()
+        # WHY(tenancy phase B): exercises the user_id-stamp mechanism for
+        # visibility='public' → super-admin so caller_can(share_public) passes.
         ti = TokenInfo(
             workspace_id="ws-bene",
             sub="42",
-            scopes=("mcp:memory",),
+            scopes=("admin",),
         )
         app.dependency_overrides[get_token_info] = lambda: ti
         app.dependency_overrides[get_workspace] = lambda: "ws-bene"

--- a/tools/smoke_test_production.py
+++ b/tools/smoke_test_production.py
@@ -2112,6 +2112,38 @@ def check_reranker_cat_match_fires(api: str, token: str) -> CheckResult:
     )
 
 
+def check_role_policy_roundtrip(api: str, token: str) -> CheckResult:
+    """PUT a per-workspace override then GET reflects it (owner==admin, manage_members)."""
+    ws = SMOKE_VECTOR_WORKSPACE
+    hdr = _act_as(SMOKE_VECTOR_OWNER, workspace=ws)
+    c1, b1, _ = _http("PUT", f"{api}/stats/workspaces/{ws}/role-permissions", token,
+                      body={"role": "editor", "permission": "share_public", "allowed": False},
+                      extra_headers=hdr)
+    if c1 != 200:
+        return CheckResult("role_policy_roundtrip", False, f"PUT http={c1}: {b1}")
+    c2, b2, _ = _http("GET", f"{api}/stats/workspaces/{ws}/role-permissions", token, extra_headers=hdr)
+    val = (b2 or {}).get("matrix", {}).get("editor", {}).get("share_public") if isinstance(b2, dict) else None
+    ok = c2 == 200 and val is False
+    # restore default → idempotent
+    _http("PUT", f"{api}/stats/workspaces/{ws}/role-permissions", token,
+          body={"role": "editor", "permission": "share_public", "allowed": True}, extra_headers=hdr)
+    return CheckResult("role_policy_roundtrip", ok, f"PUT={c1} GET={c2} editor.share_public={val}")
+
+
+def check_role_enforcement(api: str, token: str) -> CheckResult:
+    """A 'user'-role caller (act-as, no membership → role user) must be DENIED
+    share_public on /memory/put (403)."""
+    ws = SMOKE_VECTOR_WORKSPACE
+    hdr = _act_as("smoke-roleuser", workspace=ws)
+    suffix = int(time.time())
+    code, body, _ = _http("POST", f"{api}/memory/put", token,
+                          body={"source_id": f"smoke:role:{suffix}", "source_type": "note",
+                                "content": "role check", "visibility": "public"},
+                          extra_headers=hdr)
+    return CheckResult("role_enforcement", code == 403,
+                       f"user->share_public http={code} (must be 403) body={body}")
+
+
 def check_igio_lens_axes_present(api: str, token: str) -> CheckResult:
     """IGIO-Lens acceptance: GET /stats/igio-lens returns all four IGIO axes with
     integer counts + an unclassified bucket (workspace-scoped). Guards the
@@ -2459,6 +2491,8 @@ ALL_CHECKS = [
     ("mayring_process_fail_closed",   check_mayring_process_fail_closed),
     ("ingest_links_categories",       check_ingest_links_categories),
     ("reranker_cat_match_fires",      check_reranker_cat_match_fires),
+    ("role_policy_roundtrip",         check_role_policy_roundtrip),
+    ("role_enforcement",              check_role_enforcement),
     ("igio_lens_axes_present",        check_igio_lens_axes_present),
     ("intervention_todos_surface",    check_intervention_todos_surface),
     ("dashboard_endpoints",           check_dashboard_endpoints),


### PR DESCRIPTION
Aus Spec 2026-05-31 (Achse 2). Permission-Katalog + Default-3-Tier-Matrix + zentrale can() (super-admin-bypass, public-ws-manage_members-gate, anti-lockout); workspace_role_permissions v16 (additiv, keine Datenmigration); caller_role/caller_can (owner=admin); Policy-Endpoint /stats/workspaces/{ws}/role-permissions (manage_members-gated); Enforcement in /memory/put (write/share_org/share_public) + share/patch (manage_foreign + share_*). FIX: is_admin honoriert jetzt '*' (Service-Token) → kein System-Ingest-Self-Lockout. Smoke role_policy_roundtrip + role_enforcement. Submodul auf core-main (PR #16). Volle Suite grün lokal. Phase C (Rollen-Vergabe-UI + public-ws-env) folgt separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce workspace role-based permissions for memory ingestion and sharing, introduce a per-workspace role-permission matrix API with central authorization helpers, and extend tests and smoke checks to cover the new tenancy Phase B behavior.

New Features:
- Add a per-workspace role-permission matrix API, gated by manage_members, to view and update effective role permissions.
- Introduce authorization helper utilities to derive caller roles and permissions from JWT token info and core authz configuration.

Bug Fixes:
- Ensure service tokens with wildcard scopes are treated as super-admins to prevent system ingest lockouts.

Enhancements:
- Apply role-based permission enforcement to memory ingestion and source sharing endpoints, including manage_foreign and share_* gates.
- Update token admin detection and various tests to align with the new role and permission model.
- Add smoke tests to verify role policy roundtrip and runtime enforcement of role-based permissions on critical endpoints.

Tests:
- Add unit tests for memory ingestion and sharing authorization behavior under different roles and permissions.
- Add tests for the new role-permissions API and the JWT-to-authz bridge, including default matrices and anti-lockout rules.
- Adjust existing tests to run under super-admin or owner contexts so they remain focused on their primary behavior under the new role gates.