### PR TITLE
Tenancy Phase C (backend): GET /stats/sources

### DIFF
--- a/src/api/routes/sources_list.py
+++ b/src/api/routes/sources_list.py
@@ -1,0 +1,34 @@
+"""GET /stats/sources — list a workspace's sources with visibility, for the
+Share-UI (tenancy Phase C). Read-only; workspace-scoped (under /stats/ → already
+in the nginx allowlist). NOT a memory search — a flat catalog for the dashboard."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from src.api.auth import get_token_info, get_workspace
+from src.api.dependencies import get_conn as _get_conn
+from src.api.jwt_auth import TokenInfo
+
+router = APIRouter()
+
+
+@router.get("/stats/sources")
+async def list_sources_endpoint(
+    limit: int = 200,
+    workspace_id: str = Depends(get_workspace),
+    info: TokenInfo = Depends(get_token_info),
+) -> dict:
+    rows = _get_conn().execute(
+        "SELECT source_id, source_type, visibility, org_id, scope_key, captured_at "
+        "FROM sources WHERE workspace_id = ? ORDER BY captured_at DESC LIMIT ?",
+        (workspace_id, int(limit)),
+    ).fetchall()
+    out = []
+    for r in rows:
+        g = (lambda k, i: r[k] if hasattr(r, "keys") else r[i])
+        out.append({
+            "source_id": g("source_id", 0), "source_type": g("source_type", 1),
+            "visibility": g("visibility", 2) or "private", "org_id": g("org_id", 3),
+            "scope_key": g("scope_key", 4), "captured_at": g("captured_at", 5),
+        })
+    return {"workspace_id": workspace_id, "sources": out}

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -104,6 +104,8 @@ from src.api.routes import backfill_admin as _backfill_admin  # tenancy phase A:
 app.include_router(_backfill_admin.router)
 from src.api.routes import role_permissions as _role_permissions  # tenancy phase B
 app.include_router(_role_permissions.router)
+from src.api.routes import sources_list as _sources_list  # tenancy phase C
+app.include_router(_sources_list.router)
 from src.api.routes import watch_repos as _watch_repos  # dashboard-managed repo-watch list
 app.include_router(_watch_repos.router)
 from src.api.routes import agent_keys as _agent_keys  # per-agent A2A API keys (X-API-Key)

--- a/tests/test_sources_list_endpoint.py
+++ b/tests/test_sources_list_endpoint.py
@@ -1,0 +1,18 @@
+import asyncio
+from src.api.routes import sources_list as sl
+from src.api.jwt_auth import TokenInfo
+
+
+def test_lists_workspace_sources_with_visibility(tmp_path, monkeypatch):
+    from mayring_core.memory import store
+    from mayring_core.memory.store import upsert_source
+    from mayring_core.memory.schema import Source
+    conn = store.init_memory_db(tmp_path / "m.db")
+    upsert_source(conn, Source(source_id="note:a", source_type="note", repo="r", path="p", visibility="private", user_id="1"), workspace_id="ws-1")
+    upsert_source(conn, Source(source_id="note:b", source_type="note", repo="r", path="p", visibility="public"), workspace_id="ws-1")
+    upsert_source(conn, Source(source_id="note:other", source_type="note", repo="r", path="p", visibility="private", user_id="1"), workspace_id="ws-2")
+    monkeypatch.setattr(sl, "_get_conn", lambda: conn)
+    res = asyncio.run(sl.list_sources_endpoint(workspace_id="ws-1", info=TokenInfo(workspace_id="ws-1", scopes=("admin",))))
+    ids = {s["source_id"]: s for s in res["sources"]}
+    assert set(ids) == {"note:a", "note:b"}
+    assert ids["note:b"]["visibility"] == "public"


### PR DESCRIPTION
Sources-Katalog-Endpoint (workspace-scoped, /stats/) für die Phase-C-Share-UI in app.linn.games. Additiv, keine Migration. 15 Tests grün lokal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a workspace-scoped stats endpoint to list sources with visibility metadata for the Share UI.

New Features:
- Expose GET /stats/sources API to return a flat catalog of a workspace's sources including visibility and metadata for tenancy Phase C.

Tests:
- Add an integration-style test ensuring the sources stats endpoint lists only the workspace's sources and preserves visibility flags.