### PR TITLE
fix(#343,#344): Hotpath-Handler in Threadpool + smoke-teardown robust

### DIFF
--- a/src/api/routes/devices.py
+++ b/src/api/routes/devices.py
@@ -63,6 +63,33 @@ def _touch_best_effort(conn: Any, device_id: str, workspace_id: str) -> None:
         raise
 
 
+# WHY(#343): fail_stale_cloud_jobs ist ein TTL-Sweep (WRITE) der im Claim-Hotpath
+# bei JEDEM Poll lief → zweite Write-Amplifikation neben touch_last_seen. Der Sweep
+# ist unkritisch + idempotent → global gedrosselt (max 1×/60s) + best-effort (ein
+# DB-Lock killt den Claim nicht). Der Claim-Handler selbst läuft jetzt im Threadpool
+# (def statt async def), sodass ein 10s-busy_timeout-Wait nicht mehr den Event-Loop
+# inkl. /health blockiert.
+_LAST_STALE_SWEEP: list[float] = [0.0]
+_STALE_SWEEP_INTERVAL_S = 60.0
+
+
+def _fail_stale_best_effort() -> None:
+    now = time.monotonic()
+    if now - _LAST_STALE_SWEEP[0] < _STALE_SWEEP_INTERVAL_S:
+        return
+    try:
+        pi_jobs.fail_stale_cloud_jobs(
+            max_age_s=float(os.getenv("MAYRING_CLOUD_JOB_TTL_S", "1800")),
+            db_path=_job_db_path(),
+        )
+        _LAST_STALE_SWEEP[0] = now
+    except sqlite3.OperationalError as e:
+        if "locked" in str(e).lower():
+            logger.warning("fail_stale_cloud_jobs skipped (db locked): %s", e)
+            return
+        raise
+
+
 def _job_db_path() -> Path:
     """DB file the pi_jobs helpers should hit — mirror dependencies.get_conn so
     the per-call job connection and the shared device connection point at the
@@ -111,7 +138,7 @@ class CloudCompleteRequest(BaseModel):
 # --- device registry --------------------------------------------------------
 
 @router.post("/devices/register")
-async def register_device(
+def register_device(
     req: DeviceRegisterRequest,
     workspace_id: str = Depends(get_workspace),
     x_device_id: str | None = Header(default=None, alias="X-Device-Id"),
@@ -135,7 +162,7 @@ async def register_device(
 
 
 @router.post("/devices/heartbeat")
-async def device_heartbeat(
+def device_heartbeat(
     req: HeartbeatRequest,
     workspace_id: str = Depends(get_workspace),
     x_device_id: str | None = Header(default=None, alias="X-Device-Id"),
@@ -148,7 +175,7 @@ async def device_heartbeat(
 
 
 @router.get("/devices")
-async def list_devices(workspace_id: str = Depends(get_workspace)) -> dict:
+def list_devices(workspace_id: str = Depends(get_workspace)) -> dict:
     items = device_store.list_devices(_get_conn(), workspace_id)
     return {"devices": items, "count": len(items)}
 
@@ -156,7 +183,7 @@ async def list_devices(workspace_id: str = Depends(get_workspace)) -> dict:
 # --- hook events ------------------------------------------------------------
 
 @router.post("/hooks/events")
-async def record_hook_event(
+def record_hook_event(
     req: HookEventRequest,
     workspace_id: str = Depends(get_workspace),
     x_device_id: str | None = Header(default=None, alias="X-Device-Id"),
@@ -181,7 +208,7 @@ async def record_hook_event(
 
 
 @router.get("/hooks/events")
-async def list_hook_events(
+def list_hook_events(
     since: str | None = Query(default=None),
     limit: int = Query(default=200, le=2000),
     workspace_id: str = Depends(get_workspace),
@@ -193,7 +220,7 @@ async def list_hook_events(
 # --- write-job routing (cloud-claim path, reactivated #274) -----------------
 
 @router.post("/pi_task_claim_cloud")
-async def pi_task_claim_cloud(
+def pi_task_claim_cloud(
     req: CloudClaimRequest,
     workspace_id: str = Depends(get_workspace),
     x_device_id: str | None = Header(default=None, alias="X-Device-Id"),
@@ -210,11 +237,9 @@ async def pi_task_claim_cloud(
     )
     _touch_best_effort(conn, device_id, workspace_id)
     # Cheap piggy-backed TTL sweep: fail cloud jobs no worker claimed in time so
-    # an A2A client does not poll forever. No cron needed.
-    pi_jobs.fail_stale_cloud_jobs(
-        max_age_s=float(os.getenv("MAYRING_CLOUD_JOB_TTL_S", "1800")),
-        db_path=_job_db_path(),
-    )
+    # an A2A client does not poll forever. No cron needed. Throttled + best-effort
+    # (#343) so it can't write-amplify the claim hotpath.
+    _fail_stale_best_effort()
     job = pi_jobs.claim_cloud_next(
         device_id,
         capabilities=caps,
@@ -227,7 +252,7 @@ async def pi_task_claim_cloud(
 
 
 @router.post("/pi_task_complete_cloud")
-async def pi_task_complete_cloud(
+def pi_task_complete_cloud(
     req: CloudCompleteRequest,
     workspace_id: str = Depends(get_workspace),
 ) -> dict:

--- a/src/api/routes/reranker_admin.py
+++ b/src/api/routes/reranker_admin.py
@@ -486,12 +486,16 @@ def reembed_categories(info: TokenInfo = Depends(get_token_info)) -> dict:
                 "detail": "no active categories with embedding_id"}
     url = os.getenv("OLLAMA_URL", "http://localhost:11434")
     model = os.getenv("MAYRING_EMBED_MODEL", "nomic-embed-text")
+    # WHY(#343): fail-fast embed-Timeout statt hardcoded 120 — ein hängendes/
+    # überlastetes Ollama soll den (im Threadpool laufenden) Reembed-Batch nicht
+    # minutenlang blockieren. OLLAMA_EMBED_TIMEOUT=30 default.
+    from mayring_core.config import OLLAMA_EMBED_TIMEOUT
     col = get_chroma_collection("codebook_categories")
     ids = [r[0] for r in rows]
     texts = [f"{r[1]}: {r[2]}" for r in rows]
     embedded = 0
     for i in range(0, len(ids), 64):
-        embs = embed_batch(url, model, texts[i:i + 64], timeout=120)
+        embs = embed_batch(url, model, texts[i:i + 64], timeout=OLLAMA_EMBED_TIMEOUT)
         if embs:
             col.upsert(ids=ids[i:i + 64], embeddings=embs,
                        documents=texts[i:i + 64])

--- a/tools/smoke_test_production.py
+++ b/tools/smoke_test_production.py
@@ -3055,32 +3055,40 @@ def main() -> int:
     wait_for_search_ready(api, token, max_wait=args.ready_timeout)
     print()
 
+    # WHY(#344): purge BEFORE the run too — a finally-block does not run when the
+    # CI step is hard-killed (SIGKILL on workflow timeout, e.g. the 781s #345 run),
+    # so smoke.*-workspaces from a killed prior run would otherwise accumulate.
+    # This bounds the clutter to at most one in-flight run.
+    _teardown_smoke_workspaces(api, token)
+
     results: list[CheckResult] = []
     t_start = time.time()
-    for name, fn in ALL_CHECKS:
-        if name in skip:
-            print(f"  SKIP  {name}")
-            continue
-        t0 = time.time()
-        try:
-            res = fn(api, token)
-        except Exception as e:
-            res = CheckResult(name, False, f"check raised: {type(e).__name__}: {e}")
-        dt = time.time() - t0
-        marker = " OK " if res.passed else "FAIL"
-        print(f"  [{marker}] {res.name}  ({dt:.2f}s)")
-        if res.detail:
-            indent = "         "
-            for line in res.detail.split("\n"):
-                print(f"{indent}{line}")
-        results.append(res)
-        if args.fail_fast and not res.passed:
-            break
-        if args.pace > 0:
-            time.sleep(args.pace)
-
-    # Self-clean ephemeral workspaces this run (and any prior runs) created (#253).
-    _teardown_smoke_workspaces(api, token)
+    try:
+        for name, fn in ALL_CHECKS:
+            if name in skip:
+                print(f"  SKIP  {name}")
+                continue
+            t0 = time.time()
+            try:
+                res = fn(api, token)
+            except Exception as e:
+                res = CheckResult(name, False, f"check raised: {type(e).__name__}: {e}")
+            dt = time.time() - t0
+            marker = " OK " if res.passed else "FAIL"
+            print(f"  [{marker}] {res.name}  ({dt:.2f}s)")
+            if res.detail:
+                indent = "         "
+                for line in res.detail.split("\n"):
+                    print(f"{indent}{line}")
+            results.append(res)
+            if args.fail_fast and not res.passed:
+                break
+            if args.pace > 0:
+                time.sleep(args.pace)
+    finally:
+        # Self-clean ephemeral workspaces this run (and any prior runs) created
+        # (#253/#344) — in finally so an exception/SystemExit mid-loop still purges.
+        _teardown_smoke_workspaces(api, token)
 
     failed = [r for r in results if not r.passed]
     elapsed = time.time() - t_start


### PR DESCRIPTION
## #343 — async-blocking Hotpath (Prod-Outage-Wurzel)
Synchrones sqlite lief in `async def`-Handlern → ein 10s-`busy_timeout`-Lock-Wait blockierte den Event-Loop inkl. `/health` → mcp-Outage trotz CPU≈0.

- **Alle 7 Hotpath-Handler in `devices.py` `async def` → `def`** → FastAPI-Threadpool. Ein DB-Lock blockiert nur einen Threadpool-Slot, nicht mehr den Event-Loop.
- **`fail_stale_cloud_jobs`** (TTL-Sweep, WRITE pro Claim-Poll) → `_fail_stale_best_effort`: gedrosselt (1×/60s) + best-effort bei `database is locked`. Zweite Write-Amplifikation neben `touch_last_seen` (cd07b42) geschlossen.
- **`reembed-categories`** embed-Timeout `120` → `OLLAMA_EMBED_TIMEOUT` (fail-fast).

## #344 — smoke-WS-Clutter
`_teardown_smoke_workspaces` lief nicht, wenn der CI-Step hart gekillt wird (SIGKILL bei Workflow-Timeout, vgl. 781s-Lauf #345).
- teardown in `try/finally` **+ Pre-Run** (finally läuft bei SIGKILL nicht) → Clutter auf max. einen in-flight-Lauf begrenzt.

## Verifikation
- `py_compile` grün; isolierte Logik-Tests (drossel, best-effort lock-catch, non-lock-raise, alle Handler sync) grün lokal (voller Server-Import lokal durch protobuf/a2a-Versionskonflikt blockiert → CI ist autoritativ).

Closes #343, closes #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route device hotpaths and admin maintenance operations away from blocking the event loop while hardening smoke test workspace cleanup against interrupted CI runs.

Bug Fixes:
- Run device registry, heartbeat, listing, hook, and cloud job claim/complete endpoints as sync handlers so DB contention no longer blocks the async event loop.
- Throttle and make best-effort the fail_stale_cloud_jobs sweep in the cloud claim path to avoid write amplification and request failures when the job DB is locked.
- Apply a configurable OLLAMA_EMBED_TIMEOUT to category re-embedding so hung or overloaded embedding backends do not stall the batch indefinitely.
- Ensure smoke test ephemeral workspaces are always torn down, including on exceptions and before each run, to prevent workspace clutter across CI executions.

Enhancements:
- Centralize and reuse best-effort stale cloud job sweeping in the devices routes for more predictable load and behavior.