### PR TITLE
fix(security): code-scanning #143 ReDoS + #145 stack-trace-exposure

### DIFF
--- a/src/api/routes/codebooks.py
+++ b/src/api/routes/codebooks.py
@@ -251,8 +251,15 @@ async def categorize_endpoint(req: CategorizeRequest, _ws: str = Depends(get_wor
                                  dry_run=req.dry_run)
     except Exception as e:
         # Duell-tauglich: ein Modell, das Müll/leer liefert (oder fehlt), darf den Lauf
-        # nicht mit 500 abbrechen — der Fehler kommt im Body zurück (NICHT stumm).
-        return {"error": str(e), "model": req.model.strip() or "router-text-default"}
+        # nicht mit 500 abbrechen. WHY(#145 stack-trace-exposure): rohe Exception NICHT
+        # an den Client geben (Internals-Leak) — voll serverseitig loggen, im Body nur
+        # ein generischer Marker. Nicht stumm, aber kein Detail-Leak.
+        import logging
+        logging.getLogger(__name__).warning(
+            "reduce_text_server failed (model=%s): %s",
+            req.model.strip() or "router-text-default", e,
+        )
+        return {"error": "categorize_failed", "model": req.model.strip() or "router-text-default"}
     cand = res.candidates[0] if res.candidates else None
     return {
         "label": cand.label if cand else "",

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -31,7 +31,10 @@ router = APIRouter(tags=["projects"])
 # `name` is now a single greedy non-slash run (linear, bounded by '/'); the
 # optional `.git` suffix + trailing slash are stripped in _normalize_remote.
 _REMOTE_RE = re.compile(
-    r"github\.com[:/](?P<owner>[^/]+)/(?P<name>[^/]+)",
+    # WHY(#143 polynomial-redos): possessive Quantifier (py3.11+) verhindern
+    # Backtracking der beiden benachbarten [^/]+-Runs — kein ReDoS-Risiko mehr,
+    # Matches identisch (owner/name sind ohnehin durch '/' begrenzt).
+    r"github\.com[:/](?P<owner>[^/]++)/(?P<name>[^/]++)",
     re.IGNORECASE,
 )
 _SEMANTIC_MIN = 0.55


### PR DESCRIPTION
Behebt 2 der 3 seit ~1 Woche offenen Code-Scanning-Alerts. **Kein Auto-Merge** — bewusst als PR, damit das Deploy-Timing kontrolliert ist (Prod-mcp hatte gerade einen db-lock-Outage).

## #143 py/polynomial-redos — `projects.py` `_REMOTE_RE`
Zwei benachbarte `[^/]+`-Runs → possessive Quantifier (`[^/]++`, py3.11+) verhindern Backtracking. Matches unverändert (verifiziert: `git@…`, `https://…`, `.git`-Suffix, extra-path, gitlab→None, none→None).

## #145 py/stack-trace-exposure — `codebooks.py` reduce
`return {"error": str(e)}` leakte die rohe Exception an den Client. Jetzt: voll serverseitig `logging.warning`, Body nur `"categorize_failed"`. Nicht stumm (CLAUDE.md-konform), kein Internals-Leak.

## #144 py/weak-sensitive-data-hashing — separat dismissed
`agent_keys` hasht `mca_` + `secrets.token_urlsafe(24)` = **192-bit Zufallstoken**. Schnelles SHA-256 ist hier korrekt; ein KDF (bcrypt/argon2) bringt bei dieser Entropie keinen Sicherheitsgewinn, und ein Umbau würde **alle bestehenden Agent-Keys invalidieren**. → als False-Positive dismissed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Address security findings by hardening regex handling of GitHub remotes and removing exception detail leakage from the categorize endpoint.

Bug Fixes:
- Prevent potential ReDoS in GitHub remote URL parsing by making owner and name path segments non-backtracking.
- Stop leaking raw exception messages to clients in the categorize endpoint by logging server-side and returning a generic error marker.